### PR TITLE
fix(search): 修复中文输入法删除拼音时误删粘贴内容

### DIFF
--- a/src/renderer/src/components/search/SearchBox.vue
+++ b/src/renderer/src/components/search/SearchBox.vue
@@ -332,8 +332,8 @@ function onKeydown(event: KeyboardEvent): void {
     (props.pastedImage || props.pastedFiles || props.pastedText) &&
     (event.key === 'Backspace' || event.key === 'Delete')
   ) {
-    // 如果输入框为空，清除图片、文件或文本
-    if (!props.modelValue) {
+    // 如果输入框为空且不在输入法组合中，清除图片、文件或文本
+    if (!props.modelValue && !isComposing.value) {
       event.preventDefault()
       if (props.pastedImage) {
         clearPastedImage()


### PR DESCRIPTION
问题：
当使用中文输入法输入时，删除拼音字母会触发 Backspace 事件，
此时 modelValue 可能暂时为空（拼音还在组合中），导致误判为
"输入框为空"并清除 pasted-text。

修复：
在清除逻辑中增加对 isComposing 状态的检查，只有在输入框真正
为空且不在输入法组合状态时，才清除粘贴内容。