### PR TITLE
fix: 分离窗口搜索框聚焦高亮改为透明白色叠加，移除硬编码蓝色

### DIFF
--- a/src/main/api/renderer/settings.ts
+++ b/src/main/api/renderer/settings.ts
@@ -1,9 +1,9 @@
 import { app, globalShortcut, ipcMain, nativeTheme } from 'electron'
 import { getCurrentShortcut, updateShortcut } from '../../index.js'
 
-import databaseAPI from '../shared/database'
-import windowManager from '../../managers/windowManager.js'
 import proxyManager from '../../managers/proxyManager.js'
+import windowManager from '../../managers/windowManager.js'
+import databaseAPI from '../shared/database'
 
 /**
  * 设置管理API - 主程序专用

--- a/src/renderer/src/assets/titlebar.css
+++ b/src/renderer/src/assets/titlebar.css
@@ -14,6 +14,7 @@
   --input-focus: #0284c7;
   --input-focus-bg: rgba(0, 0, 0, 0.08);
   --hover-bg: #f9fafb;
+  --primary-color: #0284c7;
 }
 
 /* Windows 下根据 data-material 属性应用不同材质样式 */
@@ -50,13 +51,14 @@
     --input-focus: #0284c7;
     --input-focus-bg: rgba(0, 0, 0, 0.3);
     --hover-bg: #374151;
+    --primary-color: #38bdf8;
   }
 
   /* Windows 暗色模式下根据 data-material 属性应用不同材质样式 */
   .os-windows[data-material='mica'] {
     --titlebar-bg: transparent;
     --input-bg: rgba(255, 255, 255, 0.06);
-    --input-focus-bg: rgba(56, 189, 248, 0.12);
+    --input-focus-bg: rgba(255, 255, 255, 0.1);
     --hover-bg: rgba(255, 255, 255, 0.05);
     --win-button-hover: rgba(255, 255, 255, 0.08);
   }
@@ -64,7 +66,7 @@
   .os-windows[data-material='acrylic'] {
     --titlebar-bg: transparent;
     --input-bg: rgba(255, 255, 255, 0.04);
-    --input-focus-bg: rgba(56, 189, 248, 0.12);
+    --input-focus-bg: rgba(255, 255, 255, 0.1);
     --hover-bg: rgba(255, 255, 255, 0.05);
     --win-button-hover: rgba(255, 255, 255, 0.06);
   }


### PR DESCRIPTION
将暗色 Mica/Acrylic 模式下 --input-focus-bg 从硬编码蓝色 rgba(56,189,248,0.12) 改为中性的 rgba(255,255,255,0.1)，补充 --primary-color 默认值定义