### PR TITLE
- fix: 修复 mac 应用本地化名称搜索与显示问题

### DIFF
--- a/src/main/api/renderer/commands.ts
+++ b/src/main/api/renderer/commands.ts
@@ -30,7 +30,7 @@ interface LastMatchState {
  * 应用管理API - 主程序专用
  */
 export class AppsAPI {
-  private static readonly APP_CACHE_VERSION = 3
+  private static readonly APP_CACHE_VERSION = 4
   private static readonly APP_CACHE_VERSION_KEY = 'cached-commands-version'
   private mainWindow: Electron.BrowserWindow | null = null
   private pluginManager: PluginManager | null = null

--- a/src/main/core/commandScanner/macScanner.ts
+++ b/src/main/core/commandScanner/macScanner.ts
@@ -12,6 +12,33 @@ interface LocalizedAppMetadata {
   aliases?: string[]
 }
 
+function flattenLocalizedNames(items: LocalizedAppMetadata[]): string[] {
+  return uniqueNonEmpty(items.flatMap((item) => [item.name, ...(item.aliases || [])]))
+}
+
+export function buildAppDisplayInfo(
+  bundleNames: string[],
+  localizedMetadata: LocalizedAppMetadata | null,
+  allLocalizedMetadata: LocalizedAppMetadata[] = []
+): LocalizedAppMetadata {
+  const localizedNames = flattenLocalizedNames(allLocalizedMetadata)
+
+  if (localizedMetadata?.name) {
+    return {
+      name: localizedMetadata.name,
+      aliases: uniqueNonEmpty([...bundleNames, ...localizedNames]).filter(
+        (alias) => alias !== localizedMetadata.name
+      )
+    }
+  }
+
+  const [name, ...aliases] = uniqueNonEmpty([...bundleNames, ...localizedNames])
+  return {
+    name,
+    aliases
+  }
+}
+
 function uniqueNonEmpty(values: Array<string | undefined | null>): string[] {
   return [...new Set(values.map((value) => value?.trim()).filter(Boolean) as string[])]
 }
@@ -289,6 +316,77 @@ async function getLocalizedMetadata(appPath: string): Promise<LocalizedAppMetada
   )
 }
 
