### PR TITLE
fix: 修复滚动条样式缺失和扫描过滤不完整

### DIFF
--- a/src/main/api/renderer/systemCommands.ts
+++ b/src/main/api/renderer/systemCommands.ts
@@ -1,4 +1,5 @@
-import { BrowserWindow, shell, clipboard } from 'electron'
+import { BrowserWindow, clipboard, shell } from 'electron'
+import { GLOBAL_SCROLLBAR_CSS } from '../../core/globalStyles'
 import windowManager from '../../managers/windowManager'
 
 interface SystemCommandContext {
@@ -242,6 +243,10 @@ function handleWindowInfo(ctx: SystemCommandContext): any {
   })
 
   infoWindow.loadURL(`data:text/html;charset=utf-8,${encodeURIComponent(html)}`)
+
+  infoWindow.webContents.on('did-finish-load', () => {
+    infoWindow.webContents.insertCSS(GLOBAL_SCROLLBAR_CSS)
+  })
 
   infoWindow.on('blur', () => {
     if (!infoWindow.isDestroyed()) {

--- a/src/main/core/commandScanner/windowsScanner.ts
+++ b/src/main/core/commandScanner/windowsScanner.ts
@@ -26,7 +26,7 @@ export const SKIP_FOLDERS = [
 // 仅按名称过滤，不按目标类型/路径/扩展名过滤
 // 因为扫描范围仅限开始菜单和桌面，这些位置的快捷方式都是有意放置的
 export const SKIP_NAME_PATTERN =
-  /^uninstall |^卸载|卸载$|website|网站|帮助|help|readme|read me|文档|manual|license|documentation/i
+  /^uninstall|^卸载|卸载$|website|网站|帮助|help|readme|read me|文档|manual|license|documentation/i
 
 // ========== 辅助函数 ==========
 

--- a/src/renderer/src/components/SuperPanel.vue
+++ b/src/renderer/src/components/SuperPanel.vue
@@ -609,9 +609,6 @@ onUnmounted(() => {
   min-height: 0;
 }
 
-.pinned-grid::-webkit-scrollbar {
-  display: none;
-}
 
 .grid-item {
   display: flex;
@@ -707,9 +704,6 @@ onUnmounted(() => {
   flex: 1;
 }
 
-.search-list::-webkit-scrollbar {
-  display: none;
-}
 
 .list-item {
   display: flex;


### PR DESCRIPTION
- 窗口信息命令创建的窗口注入全局滚动条样式
- 超级面板恢复滚动条显示，使用全局统一样式
- 修复名称恰好为 "Uninstall" 的快捷方式未被过滤的问题