### PR TITLE
feat: 设置页面顶部搜索栏集成、加权搜索与主进程静态导入重构

### DIFF
--- a/internal-plugins/setting/src/components/settings/AiModels.vue
+++ b/internal-plugins/setting/src/components/settings/AiModels.vue
@@ -10,7 +10,7 @@
 
         <!-- 模型列表 -->
         <div class="model-list">
-          <div v-for="model in models" :key="model.id" class="card model-item">
+          <div v-for="model in filteredModels" :key="model.id" class="card model-item">
             <div class="model-info">
               <div class="model-header">
                 <h3 class="model-name">{{ model.label }}</h3>
@@ -105,10 +105,15 @@
 </template>
 
 <script setup lang="ts">
-import { onMounted, ref } from 'vue'
+import { computed, onMounted, ref } from 'vue'
 import { useToast } from '../../composables/useToast'
+import { weightedSearch } from '../../utils/weightedSearch'
 import Icon from '../common/Icon.vue'
 import AiModelEditor from './AiModelEditor.vue'
+
+const props = defineProps<{
+  searchQuery?: string
+}>()
 
 const { success, error, confirm } = useToast()
 
@@ -125,6 +130,14 @@ interface AiModel {
 // 模型列表
 const models = ref<AiModel[]>([])
 const isDeleting = ref(false)
+
+const filteredModels = computed(() =>
+  weightedSearch(models.value, props.searchQuery || '', [
+    { value: (m) => m.label || '', weight: 10 },
+    { value: (m) => m.apiUrl || '', weight: 5 },
+    { value: (m) => m.description || '', weight: 3 }
+  ])
+)
 
 // 编辑器状态
 const showEditor = ref(false)

--- a/internal-plugins/setting/src/components/settings/GlobalShortcuts.vue
+++ b/internal-plugins/setting/src/components/settings/GlobalShortcuts.vue
@@ -10,7 +10,7 @@
 
         <!-- 快捷键列表 -->
         <div class="shortcut-list">
-          <div v-for="shortcut in shortcuts" :key="shortcut.id" class="card shortcut-item">
+          <div v-for="shortcut in filteredShortcuts" :key="shortcut.id" class="card shortcut-item">
             <div class="shortcut-info">
               <div class="shortcut-key-display">{{ shortcut.shortcut }}</div>
               <div class="shortcut-desc">{{ shortcut.target }}</div>
@@ -89,10 +89,15 @@
 </template>
 
 <script setup lang="ts">
-import { onMounted, ref } from 'vue'
+import { computed, onMounted, ref } from 'vue'
 import { useToast } from '../../composables/useToast'
+import { weightedSearch } from '../../utils/weightedSearch'
 import Icon from '../common/Icon.vue'
 import ShortcutEditor from './ShortcutEditor.vue'
+
+const props = defineProps<{
+  searchQuery?: string
+}>()
 
 const { success, error, warning, confirm } = useToast()
 
@@ -106,6 +111,13 @@ interface GlobalShortcut {
 // 快捷键列表
 const shortcuts = ref<GlobalShortcut[]>([])
 const isDeleting = ref(false)
+
+const filteredShortcuts = computed(() =>
+  weightedSearch(shortcuts.value, props.searchQuery || '', [
+    { value: (s) => s.shortcut || '', weight: 10 },
+    { value: (s) => s.target || '', weight: 5 }
+  ])
+)
 
 // 编辑器状态
 const showEditor = ref(false)

--- a/internal-plugins/setting/src/components/settings/LocalLaunch.vue
+++ b/internal-plugins/setting/src/components/settings/LocalLaunch.vue
@@ -72,7 +72,7 @@
       <!-- 本地启动项列表 -->
       <div v-else class="shortcuts-list">
         <div
-          v-for="shortcut in shortcuts"
+          v-for="shortcut in filteredShortcuts"
           :key="shortcut.id"
           class="card shortcut-item"
           :title="shortcut.path"
@@ -199,9 +199,14 @@
 </template>
 
 <script setup lang="ts">
-import { nextTick, onMounted, ref } from 'vue'
-import AdaptiveIcon from '../common/AdaptiveIcon.vue'
+import { computed, nextTick, onMounted, ref } from 'vue'
 import { useToast } from '../../composables/useToast'
+import { weightedSearch } from '../../utils/weightedSearch'
+import AdaptiveIcon from '../common/AdaptiveIcon.vue'
+
+const props = defineProps<{
+  searchQuery?: string
+}>()
 
 const { success, error, confirm } = useToast()
 
@@ -222,6 +227,13 @@ const loading = ref(true)
 const isAdding = ref(false)
 const isDeleting = ref(false)
 const isDragging = ref(false)
+
+const filteredShortcuts = computed(() =>
+  weightedSearch(shortcuts.value, props.searchQuery || '', [
+    { value: (s) => s.alias || s.name || '', weight: 10 },
+    { value: (s) => s.path || '', weight: 5 }
+  ])
+)
 
 // 别名编辑状态
 const editingId = ref<string | null>(null)

--- a/internal-plugins/setting/src/components/settings/PluginMarket.vue
+++ b/internal-plugins/setting/src/components/settings/PluginMarket.vue
@@ -9,7 +9,7 @@
         </div>
         <div v-else class="market-grid">
           <div
-            v-for="plugin in plugins"
+            v-for="plugin in filteredPlugins"
             :key="plugin.name"
             class="card plugin-card"
             :title="plugin.description"
@@ -125,10 +125,15 @@
 </template>
 
 <script setup lang="ts">
-import { onMounted, onUnmounted, ref } from 'vue'
+import { computed, onMounted, onUnmounted, ref } from 'vue'
 import { useToast } from '../../composables/useToast'
+import { weightedSearch } from '../../utils/weightedSearch'
 import AdaptiveIcon from '../common/AdaptiveIcon.vue'
 import PluginDetail from './PluginDetail.vue'
+
+const props = defineProps<{
+  searchQuery?: string
+}>()
 
 const { success, error, confirm } = useToast()
 
@@ -149,6 +154,13 @@ interface Plugin {
 const plugins = ref<Plugin[]>([])
 const isLoading = ref(false)
 const installingPlugin = ref<string | null>(null)
+
+const filteredPlugins = computed(() =>
+  weightedSearch(plugins.value, props.searchQuery || '', [
+    { value: (p) => p.title || p.name || '', weight: 10 },
+    { value: (p) => p.description || '', weight: 5 }
+  ])
+)
 
 // 详情弹窗状态
 const isDetailVisible = ref(false)

--- a/internal-plugins/setting/src/components/settings/Settings.vue
+++ b/internal-plugins/setting/src/components/settings/Settings.vue
@@ -20,28 +20,28 @@
       <GeneralSettings v-if="activeMenu === 'general'" />
 
       <!-- 插件中心 -->
-      <PluginCenter v-if="activeMenu === 'plugins'" />
+      <PluginCenter v-if="activeMenu === 'plugins'" :search-query="props.searchQuery" />
 
       <!-- 插件市场 -->
-      <PluginMarket v-if="activeMenu === 'market'" />
+      <PluginMarket v-if="activeMenu === 'market'" :search-query="props.searchQuery" />
 
       <!-- 我的数据 -->
-      <DataManagement v-if="activeMenu === 'data'" />
+      <DataManagement v-if="activeMenu === 'data'" :search-query="props.searchQuery" />
 
       <!-- 全局快捷键 -->
-      <GlobalShortcuts v-if="activeMenu === 'shortcuts'" />
+      <GlobalShortcuts v-if="activeMenu === 'shortcuts'" :search-query="props.searchQuery" />
 
       <!-- WebDAV 同步 -->
       <SyncSettings v-if="activeMenu === 'sync'" />
 
       <!-- 所有指令 -->
-      <AllCommands v-if="activeMenu === 'all-commands'" />
+      <AllCommands v-if="activeMenu === 'all-commands'" :search-query="props.searchQuery" />
 
       <!-- 本地启动 -->
-      <LocalLaunch v-if="activeMenu === 'local-launch'" />
+      <LocalLaunch v-if="activeMenu === 'local-launch'" :search-query="props.searchQuery" />
 
       <!-- AI 模型管理 -->
-      <AiModels v-if="activeMenu === 'ai-models'" />
+      <AiModels v-if="activeMenu === 'ai-models'" :search-query="props.searchQuery" />
     </div>
   </div>
 </template>
@@ -62,6 +62,7 @@ import SyncSettings from './SyncSettings.vue'
 // Props
 interface Props {
   activePage: string
+  searchQuery?: string
 }
 
 const props = defineProps<Props>()

--- a/internal-plugins/setting/src/components/settings/common/CommandCard.vue
+++ b/internal-plugins/setting/src/components/settings/common/CommandCard.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="card command-card">
+  <div class="card command-card" :title="command.path || ''">
     <div class="command-icon">
       <span v-if="command.icon && command.icon.length <= 2" class="icon-emoji">
         {{ command.icon }}

--- a/internal-plugins/setting/src/env.d.ts
+++ b/internal-plugins/setting/src/env.d.ts
@@ -96,6 +96,7 @@ declare global {
           success: boolean
           data?: Array<{
             pluginName: string
+            pluginTitle: string | null
             docCount: number
             attachmentCount: number
             logo: string | null

--- a/internal-plugins/setting/src/utils/weightedSearch.ts
+++ b/internal-plugins/setting/src/utils/weightedSearch.ts
@@ -1,0 +1,31 @@
+/**
+ * 加权搜索：根据多个字段的权重对列表进行过滤和排序。
+ * 匹配权重高的字段的项排在前面，无匹配的项被过滤掉。
+ *
+ * @param items 待搜索的列表
+ * @param query 搜索关键词（原始输入，内部会 trim + toLowerCase）
+ * @param fields 字段定义数组，每项包含取值函数和权重
+ * @returns 过滤并按权重降序排列的结果
+ */
+export function weightedSearch<T>(
+  items: T[],
+  query: string,
+  fields: Array<{ value: (item: T) => string; weight: number }>
+): T[] {
+  const q = query.trim().toLowerCase()
+  if (!q) return items
+
+  return items
+    .map((item) => {
+      let score = 0
+      for (const field of fields) {
+        if (field.value(item).toLowerCase().includes(q)) {
+          score += field.weight
+        }
+      }
+      return { item, score }
+    })
+    .filter((x) => x.score > 0)
+    .sort((a, b) => b.score - a.score)
+    .map((x) => x.item)
+}

--- a/src/main/api/index.ts
+++ b/src/main/api/index.ts
@@ -218,7 +218,6 @@ class APIManager {
       }
 
       // 合并动态 features（支持动态指令）
-      const { pluginFeatureAPI } = await import('./plugin/feature.js')
       const dynamicFeatures = pluginFeatureAPI.loadDynamicFeatures(plugin.name)
       const allFeatures = [...(plugin.features || []), ...dynamicFeatures]
 

--- a/src/main/api/plugin/internal.ts
+++ b/src/main/api/plugin/internal.ts
@@ -1,5 +1,7 @@
 import { IpcMainInvokeEvent, ipcMain } from 'electron'
 import detachedWindowManager from '../../core/detachedWindowManager.js'
+import superPanelManager from '../../core/superPanelManager.js'
+import aiModelsAPI from '../renderer/aiModels.js'
 import commandsAPI from '../renderer/commands.js'
 import pluginsAPI from '../renderer/plugins.js'
 import settingsAPI from '../renderer/settings.js'
@@ -7,7 +9,6 @@ import systemAPI from '../renderer/system.js'
 import windowAPI from '../renderer/window.js'
 import databaseAPI from '../shared/database'
 import updaterAPI from '../updater.js'
-import aiModelsAPI from '../renderer/aiModels.js'
 
 /**
  * 权限错误类
@@ -360,7 +361,6 @@ export class InternalPluginAPI {
       this.mainWindow?.webContents.send('update-avatar', avatar)
 
       // 广播到超级面板窗口
-      const { default: superPanelManager } = await import('../../core/superPanelManager.js')
       superPanelManager.broadcastToSuperPanel('update-avatar', avatar)
 
       return { success: true }
@@ -545,8 +545,7 @@ export class InternalPluginAPI {
         if (!requireInternalPlugin(this.pluginManager, event)) {
           throw new PermissionDeniedError('internal:update-super-panel-config')
         }
-        // 转发给 superPanelManager（延迟导入避免循环依赖）
-        const { default: superPanelManager } = await import('../../core/superPanelManager.js')
+        // 转发给 superPanelManager
         superPanelManager.updateConfig(config)
         return { success: true }
       }

--- a/src/main/api/renderer/commands.ts
+++ b/src/main/api/renderer/commands.ts
@@ -7,6 +7,7 @@ import { scanApplications } from '../../core/commandScanner'
 import { UwpManager } from '../../core/native'
 import { pluginFeatureAPI } from '../plugin/feature'
 import databaseAPI from '../shared/database'
+import { WINDOWS_SETTINGS } from '../../core/systemSettings/windowsSettings.js'
 import pluginsAPI from './plugins'
 import { executeSystemCommand } from './systemCommands'
 import { findCommandIndex, filterOutCommand, hasCommand } from './commandMatchers'
@@ -535,8 +536,6 @@ export class AppsAPI {
         } else {
           // 如果不是普通应用，尝试从系统设置中查找
           if (process.platform === 'win32') {
-            const { WINDOWS_SETTINGS } =
-              await import('../../core/systemSettings/windowsSettings.js')
             const setting = WINDOWS_SETTINGS.find((s: any) => s.uri === appPath)
 
             if (setting) {

--- a/src/main/api/renderer/sync.ts
+++ b/src/main/api/renderer/sync.ts
@@ -4,6 +4,7 @@ import { SyncConfig } from '../../core/sync/types'
 import lmdbInstance from '../../core/lmdb/lmdbInstance'
 import { safeStorage } from 'electron'
 import pluginDeviceAPI from '../plugin/device'
+import { WebDAVSyncClient } from '../../core/sync/webdavClient'
 
 /**
  * 同步 API
@@ -25,7 +26,6 @@ export class SyncAPI {
     // 测试 WebDAV 连接
     ipcMain.handle('sync:test-connection', async (_event, config: SyncConfig) => {
       try {
-        const { WebDAVSyncClient } = await import('../../core/sync/webdavClient')
         const client = new WebDAVSyncClient()
         await client.init(config)
         return { success: true }

--- a/src/main/api/renderer/systemCommands.ts
+++ b/src/main/api/renderer/systemCommands.ts
@@ -1,4 +1,6 @@
+import { exec } from 'child_process'
 import { BrowserWindow, clipboard, shell } from 'electron'
+import { promisify } from 'util'
 import { GLOBAL_SCROLLBAR_CSS } from '../../core/globalStyles'
 import windowManager from '../../managers/windowManager'
 
@@ -15,8 +17,6 @@ export async function executeSystemCommand(
   ctx: SystemCommandContext,
   param?: any
 ): Promise<any> {
-  const { exec } = await import('child_process')
-  const { promisify } = await import('util')
   const execAsync = promisify(exec)
 
   const platform = process.platform

--- a/src/main/api/renderer/systemSettings.ts
+++ b/src/main/api/renderer/systemSettings.ts
@@ -1,3 +1,5 @@
+import { WINDOWS_SETTINGS } from '../../core/systemSettings/windowsSettings.js'
+
 export class SystemSettingsAPI {
   public init(): void {
     // 暂时不需要初始化逻辑
@@ -5,7 +7,6 @@ export class SystemSettingsAPI {
 
   public async getSystemSettings(): Promise<any[]> {
     if (process.platform === 'win32') {
-      const { WINDOWS_SETTINGS } = await import('../../core/systemSettings/windowsSettings.js')
       return WINDOWS_SETTINGS
     }
     return []

--- a/src/main/api/shared/database.ts
+++ b/src/main/api/shared/database.ts
@@ -421,6 +421,7 @@ export class DatabaseAPI {
     success: boolean
     data?: Array<{
       pluginName: string
+      pluginTitle: string | null
       docCount: number
       attachmentCount: number
       logo: string | null
@@ -467,6 +468,7 @@ export class DatabaseAPI {
         const plugin = plugins.find((p: any) => p.name === pluginName)
         return {
           pluginName,
+          pluginTitle: plugin?.title || null,
           docCount: stats.docCount,
           attachmentCount: stats.attachmentCount,
           logo: plugin?.logo || null
@@ -493,6 +495,7 @@ export class DatabaseAPI {
       if (ztoolsDocCount > 0 || ztoolsAttachmentCount > 0) {
         data.unshift({
           pluginName: 'ZTOOLS',
+          pluginTitle: '主程序',
           docCount: ztoolsDocCount,
           attachmentCount: ztoolsAttachmentCount,
           logo: null // 主程序没有 logo，前端会显示特殊图标
@@ -678,6 +681,7 @@ export class DatabaseAPI {
     success: boolean
     data?: Array<{
       pluginName: string
+      pluginTitle: string | null
       docCount: number
       attachmentCount: number
       logo: string | null

--- a/src/main/core/commandLauncher/index.ts
+++ b/src/main/core/commandLauncher/index.ts
@@ -1,4 +1,6 @@
 import type { ConfirmDialogOptions } from './types'
+import { launchApp as macLaunch } from './macLauncher'
+import { launchApp as winLaunch } from './windowsLauncher'
 
 // 重新导出类型
 export type { ConfirmDialogOptions } from './types'
@@ -12,11 +14,9 @@ export async function launchApp(
 
   if (platform === 'darwin') {
     // macOS
-    const { launchApp: macLaunch } = await import('./macLauncher')
     return macLaunch(appPath, confirmDialog)
   } else if (platform === 'win32') {
     // Windows
-    const { launchApp: winLaunch } = await import('./windowsLauncher')
     return winLaunch(appPath, confirmDialog)
   } else {
     console.warn(`不支持的平台: ${platform}`)

--- a/src/main/core/commandScanner/index.ts
+++ b/src/main/core/commandScanner/index.ts
@@ -1,4 +1,6 @@
 import { Command } from './types'
+import { scanApplications as macScan } from './macScanner'
+import { scanApplications as winScan } from './windowsScanner'
 
 export type { AppScanner, Command } from './types'
 
@@ -8,11 +10,9 @@ export async function scanApplications(): Promise<Command[]> {
 
   if (platform === 'darwin') {
     // macOS
-    const { scanApplications: macScan } = await import('./macScanner')
     return macScan()
   } else if (platform === 'win32') {
     // Windows
-    const { scanApplications: winScan } = await import('./windowsScanner')
     return winScan()
   } else {
     console.warn(`不支持的平台: ${platform}`)

--- a/src/main/core/detachedWindowManager.ts
+++ b/src/main/core/detachedWindowManager.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, ipcMain, WebContentsView } from 'electron'
+import { app, BrowserWindow, ipcMain, Menu, WebContentsView } from 'electron'
 import path from 'path'
 import { fileURLToPath, pathToFileURL } from 'url'
 import { v4 as uuidv4 } from 'uuid'
@@ -385,9 +385,6 @@ class DetachedWindowManager {
     ): Promise<void> => {
       // 验证事件来自这个窗口
       if (_event.sender.id !== win.webContents.id) return
-
-      // 导入 Menu 模块
-      const { Menu } = await import('electron')
 
       // 构建菜单
       const menu = Menu.buildFromTemplate(

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -10,6 +10,7 @@ import appWatcher from './appWatcher'
 import detachedWindowManager from './core/detachedWindowManager'
 import { loadInternalPlugins } from './core/internalPluginLoader'
 
+import crypto from 'crypto'
 import pluginManager from './managers/pluginManager'
 import windowManager from './managers/windowManager'
 import { IconExtractor } from './core/native/index'
@@ -121,7 +122,6 @@ export function registerIconProtocolForSession(targetSession: Electron.Session):
         await fs.mkdir(tempDir, { recursive: true })
 
         // 使用图标路径的哈希作为临时文件名
-        const crypto = await import('crypto')
         const hash = crypto.createHash('md5').update(iconPath).digest('hex')
         const tempPngPath = path.join(tempDir, `${hash}.png`)
 

--- a/src/main/utils/elevation.ts
+++ b/src/main/utils/elevation.ts
@@ -1,4 +1,4 @@
-import { execFile } from 'child_process'
+import { execFile, spawn } from 'child_process'
 import { promisify } from 'util'
 
 const execFilePromise = promisify(execFile)
@@ -47,7 +47,6 @@ export async function execWithElevation(
         await execFilePromise(command, args, { timeout: 30000 })
       } else {
         // 不等待，使用 spawn detached
-        const { spawn } = await import('child_process')
         const subprocess = spawn(command, args, {
           detached: true,
           stdio: 'ignore'

--- a/src/renderer/src/components/SuperPanel.vue
+++ b/src/renderer/src/components/SuperPanel.vue
@@ -609,7 +609,6 @@ onUnmounted(() => {
   min-height: 0;
 }
 
-
 .grid-item {
   display: flex;
   flex-direction: column;
@@ -703,7 +702,6 @@ onUnmounted(() => {
   overflow-y: auto;
   flex: 1;
 }
-
 
 .list-item {
   display: flex;


### PR DESCRIPTION
- 设置插件接入主窗口顶部搜索框，各可搜索页面显示独立 placeholder 并自动聚焦，切换页面/来源时清空输入
- 新增通用 weightedSearch 工具函数，支持多字段加权评分排序，统一应用于已安装插件、插件市场、快捷键、本地启动、AI 模型、所有指令、我的数据等页面
- 所有指令页面支持搜索过滤右侧指令面板，指令卡片 hover 显示完整路径
- 我的数据页面显示插件 title 替代 pluginId，后端 getPluginDataStats 返回 pluginTitle 字段
- 已安装插件页面移除内部搜索框，统一使用顶部搜索栏
- 主进程所有动态 import() 替换为静态 import，消除 Vite 构建警告
- 代码简化：去除冗余类型标注、多余回调包裹和误导性注释