### PR TITLE
optimize: 优化 Windows 快捷方式扫描与系统设置名称校对

### DIFF
--- a/internal-plugins/setting/src/components/settings/PluginMarket.vue
+++ b/internal-plugins/setting/src/components/settings/PluginMarket.vue
@@ -126,9 +126,9 @@
 
 <script setup lang="ts">
 import { onMounted, onUnmounted, ref } from 'vue'
+import { useToast } from '../../composables/useToast'
 import AdaptiveIcon from '../common/AdaptiveIcon.vue'
 import PluginDetail from './PluginDetail.vue'
-import { useToast } from '../../composables/useToast'
 
 const { success, error, confirm } = useToast()
 
@@ -532,18 +532,23 @@ onUnmounted(() => {
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  padding: 40px;
-  color: var(--text-secondary);
+  width: 100%;
+  height: 100%;
+  gap: 12px;
 }
 
 .loading-spinner {
-  width: 30px;
-  height: 30px;
-  border: 3px solid var(--border-color);
+  width: 32px;
+  height: 32px;
+  border: 3px solid var(--divider-color);
   border-top-color: var(--primary-color);
   border-radius: 50%;
-  animation: spin 1s linear infinite;
-  margin-bottom: 12px;
+  animation: spin 0.8s linear infinite;
+}
+
+.loading-state span {
+  font-size: 13px;
+  color: var(--text-color-secondary);
 }
 
 @keyframes spin {

--- a/internal-plugins/setting/src/env.d.ts
+++ b/internal-plugins/setting/src/env.d.ts
@@ -177,6 +177,7 @@ declare global {
         getCommands: () => Promise<{
           commands: any[]
           regexCommands: any[]
+          plugins: any[]
         }>
 
         // 本地启动管理

--- a/src/main/core/commandLauncher/windowsLauncher.ts
+++ b/src/main/core/commandLauncher/windowsLauncher.ts
@@ -1,5 +1,6 @@
 import { spawn } from 'child_process'
 import { dialog, shell } from 'electron'
+import { UwpManager } from '../native'
 import type { ConfirmDialogOptions } from './types'
 
 /**
@@ -51,6 +52,19 @@ export async function launchApp(
     if (result.response === confirmDialog.cancelId) {
       console.log('用户取消了操作')
       return
+    }
+  }
+
+  // 检查是否是 UWP 应用（uwp: 前缀）
+  if (appPath.startsWith('uwp:')) {
+    const appId = appPath.slice(4)
+    try {
+      UwpManager.launchUwpApp(appId)
+      console.log(`成功启动 UWP 应用: ${appId}`)
+      return
+    } catch (error) {
+      console.error('启动 UWP 应用失败:', error)
+      throw error
     }
   }
 

--- a/src/main/core/systemSettings/msSettingsUris.ts
+++ b/src/main/core/systemSettings/msSettingsUris.ts
@@ -1,98 +1,76 @@
 import type { SystemSetting } from './windowsSettings'
 
 /**
- * 完整的 ms-settings URI 列表
+ * 完整的 ms-settings URI 列表（名称对齐 Windows 11 设置 UI）
  * 来源：
  * - https://learn.microsoft.com/en-us/windows/apps/develop/launch/launch-settings
  * - https://ss64.com/nt/syntax-settings.html
  */
 export const MS_SETTINGS_URIS: Omit<SystemSetting, 'icon'>[] = [
-  // === 主页 ===
+  // === 系统 ===
   {
-    name: '设置主页',
-    uri: 'ms-settings:',
-    category: '系统'
-  },
-
-  // === 系统（System）===
-  {
-    name: '屏幕显示',
+    name: '屏幕',
     uri: 'ms-settings:display',
     category: '系统'
   },
   {
-    name: '高级屏幕设置',
+    name: '高级显示设置',
     uri: 'ms-settings:display-advanced',
     category: '系统'
   },
   {
-    name: '显卡性能偏好',
+    name: '显示卡',
     uri: 'ms-settings:display-advancedgraphics',
     category: '系统'
   },
   {
-    name: '默认显卡设置',
-    uri: 'ms-settings:display-advancedgraphics-default',
-    category: '系统'
-  },
-  {
-    name: '夜间护眼模式',
+    name: '夜间模式',
     uri: 'ms-settings:nightlight',
     category: '系统'
   },
   {
-    name: '音频声音',
+    name: '声音',
     uri: 'ms-settings:sound',
     category: '系统'
   },
   {
-    name: '音频设备管理',
+    name: '所有声音设备',
     uri: 'ms-settings:sound-devices',
     category: '系统'
   },
   {
-    name: '麦克风输入属性',
+    name: '麦克风属性',
     uri: 'ms-settings:sound-defaultinputproperties',
     category: '系统'
   },
   {
-    name: '扬声器输出属性',
+    name: '扬声器属性',
     uri: 'ms-settings:sound-defaultoutputproperties',
     category: '系统'
   },
   {
-    name: '应用音量控制',
+    name: '音量合成器',
     uri: 'ms-settings:apps-volume',
     category: '系统'
   },
   {
-    name: '系统通知',
+    name: '通知',
     uri: 'ms-settings:notifications',
     category: '系统'
   },
   {
-    name: '勿扰模式',
+    name: '专注',
     uri: 'ms-settings:quiethours',
     category: '系统'
   },
   {
-    name: '电源睡眠',
+    name: '电源和电池',
     uri: 'ms-settings:powersleep',
     category: '系统'
   },
   {
-    name: '电池节能',
+    name: '电源',
     uri: 'ms-settings:batterysaver',
-    category: '系统'
-  },
-  {
-    name: '电池节能配置',
-    uri: 'ms-settings:batterysaver-settings',
-    category: '系统'
-  },
-  {
-    name: '电池用量详情',
-    uri: 'ms-settings:batterysaver-usagedetails',
     category: '系统'
   },
   {
@@ -101,104 +79,99 @@ export const MS_SETTINGS_URIS: Omit<SystemSetting, 'icon'>[] = [
     category: '系统'
   },
   {
-    name: '磁盘存储',
+    name: '存储',
     uri: 'ms-settings:storagesense',
     category: '系统'
   },
   {
-    name: '存储感知自动清理',
+    name: '存储感知',
     uri: 'ms-settings:storagepolicies',
     category: '系统'
   },
   {
-    name: '清理存储建议',
+    name: '清理建议',
     uri: 'ms-settings:storagerecommendations',
     category: '系统'
   },
   {
-    name: '磁盘卷管理',
+    name: '磁盘和卷',
     uri: 'ms-settings:disksandvolumes',
     category: '系统'
   },
   {
-    name: '文件默认保存位置',
+    name: '保存新内容的地方',
     uri: 'ms-settings:savelocations',
     category: '系统'
   },
   {
-    name: '窗口多任务',
+    name: '多任务处理',
     uri: 'ms-settings:multitasking',
     category: '系统'
   },
   {
-    name: '无线投影接收',
+    name: '投影到此电脑',
     uri: 'ms-settings:project',
     category: '系统'
   },
   {
-    name: '跨设备共享',
+    name: '就近共享',
     uri: 'ms-settings:crossdevice',
     category: '系统'
   },
   {
-    name: '任务栏设置',
+    name: '任务栏',
     uri: 'ms-settings:taskbar',
-    category: '系统'
+    category: '个性化'
   },
   {
-    name: '剪贴板历史',
+    name: '剪贴板',
     uri: 'ms-settings:clipboard',
     category: '系统'
   },
   {
-    name: '远程桌面连接',
+    name: '远程桌面',
     uri: 'ms-settings:remotedesktop',
     category: '系统'
   },
   {
-    name: 'BitLocker 设备加密',
+    name: '设备加密',
     uri: 'ms-settings:deviceencryption',
     category: '系统'
   },
   {
-    name: '系统信息',
+    name: '关于',
     uri: 'ms-settings:about',
     category: '系统'
   },
 
-  // === 设备（Devices）===
+  // === 蓝牙和其他设备 ===
   {
-    name: '蓝牙设备',
+    name: '蓝牙',
     uri: 'ms-settings:bluetooth',
     category: '设备'
   },
   {
-    name: '已连接设备',
+    name: '设备',
     uri: 'ms-settings:connecteddevices',
     category: '设备'
   },
   {
-    name: '设备自动发现',
+    name: '投放',
     uri: 'ms-settings-connectabledevices:devicediscovery',
     category: '设备'
   },
   {
-    name: '打印机扫描仪',
+    name: '打印机和扫描仪',
     uri: 'ms-settings:printers',
     category: '设备'
   },
   {
-    name: '鼠标触摸板',
+    name: '鼠标',
     uri: 'ms-settings:mousetouchpad',
     category: '设备'
   },
   {
-    name: '笔记本触摸板',
-    uri: 'ms-settings:devices-touchpad',
-    category: '设备'
-  },
-  {
-    name: 'USB 设备',
+    name: 'USB',
     uri: 'ms-settings:usb',
     category: '设备'
   },
@@ -208,71 +181,66 @@ export const MS_SETTINGS_URIS: Omit<SystemSetting, 'icon'>[] = [
     category: '设备'
   },
 
-  // === 网络和Internet（Network）===
+  // === 网络和 Internet ===
   {
-    name: '网络和互联网',
-    uri: 'ms-settings:network',
-    category: '网络'
-  },
-  {
-    name: '网络连接状态',
+    name: '网络和 Internet',
     uri: 'ms-settings:network-status',
     category: '网络'
   },
   {
-    name: 'Wi-Fi 无线网络',
+    name: 'WLAN',
     uri: 'ms-settings:network-wifi',
     category: '网络'
   },
   {
-    name: 'Wi-Fi 高级设置',
+    name: '管理已知网络',
     uri: 'ms-settings:network-wifisettings',
     category: '网络'
   },
   {
-    name: '以太网有线网络',
+    name: '以太网',
     uri: 'ms-settings:network-ethernet',
     category: '网络'
   },
   {
-    name: 'VPN 虚拟专用网',
+    name: 'VPN',
     uri: 'ms-settings:network-vpn',
     category: '网络'
   },
   {
-    name: '网络代理',
+    name: '代理',
     uri: 'ms-settings:network-proxy',
     category: '网络'
   },
   {
-    name: '飞行模式开关',
+    name: '飞行模式',
     uri: 'ms-settings:network-airplanemode',
     category: '网络'
   },
   {
-    name: '移动热点共享',
+    name: '移动热点',
     uri: 'ms-settings:network-mobilehotspot',
     category: '网络'
   },
   {
-    name: '流量使用统计',
+    name: '数据使用量',
     uri: 'ms-settings:datausage',
     category: '网络'
   },
 
-  // === 个性化（Personalization）===
+  // === 个性化 ===
   {
-    name: '个性化设置',
+    name: '个性化',
     uri: 'ms-settings:personalization',
     category: '个性化'
   },
   {
-    name: '桌面背景壁纸',
+    name: '背景',
     uri: 'ms-settings:personalization-background',
     category: '个性化'
   },
   {
-    name: '主题颜色',
+    name: '颜色',
     uri: 'ms-settings:personalization-colors',
     category: '个性化'
   },
@@ -282,230 +250,215 @@ export const MS_SETTINGS_URIS: Omit<SystemSetting, 'icon'>[] = [
     category: '个性化'
   },
   {
-    name: '主题包',
+    name: '主题',
     uri: 'ms-settings:themes',
     category: '个性化'
   },
   {
-    name: '系统字体',
+    name: '字体',
     uri: 'ms-settings:fonts',
     category: '个性化'
   },
   {
-    name: '开始菜单布局',
+    name: '开始',
     uri: 'ms-settings:personalization-start',
     category: '个性化'
   },
-  {
-    name: '快速控制中心',
-    uri: 'ms-settings:controlcenter',
-    category: '个性化'
-  },
 
-  // === 应用（Apps）===
+  // === 应用 ===
   {
-    name: '已安装应用',
+    name: '已安装的应用',
     uri: 'ms-settings:appsfeatures',
     category: '应用'
   },
   {
-    name: '默认程序',
+    name: '默认应用',
     uri: 'ms-settings:defaultapps',
     category: '应用'
   },
   {
-    name: '开机自启动',
+    name: '启动',
     uri: 'ms-settings:startupapps',
     category: '应用'
   },
   {
-    name: 'Windows 可选功能',
+    name: '可选功能',
     uri: 'ms-settings:optionalfeatures',
     category: '应用'
   },
 
-  // === 账户（Accounts）===
+  // === 账户 ===
   {
-    name: '账户信息',
+    name: '你的信息',
     uri: 'ms-settings:yourinfo',
     category: '账户'
   },
   {
-    name: '邮箱账户',
+    name: '电子邮件和账户',
     uri: 'ms-settings:emailandaccounts',
     category: '账户'
   },
   {
-    name: '登录方式',
+    name: '登录选项',
     uri: 'ms-settings:signinoptions',
     category: '账户'
   },
   {
-    name: '家庭其他用户',
+    name: '其他用户',
     uri: 'ms-settings:otherusers',
     category: '账户'
   },
   {
-    name: '账户同步',
+    name: 'Windows 备份',
     uri: 'ms-settings:sync',
     category: '账户'
   },
 
-  // === 时间和语言（Time & Language）===
+  // === 时间和语言 ===
   {
-    name: '日期时间',
+    name: '日期和时间',
     uri: 'ms-settings:dateandtime',
     category: '时间'
   },
   {
-    name: '语言区域',
+    name: '语言和区域',
     uri: 'ms-settings:regionlanguage',
     category: '语言'
   },
   {
-    name: '区域格式化',
+    name: '区域格式',
     uri: 'ms-settings:regionformatting',
     category: '语言'
   },
   {
-    name: '键盘布局',
+    name: '键盘',
     uri: 'ms-settings:keyboard',
     category: '语言'
   },
   {
-    name: '高级键盘',
+    name: '高级键盘设置',
     uri: 'ms-settings:keyboard-advanced',
     category: '语言'
   },
   {
-    name: '打字输入',
+    name: '输入',
     uri: 'ms-settings:typing',
     category: '语言'
   },
   {
-    name: '语音识别',
+    name: '语音',
     uri: 'ms-settings:speech',
     category: '语言'
   },
 
-  // === 隐私和安全（Privacy）===
+  // === 隐私和安全性 ===
   {
-    name: '隐私设置',
+    name: '隐私和安全性',
     uri: 'ms-settings:privacy',
     category: '隐私'
   },
   {
-    name: '隐私常规设置',
+    name: '常规',
     uri: 'ms-settings:privacy-general',
     category: '隐私'
   },
   {
-    name: '位置定位权限',
+    name: '位置',
     uri: 'ms-settings:privacy-location',
     category: '隐私'
   },
   {
-    name: '相机摄像头权限',
+    name: '相机',
     uri: 'ms-settings:privacy-webcam',
     category: '隐私'
   },
   {
-    name: '麦克风录音权限',
+    name: '麦克风',
     uri: 'ms-settings:privacy-microphone',
     category: '隐私'
   },
 
-  // === 更新和安全（Update & Security）===
+  // === Windows 更新 ===
   {
-    name: '系统更新',
+    name: 'Windows 更新',
     uri: 'ms-settings:windowsupdate',
     category: '更新'
   },
   {
-    name: '立即检查更新',
+    name: '检查更新',
     uri: 'ms-settings:windowsupdate-action',
     category: '更新'
   },
   {
-    name: '更新活动时间',
-    uri: 'ms-settings:windowsupdate-activehours',
-    category: '更新'
-  },
-  {
-    name: '更新历史',
+    name: '更新历史记录',
     uri: 'ms-settings:windowsupdate-history',
     category: '更新'
   },
   {
-    name: '可选更新补丁',
+    name: '可选更新',
     uri: 'ms-settings:windowsupdate-optionalupdates',
     category: '更新'
   },
   {
-    name: '更新高级选项',
+    name: '高级选项',
     uri: 'ms-settings:windowsupdate-options',
     category: '更新'
   },
   {
-    name: '更新重启计划',
+    name: '重启选项',
     uri: 'ms-settings:windowsupdate-restartoptions',
     category: '更新'
   },
   {
-    name: '按需更新搜索',
+    name: '获取最新更新',
     uri: 'ms-settings:windowsupdate-seekerondemand',
     category: '更新'
   },
   {
-    name: '更新传递优化',
+    name: '传递优化',
     uri: 'ms-settings:delivery-optimization',
     category: '更新'
   },
   {
-    name: 'Defender 安全中心',
+    name: 'Windows 安全中心',
     uri: 'ms-settings:windowsdefender',
     category: '安全'
   },
   {
-    name: '系统疑难解答',
+    name: '疑难解答',
     uri: 'ms-settings:troubleshoot',
     category: '系统'
   },
   {
-    name: '系统恢复重置',
+    name: '恢复',
     uri: 'ms-settings:recovery',
     category: '系统'
   },
   {
-    name: 'Windows 激活',
+    name: '激活',
     uri: 'ms-settings:activation',
     category: '系统'
   },
   {
-    name: '查找设备定位',
+    name: '查找我的设备',
     uri: 'ms-settings:findmydevice',
     category: '安全'
   },
   {
-    name: '开发者模式',
+    name: '开发者选项',
     uri: 'ms-settings:developers',
     category: '系统'
   },
 
-  // === 搜索（Search）===
+  // === 搜索 ===
   {
-    name: '搜索索引',
+    name: '搜索 Windows',
     uri: 'ms-settings:search',
     category: '搜索'
   },
   {
-    name: '搜索权限设置',
+    name: '搜索权限',
     uri: 'ms-settings:search-permissions',
     category: '搜索'
   },
-  {
-    name: '搜索详细设置',
-    uri: 'ms-settings:search-moredetails',
-    category: '搜索'
-  }
 ]

--- a/src/main/core/systemSettings/windowsSettings.ts
+++ b/src/main/core/systemSettings/windowsSettings.ts
@@ -52,11 +52,6 @@ const allSettings: Omit<SystemSetting, 'icon'>[] = [
     category: '应用'
   },
   {
-    name: '控制面板',
-    uri: 'control.exe',
-    category: '系统'
-  },
-  {
     name: '鼠标属性',
     uri: 'main.cpl',
     category: '设备'

--- a/tests/main/windowsScanner.test.ts
+++ b/tests/main/windowsScanner.test.ts
@@ -4,82 +4,42 @@ import {
   getIconUrl,
   deduplicateCommands,
   SKIP_FOLDERS,
-  SKIP_EXTENSIONS,
-  SKIP_NAME_PATTERN,
-  SKIP_TARGET_PATTERN,
-  SYSTEM_DIRECTORIES
+  SKIP_NAME_PATTERN
 } from '../../src/main/core/commandScanner/windowsScanner'
 
 // ========== shouldSkipShortcut ==========
 
-describe('shouldSkipShortcut', () => {
-  describe('有目标路径时（基于目标路径判断）', () => {
-    it('应跳过系统目录中的应用', () => {
-      expect(shouldSkipShortcut('Notepad', 'C:\\Windows\\notepad.exe')).toBe(true)
-      expect(shouldSkipShortcut('cmd', 'C:\\Windows\\System32\\cmd.exe')).toBe(true)
-      expect(shouldSkipShortcut('app', 'C:\\Windows\\SysWOW64\\app.exe')).toBe(true)
-    })
-
-    it('不应跳过非系统目录中的应用', () => {
-      expect(shouldSkipShortcut('App', 'C:\\Program Files\\App\\app.exe')).toBe(false)
-      expect(shouldSkipShortcut('App', 'D:\\Games\\app.exe')).toBe(false)
-    })
-
-    it('应跳过文档类扩展名', () => {
-      expect(shouldSkipShortcut('Help', 'C:\\App\\help.html')).toBe(true)
-      expect(shouldSkipShortcut('Manual', 'C:\\App\\manual.pdf')).toBe(true)
-      expect(shouldSkipShortcut('Help', 'C:\\App\\help.chm')).toBe(true)
-      expect(shouldSkipShortcut('Readme', 'C:\\App\\README.md')).toBe(true)
-      expect(shouldSkipShortcut('Doc', 'C:\\App\\guide.docx')).toBe(true)
-    })
-
-    it('不应跳过可执行文件', () => {
-      expect(shouldSkipShortcut('App', 'C:\\App\\app.exe')).toBe(false)
-    })
-
-    it('应跳过卸载程序', () => {
-      expect(shouldSkipShortcut('Uninstall', 'C:\\App\\uninstall.exe')).toBe(true)
-      expect(shouldSkipShortcut('Uninstall', 'C:\\App\\uninst.exe')).toBe(true)
-      expect(shouldSkipShortcut('Uninstall', 'C:\\App\\unins000.exe')).toBe(true)
-      expect(shouldSkipShortcut('Uninstall', 'C:\\App\\unwise.exe')).toBe(true)
-      expect(shouldSkipShortcut('Uninstall', 'C:\\App\\_uninst.exe')).toBe(true)
-    })
-
-    it('应跳过安装程序', () => {
-      expect(shouldSkipShortcut('Setup', 'C:\\App\\setup.exe')).toBe(true)
-      expect(shouldSkipShortcut('Install', 'C:\\App\\install.exe')).toBe(true)
-      expect(shouldSkipShortcut('Installer', 'C:\\App\\installer.exe')).toBe(true)
-      expect(shouldSkipShortcut('Install', 'C:\\App\\instmsi.exe')).toBe(true)
-    })
-
-    it('不应跳过名称包含 setup 但不以其开头的文件', () => {
-      // GameSetup.exe 的 basename（去掉扩展名）是 GameSetup，不匹配 ^setup$
-      expect(shouldSkipShortcut('GameSetup', 'C:\\App\\GameSetup.exe')).toBe(false)
-    })
-
-    it('目标路径检查通过时不应检查名称', () => {
-      // 即使名称匹配 SKIP_NAME_PATTERN，如果目标路径正常，也不应跳过
-      expect(shouldSkipShortcut('Uninstall Tool', 'C:\\App\\goodapp.exe')).toBe(false)
-    })
+describe('shouldSkipShortcut（仅按名称过滤）', () => {
+  it('应跳过卸载相关名称', () => {
+    expect(shouldSkipShortcut('Uninstall App')).toBe(true)
+    expect(shouldSkipShortcut('卸载程序')).toBe(true)
+    expect(shouldSkipShortcut('App卸载')).toBe(true)
   })
 
-  describe('无目标路径时（降级检查名称）', () => {
-    it('应跳过匹配跳过名称模式的应用', () => {
-      expect(shouldSkipShortcut('Uninstall App')).toBe(true)
-      expect(shouldSkipShortcut('卸载程序')).toBe(true)
-      expect(shouldSkipShortcut('App卸载')).toBe(true)
-      expect(shouldSkipShortcut('Website')).toBe(true)
-      expect(shouldSkipShortcut('公司网站')).toBe(true)
-      expect(shouldSkipShortcut('Help Center')).toBe(true)
-      expect(shouldSkipShortcut('readme')).toBe(true)
-      expect(shouldSkipShortcut('Documentation')).toBe(true)
-    })
+  it('应跳过网站/帮助/文档相关名称', () => {
+    expect(shouldSkipShortcut('Website')).toBe(true)
+    expect(shouldSkipShortcut('公司网站')).toBe(true)
+    expect(shouldSkipShortcut('Help Center')).toBe(true)
+    expect(shouldSkipShortcut('readme')).toBe(true)
+    expect(shouldSkipShortcut('Documentation')).toBe(true)
+    expect(shouldSkipShortcut('用户文档')).toBe(true)
+  })
 
-    it('不应跳过正常名称', () => {
-      expect(shouldSkipShortcut('Visual Studio Code')).toBe(false)
-      expect(shouldSkipShortcut('Chrome')).toBe(false)
-      expect(shouldSkipShortcut('原神')).toBe(false)
-    })
+  it('不应跳过正常应用名称', () => {
+    expect(shouldSkipShortcut('Visual Studio Code')).toBe(false)
+    expect(shouldSkipShortcut('Chrome')).toBe(false)
+    expect(shouldSkipShortcut('原神')).toBe(false)
+    expect(shouldSkipShortcut('文件资源管理器')).toBe(false)
+    expect(shouldSkipShortcut('cmd')).toBe(false)
+    expect(shouldSkipShortcut('PowerShell')).toBe(false)
+    expect(shouldSkipShortcut('设备管理器')).toBe(false)
+  })
+
+  it('不应跳过名称包含关键词但不匹配模式的应用', () => {
+    // "文件" 不等于 "文档"，不应被过滤
+    expect(shouldSkipShortcut('文件资源管理器')).toBe(false)
+    // "helper" 包含 "help" 但 SKIP_NAME_PATTERN 是匹配 "help" 子串，所以会被过滤
+    // 这是预期行为：名为 "helper" 的快捷方式通常是辅助工具
   })
 })
 
@@ -105,7 +65,7 @@ describe('getIconUrl', () => {
 // ========== deduplicateCommands ==========
 
 describe('deduplicateCommands', () => {
-  it('应去除完全相同名称和路径的重复项', () => {
+  it('应去除完全相同名称和路径的重复项（无 _dedupeTarget 时降级为 path）', () => {
     const apps = [
       { name: 'App', path: 'C:\\app.exe' },
       { name: 'App', path: 'C:\\app.exe' }
@@ -115,20 +75,57 @@ describe('deduplicateCommands', () => {
     expect(result[0].name).toBe('App')
   })
 
-  it('应保留不同名但同路径的应用（核心特性）', () => {
+  it('应合并同名同目标但不同 .lnk 路径的快捷方式', () => {
+    // 用户开始菜单和系统开始菜单都有同名同目标的快捷方式
     const apps = [
-      { name: '原神', path: 'C:\\miHoYo\\launcher.exe' },
-      { name: '米哈游启动器', path: 'C:\\miHoYo\\launcher.exe' }
+      {
+        name: 'App',
+        path: 'C:\\Users\\test\\Start Menu\\Programs\\App.lnk',
+        _dedupeTarget: 'C:\\Program Files\\App\\app.exe'
+      },
+      {
+        name: 'App',
+        path: 'C:\\ProgramData\\Start Menu\\Programs\\App.lnk',
+        _dedupeTarget: 'C:\\Program Files\\App\\app.exe'
+      }
+    ]
+    const result = deduplicateCommands(apps)
+    expect(result).toHaveLength(1)
+    expect(result[0].name).toBe('App')
+    // 保留第一个出现的 .lnk 路径
+    expect(result[0].path).toBe('C:\\Users\\test\\Start Menu\\Programs\\App.lnk')
+  })
+
+  it('应保留不同名但同目标的应用（核心特性）', () => {
+    const apps = [
+      {
+        name: '原神',
+        path: 'C:\\Users\\test\\Start Menu\\原神.lnk',
+        _dedupeTarget: 'C:\\miHoYo\\launcher.exe'
+      },
+      {
+        name: '米哈游启动器',
+        path: 'C:\\Users\\test\\Start Menu\\米哈游启动器.lnk',
+        _dedupeTarget: 'C:\\miHoYo\\launcher.exe'
+      }
     ]
     const result = deduplicateCommands(apps)
     expect(result).toHaveLength(2)
     expect(result.map((a) => a.name).sort()).toEqual(['原神', '米哈游启动器'].sort())
   })
 
-  it('应保留同名但不同路径的应用', () => {
+  it('应保留同名但不同目标的应用', () => {
     const apps = [
-      { name: 'App', path: 'C:\\v1\\app.exe' },
-      { name: 'App', path: 'C:\\v2\\app.exe' }
+      {
+        name: 'App',
+        path: 'C:\\Users\\test\\Start Menu\\App.lnk',
+        _dedupeTarget: 'C:\\v1\\app.exe'
+      },
+      {
+        name: 'App',
+        path: 'C:\\ProgramData\\Start Menu\\App.lnk',
+        _dedupeTarget: 'C:\\v2\\app.exe'
+      }
     ]
     const result = deduplicateCommands(apps)
     expect(result).toHaveLength(2)
@@ -136,8 +133,16 @@ describe('deduplicateCommands', () => {
 
   it('去重应不区分大小写', () => {
     const apps = [
-      { name: 'App', path: 'C:\\App\\APP.EXE' },
-      { name: 'app', path: 'c:\\app\\app.exe' }
+      {
+        name: 'App',
+        path: 'C:\\Users\\Start Menu\\App.lnk',
+        _dedupeTarget: 'C:\\App\\APP.EXE'
+      },
+      {
+        name: 'app',
+        path: 'C:\\ProgramData\\Start Menu\\App.lnk',
+        _dedupeTarget: 'c:\\app\\app.exe'
+      }
     ]
     const result = deduplicateCommands(apps)
     expect(result).toHaveLength(1)
@@ -145,11 +150,24 @@ describe('deduplicateCommands', () => {
 
   it('应保留第一个出现的重复项', () => {
     const apps = [
-      { name: 'App', path: 'C:\\app.exe', icon: 'icon1' },
-      { name: 'App', path: 'C:\\app.exe', icon: 'icon2' }
+      { name: 'App', path: 'C:\\first\\App.lnk', icon: 'icon1', _dedupeTarget: 'C:\\app.exe' },
+      { name: 'App', path: 'C:\\second\\App.lnk', icon: 'icon2', _dedupeTarget: 'C:\\app.exe' }
     ]
     const result = deduplicateCommands(apps)
     expect(result[0].icon).toBe('icon1')
+  })
+
+  it('去重后应清除 _dedupeTarget 字段', () => {
+    const apps = [
+      {
+        name: 'App',
+        path: 'C:\\Users\\Start Menu\\App.lnk',
+        _dedupeTarget: 'C:\\app.exe'
+      }
+    ]
+    const result = deduplicateCommands(apps)
+    expect(result).toHaveLength(1)
+    expect((result[0] as any)._dedupeTarget).toBeUndefined()
   })
 
   it('空数组应返回空数组', () => {
@@ -234,17 +252,5 @@ describe('配置常量', () => {
     expect(SKIP_FOLDERS).toContain('docs')
     expect(SKIP_FOLDERS).toContain('examples')
     expect(SKIP_FOLDERS).toContain('demo')
-  })
-
-  it('SKIP_EXTENSIONS 应包含常见文档扩展名', () => {
-    expect(SKIP_EXTENSIONS).toContain('.html')
-    expect(SKIP_EXTENSIONS).toContain('.pdf')
-    expect(SKIP_EXTENSIONS).toContain('.chm')
-    expect(SKIP_EXTENSIONS).toContain('.md')
-  })
-
-  it('SYSTEM_DIRECTORIES 应包含 Windows 系统目录', () => {
-    expect(SYSTEM_DIRECTORIES).toContain('c:\\windows\\')
-    expect(SYSTEM_DIRECTORIES).toContain('c:\\windows\\system32\\')
   })
 })


### PR DESCRIPTION
## Summary
- 优化 Windows 快捷方式扫描：改为存储 .lnk 路径并通过 Shell 启动，确保所有快捷方式（如"文件资源管理器"）正常识别和打开
- 支持解析 desktop.ini + MUI 资源获取本地化显示名称，解决快捷方式显示英文名的问题
- 简化过滤逻辑（仅跳过网址类），合并同名同目标路径的重复快捷方式
- 校对 ms-settings 名称对齐 Windows 11 24H2 实际 UI，移除无效/过时条目

## Changes
### 快捷方式扫描 (`windowsScanner.ts`)
- `appPath` 改为存储 `.lnk` 文件路径，新增 `_dedupeTarget` 字段存储实际目标路径用于去重
- 新增 `getLocalizedDisplayNames()` 解析 `desktop.ini` 中的本地化名称（支持 UTF-16LE/UTF-8 编码）
- 新增 `resolveMuiStrings()` 通过 PowerShell P/Invoke 手动加载 MUI 资源解析 `@dll,-id` 格式的本地化字符串
- `shouldSkipShortcut()` 简化为仅基于名称模式过滤
- `deduplicateCommands()` 使用 `name|targetPath` 组合键去重

### 启动器 (`windowsLauncher.ts`)
- 新增 `.lnk` 文件的 `shell.openPath` 启动支持和 `shell.showItemInFolder` 定位支持

### 系统设置 (`msSettingsUris.ts`, `windowsSettings.ts`)
- 校对名称对齐 Win11 24H2：Wi-Fi→WLAN、附近共享→就近共享、显示→屏幕、电池→电源、声音设备→所有声音设备等
- 移除无效条目：电池节能设置、电池使用情况、搜索详情、设置主页、快速控制中心
- 移除重复条目（显示卡、网络和 Internet）
- 任务栏 category 修正为"个性化"

### 前端 (`AllCommands.vue`, `AdaptiveIcon.vue`, `PluginMarket.vue`)
- 适配新的快捷方式路径格式和图标协议

## Test plan
- [ ] 验证扫描结果包含"文件资源管理器"等系统快捷方式，且显示为中文名
- [ ] 验证点击快捷方式能正常启动对应程序
- [ ] 验证"打开文件位置"定位到 .lnk 所在目录
- [ ] 验证同名同目标的快捷方式被正确合并
- [ ] 验证 ms-settings URI 能正常打开对应设置页面