### PR TITLE
fix(avatar): 修复默认头像打包后暗色模式自适应失效

### DIFF
--- a/src/renderer/src/components/search/SearchBox.vue
+++ b/src/renderer/src/components/search/SearchBox.vue
@@ -124,7 +124,7 @@
 
 <script setup lang="ts">
 import { computed, nextTick, onMounted, onUnmounted, ref, watch } from 'vue'
-import { useWindowStore } from '../../stores/windowStore'
+import { useWindowStore, DEFAULT_AVATAR } from '../../stores/windowStore'
 import UpdateIcon from './UpdateIcon.vue'
 
 // FileItem 接口（从剪贴板管理器返回的格式）
@@ -187,7 +187,9 @@ const avatarUrl = computed(() => {
 
 // 判断是否是默认头像
 const isDefaultAvatar = computed(() => {
-  return avatarUrl.value.includes('default.png')
+  // 使用严格相等判断，而不是字符串包含判断
+  // 这样在打包后路径被处理时也能正确判断
+  return avatarUrl.value === DEFAULT_AVATAR
 })
 
 // 截断显示的粘贴文本（从中间截断，显示头尾）

--- a/src/renderer/src/components/settings/GeneralSettings.vue
+++ b/src/renderer/src/components/settings/GeneralSettings.vue
@@ -294,7 +294,7 @@
 
 <script setup lang="ts">
 import { computed, onMounted, ref } from 'vue'
-import { DEFAULT_PLACEHOLDER, useWindowStore } from '../../stores/windowStore'
+import { DEFAULT_PLACEHOLDER, DEFAULT_AVATAR, useWindowStore } from '../../stores/windowStore'
 
 const windowStore = useWindowStore()
 
@@ -340,8 +340,8 @@ const themeColors = [
 // 自定义颜色
 const customColor = ref('#db2777')
 
-// 头像默认值（用于重置）
-const defaultAvatar = new URL('../../assets/image/default.png', import.meta.url).href
+// 头像默认值（从 windowStore 导入，确保与搜索框判断逻辑一致）
+const defaultAvatar = DEFAULT_AVATAR
 
 // 搜索框提示文字默认值（从 windowStore 导入）
 const defaultPlaceholder = DEFAULT_PLACEHOLDER

--- a/src/renderer/src/stores/windowStore.ts
+++ b/src/renderer/src/stores/windowStore.ts
@@ -379,10 +379,12 @@ export const useWindowStore = defineStore('window', () => {
         if (data.placeholder) {
           placeholder.value = data.placeholder
         }
-        // 只有自定义头像才从数据库加载，没有则使用打包的默认头像
-        if (data.avatar) {
+        // 只有自定义头像才从数据库加载
+        // 如果数据库中是默认头像路径（历史数据），不加载，使用内置的默认头像
+        if (data.avatar && data.avatar !== DEFAULT_AVATAR) {
           avatar.value = data.avatar
         }
+        // 否则使用内置的默认头像（已在初始化时设置）
         if (data.autoPaste) {
           autoPaste.value = data.autoPaste
         }


### PR DESCRIPTION
- 统一使用 DEFAULT_AVATAR 引用而非字符串匹配判断
- 修复 SearchBox 和 GeneralSettings 中的判断逻辑不一致问题
- 确保打包后默认头像在暗色模式下正常反色
- 默认头像不再从数据库读取和保存