+async function getAllLocalizedMetadataFromLproj(appPath: string): Promise<LocalizedAppMetadata[]> {
+  const resourcesPath = path.join(appPath, 'Contents', 'Resources')
+
+  try {
+    const entries = await fs.readdir(resourcesPath, { withFileTypes: true })
+    const lprojDirs = entries.filter(
+      (entry) => entry.isDirectory() && entry.name.endsWith('.lproj')
+    )
+
+    const results: LocalizedAppMetadata[] = []
+    for (const dir of lprojDirs) {
+      const stringsPath = path.join(resourcesPath, dir.name, 'InfoPlist.strings')
+      if (!fsSync.existsSync(stringsPath)) continue
+
+      const data = await readStringsFile(stringsPath)
+      const name = data?.CFBundleDisplayName || data?.CFBundleName
+      if (!name) continue
+
+      results.push({
+        name,
+        aliases: extractLocalizedAliases(data, name)
+      })
+    }
+
+    return results
+  } catch {
+    return []
+  }
+}
+
+async function getAllLocalizedMetadataFromLoctable(
+  appPath: string
+): Promise<LocalizedAppMetadata[]> {
+  const loctablePath = path.join(appPath, 'Contents', 'Resources', 'InfoPlist.loctable')
+  if (!fsSync.existsSync(loctablePath)) return []
+
+  try {
+    const data: any = await new Promise((resolve, reject) => {
+      plist.readFile(loctablePath, (err: any, result: any) => {
+        if (err) reject(err)
+        else resolve(result)
+      })
+    })
+
+    if (!data || typeof data !== 'object') {
+      return []
+    }
+
+    return Object.values(data)
+      .map((entry: any) => {
+        const name = entry?.CFBundleDisplayName || entry?.CFBundleName
+        if (!name) return null
+
+        return {
+          name,
+          aliases: extractLocalizedAliases(entry, name)
+        }
+      })
+      .filter(Boolean) as LocalizedAppMetadata[]
+  } catch {
+    return []
+  }
+}
+
+async function getAllLocalizedMetadata(appPath: string): Promise<LocalizedAppMetadata[]> {
+  return [
+    ...(await getAllLocalizedMetadataFromLproj(appPath)),
+    ...(await getAllLocalizedMetadataFromLoctable(appPath))
+  ]
+}
+
 async function getBundleNames(appPath: string): Promise<string[]> {
   const fileName = path.basename(appPath, '.app')
 
@@ -310,21 +408,13 @@ async function getBundleNames(appPath: string): Promise<string[]> {
 // 获取应用显示名称（优先本地化名称，无需子进程）
 async function getAppDisplayInfo(appPath: string): Promise<LocalizedAppMetadata> {
   const bundleNames = await getBundleNames(appPath)
+  const allLocalizedMetadata = await getAllLocalizedMetadata(appPath)
 
   // 1. 尝试从 .lproj 获取本地化名称（如 "时钟"、"访达"）
   const localizedMetadata = await getLocalizedMetadata(appPath)
-  if (localizedMetadata?.name) {
-    return {
-      name: localizedMetadata.name,
-      aliases: uniqueNonEmpty([...bundleNames, ...(localizedMetadata.aliases || [])]).filter(
-        (alias) => alias !== localizedMetadata.name
-      )
-    }
-  }
 
-  // 2. 兜底：使用 bundle 原名 / 文件名
-  const [name, ...aliases] = bundleNames
-  return { name, aliases }
+  // 2. 显示名优先使用当前系统语言，本地化的其他语言名称全部作为别名参与搜索
+  return buildAppDisplayInfo(bundleNames, localizedMetadata, allLocalizedMetadata)
 }
 
 // 获取应用图标文件路径

--- a/src/renderer/src/components/common/CommandList.vue
+++ b/src/renderer/src/components/common/CommandList.vue
@@ -31,7 +31,7 @@
           />
           <!-- 占位图标（无图标或加载失败时显示） -->
           <div v-else class="app-icon-placeholder">
-            {{ app.name.charAt(0).toUpperCase() }}
+            {{ getDisplayName(app).charAt(0).toUpperCase() }}
           </div>
           <!-- eslint-disable-next-line vue/no-v-html -->
           <span class="app-name" v-html="getHighlightedName(app)"></span>
@@ -61,7 +61,7 @@
         />
         <!-- 占位图标（无图标或加载失败时显示） -->
         <div v-else class="app-icon-placeholder">
-          {{ app.name.charAt(0).toUpperCase() }}
+          {{ getDisplayName(app).charAt(0).toUpperCase() }}
         </div>
         <!-- eslint-disable-next-line vue/no-v-html -->
         <span class="app-name" v-html="getHighlightedName(app)"></span>
@@ -165,7 +165,11 @@ watch(
 )
 
 function getHighlightedName(app: Command): string {
-  return highlightMatch(app.name, app.matches, app.matchType, props.searchQuery)
+  return highlightMatch(getDisplayName(app), app.matches, app.matchType, props.searchQuery)
+}
+
+function getDisplayName(app: Command): string {
+  return app.displayName || app.name
 }
 
 // 获取 title 文本（悬浮提示）
@@ -177,6 +181,10 @@ function getTitleText(app: Command): string {
   }
 
   // 其他类型：显示名称
+  if (app.displayName && app.displayName !== app.name) {
+    return `${app.displayName}\n${app.name}`
+  }
+
   return app.name
 }
 

--- a/src/renderer/src/components/common/VerticalList.vue
+++ b/src/renderer/src/components/common/VerticalList.vue
@@ -44,7 +44,7 @@ defineEmits<{
 }>()
 
 function getHighlightedName(app: Command): string {
-  return highlightMatch(app.name, app.matches, app.matchType, props.searchQuery)
+  return highlightMatch(app.displayName || app.name, app.matches, app.matchType, props.searchQuery)
 }
 </script>
 

--- a/src/renderer/src/stores/commandDataStore.ts
+++ b/src/renderer/src/stores/commandDataStore.ts
@@ -7,7 +7,8 @@ import settingsFillIcon from '../assets/image/settings-fill.png'
 import {
   getCommandId as _getCommandId,
   applySpecialConfig as _applySpecialConfig,
-  calculateMatchScore as _calculateMatchScore
+  calculateMatchScore as _calculateMatchScore,
+  getMatchedDisplayName as _getMatchedDisplayName
 } from './commandUtils'
 
 // 正则匹配指令
@@ -88,7 +89,8 @@ export interface Command {
   cmdType?: 'text' | 'regex' | 'over' | 'img' | 'files' // cmd类型
   mainPush?: boolean // 是否为 mainPush 功能（搜索时动态查询插件获取结果）
   matches?: MatchInfo[] // 搜索匹配信息（用于高亮显示）
-  matchType?: 'acronym' | 'name' | 'pinyin' | 'pinyinAbbr' // 匹配类型（用于高亮算法选择）
+  matchType?: 'acronym' | 'name' | 'aliases' | 'pinyin' | 'pinyinAbbr' // 匹配类型（用于高亮算法选择）
+  displayName?: string // 搜索结果展示名称（命中 aliases 时优先显示别名）
   // 系统设置字段（新增）
   settingUri?: string // ms-settings URI
   category?: string // 分类（用于分组显示）
@@ -697,13 +699,15 @@ export const useCommandDataStore = defineStore('commandData', () => {
       bestMatches = fuseResults
         .map((r) => {
           // 检测匹配类型（用于前端高亮算法选择）
-          let matchType: 'acronym' | 'name' | 'pinyin' | 'pinyinAbbr' | undefined
+          let matchType: 'acronym' | 'name' | 'aliases' | 'pinyin' | 'pinyinAbbr' | undefined
           if (r.matches && r.matches.length > 0) {
-            // 优先级：acronym > name > pinyin > pinyinAbbr
+            // 优先级：acronym > name > aliases > pinyin > pinyinAbbr
             if (r.matches.some((m) => m.key === 'acronym')) {
               matchType = 'acronym'
             } else if (r.matches.some((m) => m.key === 'name')) {
               matchType = 'name'
+            } else if (r.matches.some((m) => m.key === 'aliases')) {
+              matchType = 'aliases'
             } else if (r.matches.some((m) => m.key === 'pinyin')) {
               matchType = 'pinyin'
             } else if (r.matches.some((m) => m.key === 'pinyinAbbr')) {
@@ -715,13 +719,14 @@ export const useCommandDataStore = defineStore('commandData', () => {
             ...r.item,
             matches: r.matches as MatchInfo[],
             matchType,
+            displayName: _getMatchedDisplayName(r.item, r.matches as MatchInfo[]),
             _score: r.score || 0
           }
         })
         .sort((a, b) => {
           // 自定义排序：优先连续匹配
-          const scoreA = calculateMatchScore(a.name, query, a.matches)
-          const scoreB = calculateMatchScore(b.name, query, b.matches)
+          const scoreA = calculateMatchScore(a.displayName || a.name, query, a.matches)
+          const scoreB = calculateMatchScore(b.displayName || b.name, query, b.matches)
           return scoreB - scoreA // 分数高的排前面
         })
 

--- a/src/renderer/src/stores/commandUtils.ts
+++ b/src/renderer/src/stores/commandUtils.ts
@@ -101,3 +101,18 @@ export function calculateMatchScore(text: string, query: string, matches?: Match
 
   return score
 }
+
+/**
+ * 获取搜索结果的展示名称
+ * 命中 aliases 时，优先展示命中的别名，达到“多 cmd”近似体验
+ */
+export function getMatchedDisplayName<T extends { name: string }>(
+  command: T,
+  matches?: MatchInfo[]
+): string {
+  const aliasMatch = matches?.find(
+    (match) => match.key === 'aliases' && typeof match.value === 'string' && match.value.trim()
+  )
+
+  return aliasMatch?.value || command.name
+}

--- a/src/renderer/src/utils/highlight.ts
+++ b/src/renderer/src/utils/highlight.ts
@@ -17,7 +17,7 @@ interface MatchInfo {
 export function highlightMatch(
   text: string,
   matches?: MatchInfo[],
-  matchType?: 'acronym' | 'name' | 'pinyin' | 'pinyinAbbr',
+  matchType?: 'acronym' | 'name' | 'aliases' | 'pinyin' | 'pinyinAbbr',
   query?: string
 ): string {
   if (!matches || matches.length === 0) {
@@ -48,8 +48,8 @@ export function highlightMatch(
   const highlightIndices = new Set<number>()
 
   matches.forEach((match) => {
-    if (match.key === 'name') {
-      // 直接使用 name 的索引
+    if (match.key === 'name' || match.key === 'aliases') {
+      // 直接使用 name / aliases 的索引
       match.indices.forEach(([start, end]) => {
         for (let i = start; i <= end; i++) {
           highlightIndices.add(i)


### PR DESCRIPTION
背景

在 macOS 下，部分应用进入索引时只保留了英文名称，未充分纳入 bundle 内的本地化名称，导致用户使用本地语言搜索时无法命中。

例如，微信开发者工具 实际可能仅以 WeChat DevTools 的形式被索引，因此搜索 微信、开发者 等关键词时无法找到对应应用。

此外，现有搜索结果在命中别名时，列表中仍可能继续展示英文主名称，导致“已匹配但显示不直观”的问题，影响搜索体验。

⸻

改动内容

本次改动主要包含两部分。

1. 补全 mac 应用的本地化名称索引
	•	扫描 mac 应用 bundle 中的多语言名称信息
	•	保留当前系统语言对应的名称作为主显示名
	•	将其他语言的本地化名称统一写入 aliases，参与搜索匹配

2. 优化搜索命中后的结果展示
	•	当搜索命中的是 aliases 时，结果标题优先展示实际命中的名称
	•	避免“输入中文命中应用，但结果仍显示英文主名称”的情况
	•	保持同一应用仅展示一条结果，不引入重复项

⸻

效果说明

修复前
	•	搜索 微信 / 开发者 时，可能无法命中 微信开发者工具
	•	即使通过别名命中，结果列表中仍可能显示为 WeChat DevTools

修复后
	•	搜索 微信 / 开发者 时，可以正确命中目标应用
	•	当命中中文别名时，结果会优先展示 微信开发者工具
	•	搜索英文名称时，仍保持原有行为，不影响英文搜索体验

⸻

设计说明

本次没有将同一个应用拆分为多条可见搜索结果，而是采用“命中哪个名称，就展示哪个名称”的方式进行优化。

这样处理有几个好处：
	•	搜索体验更符合用户直觉
	•	不会引入重复结果
	•	不影响现有固定项、历史记录和去重逻辑
	•	改动范围相对可控，兼容性更好

⸻

涉及文件
	•	src/main/core/commandScanner/macScanner.ts
	•	src/main/api/renderer/commands.ts
	•	src/renderer/src/stores/commandDataStore.ts
	•	src/renderer/src/stores/commandUtils.ts
	•	src/renderer/src/utils/highlight.ts
	•	src/renderer/src/components/common/CommandList.vue
	•	src/renderer/src/components/common/VerticalList.vue
	•	tests/main/macScanner.test.ts
	•	tests/renderer/commandUtils.test.ts

⸻

兼容性说明
	•	已提升应用缓存版本，旧缓存会自动失效并重建
	•	不影响英文搜索场景
	•	不改变原有应用启动逻辑
	•	不会引入同一应用的重复搜索结果

⸻

验证方式

已执行以下验证：
	•	pnpm vitest run tests/renderer/commandUtils.test.ts tests/main/macScanner.test.ts
	•	pnpm typecheck:web
	•	pnpm typecheck:node

⸻

总结

本次改动主要解决以下问题：
	•	mac 应用多语言名称索引不完整
	•	本地化名称搜索无法命中
	•	命中别名后结果展示不直观

在不改变现有搜索结果结构的前提下，提升了 macOS 下本地化应用搜索的可用性和展示体验。