### PR TITLE
feat: 超级面板底部工具栏支持快速屏蔽应用弹出

### DIFF
--- a/internal-plugins/setting/src/env.d.ts
+++ b/internal-plugins/setting/src/env.d.ts
@@ -355,6 +355,16 @@ declare global {
           mouseButton: string
           longPressMs: number
         }) => Promise<{ success: boolean }>
+        updateSuperPanelBlockedApps: (
+          blockedApps: Array<{ app: string; bundleId?: string; label?: string }>
+        ) => Promise<{ success: boolean }>
+        getCurrentWindowInfo: () => Promise<{
+          app: string
+          bundleId?: string
+          pid?: number
+          title?: string
+          appPath?: string
+        } | null>
         pinToSuperPanel: (command: any) => Promise<{ success: boolean; error?: string }>
         unpinSuperPanelCommand: (
           path: string,

--- a/internal-plugins/setting/src/views/GeneralSetting/GeneralSetting.vue
+++ b/internal-plugins/setting/src/views/GeneralSetting/GeneralSetting.vue
@@ -142,6 +142,7 @@ const floatingBallDoubleClickCommand = ref('')
 const superPanelEnabled = ref(false)
 const superPanelMouseButton = ref<MouseButtonType>('middle')
 const superPanelLongPressMs = ref(500)
+const superPanelBlockedApps = ref<Array<{ app: string; bundleId?: string; label?: string }>>([])
 
 // 超级面板触发模式（计算属性）
 const superPanelTriggerMode = computed({
@@ -647,6 +648,63 @@ async function handleSuperPanelLongPressMsChange(): Promise<void> {
   }
 }
 
+// 添加屏蔽应用（获取当前窗口）
+async function handleAddBlockedApp(): Promise<void> {
+  try {
+    console.log('[Setting] handleAddBlockedApp 开始')
+    const windowInfo = await window.ztools.internal.getCurrentWindowInfo()
+    console.log('[Setting] getCurrentWindowInfo 返回:', JSON.stringify(windowInfo))
+    if (!windowInfo) {
+      error('无法获取当前窗口信息')
+      return
+    }
+
+    // 去重检查
+    const exists = superPanelBlockedApps.value.some(
+      (item) => item.app.toLowerCase() === windowInfo.app.toLowerCase()
+    )
+    if (exists) {
+      info('该应用已在屏蔽列表中')
+      return
+    }
+
+    // 生成显示名称：去掉 .exe / .app 后缀
+    const label = windowInfo.app.replace(/\.(exe|app)$/i, '')
+
+    superPanelBlockedApps.value.push({
+      app: windowInfo.app,
+      bundleId: windowInfo.bundleId,
+      label
+    })
+
+    console.log(
+      '[Setting] saveSettings 前, blockedApps:',
+      JSON.stringify(superPanelBlockedApps.value)
+    )
+    await saveSettings()
+    console.log('[Setting] saveSettings 完成, 开始调用 updateSuperPanelBlockedApps')
+    await window.ztools.internal.updateSuperPanelBlockedApps(
+      superPanelBlockedApps.value.map((item) => ({ ...item }))
+    )
+    console.log('[Setting] updateSuperPanelBlockedApps 完成')
+  } catch (err) {
+    console.error('添加屏蔽应用失败:', err)
+  }
+}
+
+// 移除屏蔽应用
+async function handleRemoveBlockedApp(index: number): Promise<void> {
+  try {
+    superPanelBlockedApps.value.splice(index, 1)
+    await saveSettings()
+    await window.ztools.internal.updateSuperPanelBlockedApps(
+      superPanelBlockedApps.value.map((item) => ({ ...item }))
+    )
+  } catch (err) {
+    console.error('移除屏蔽应用失败:', err)
+  }
+}
+
 // 处理主题色变化
 async function handlePrimaryColorChange(color: string): Promise<void> {
   try {
@@ -937,6 +995,7 @@ async function loadSettings(): Promise<void> {
       superPanelEnabled.value = data.superPanelEnabled ?? false
       superPanelMouseButton.value = data.superPanelMouseButton ?? 'middle'
       superPanelLongPressMs.value = data.superPanelLongPressMs ?? 500
+      superPanelBlockedApps.value = data.superPanelBlockedApps ?? []
       // 窗口材质由主进程启动时保证一定有值，无需兜底
       windowMaterial.value = data.windowMaterial
       acrylicLightOpacity.value = data.acrylicLightOpacity ?? 78
@@ -1007,6 +1066,7 @@ async function saveSettings(): Promise<void> {
       superPanelEnabled: superPanelEnabled.value,
       superPanelMouseButton: superPanelMouseButton.value,
       superPanelLongPressMs: superPanelLongPressMs.value,
+      superPanelBlockedApps: superPanelBlockedApps.value.map((item) => ({ ...item })),
       theme: theme.value,
       primaryColor: primaryColor.value,
       customColor: customColor.value,
@@ -1608,6 +1668,35 @@ onMounted(() => {
           />
         </div>
       </div>
+
+      <div v-if="superPanelEnabled" class="setting-item blocked-apps-setting">
+        <div class="blocked-apps-content">
+          <div class="blocked-apps-header">
+            <div class="setting-label">
+              <span>屏蔽弹出</span>
+              <span class="setting-desc">在指定应用窗口中不触发超级面板</span>
+            </div>
+            <div class="setting-control">
+              <button class="btn btn-sm" @click="handleAddBlockedApp">添加当前窗口</button>
+            </div>
+          </div>
+          <div
+            v-if="superPanelEnabled && superPanelBlockedApps.length > 0"
+            class="blocked-apps-tags"
+          >
+            <span
+              v-for="(app, index) in superPanelBlockedApps"
+              :key="app.app"
+              class="blocked-app-tag"
+            >
+              {{ app.label || app.app }}
+              <button class="blocked-app-remove" @click="handleRemoveBlockedApp(index)">
+                &times;
+              </button>
+            </span>
+          </div>
+        </div>
+      </div>
     </div>
 
     <!-- ==================== 悬浮球 ==================== -->
@@ -1877,6 +1966,7 @@ onMounted(() => {
 .combined-control {
   gap: 16px;
 }
+
 .color-control {
   display: flex;
   gap: 12px;
@@ -1975,5 +2065,69 @@ onMounted(() => {
   background: var(--primary-light-bg);
   border-color: var(--primary-color);
   font-weight: 500;
+}
+
+.blocked-apps-content {
+  width: 100%;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.blocked-apps-header {
+  display: flex;
+  justify-content: space-between;
+}
+
+.blocked-apps-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  padding: 12px 16px;
+  background-color: var(--control-bg);
+  border-radius: 4px;
+  border: 2px solid var(--control-border);
+}
+
+.blocked-app-tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 8px;
+  font-size: 12px;
+  background: var(--control-bg);
+  border: 1px solid var(--control-border);
+  border-radius: 6px;
+  color: var(--text-color);
+  transition: border-color 0.2s;
+}
+
+.blocked-app-tag:hover {
+  border-color: var(--danger-color);
+}
+
+.blocked-app-remove {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  padding: 0;
+  border: none;
+  background: none;
+  color: var(--text-secondary);
+  font-size: 14px;
+  line-height: 1;
+  cursor: pointer;
+  border-radius: 50%;
+  transition:
+    color 0.2s,
+    background 0.2s;
+}
+
+.blocked-app-remove:hover {
+  color: var(--danger-color);
+  background: var(--danger-light-bg);
 }
 </style>

--- a/resources/preload.js
+++ b/resources/preload.js
@@ -805,6 +805,10 @@ window.ztools = {
     // ==================== 超级面板 API ====================
     updateSuperPanelConfig: async (config) =>
       await electron.ipcRenderer.invoke('internal:update-super-panel-config', config),
+    updateSuperPanelBlockedApps: async (blockedApps) =>
+      await electron.ipcRenderer.invoke('internal:update-super-panel-blocked-apps', blockedApps),
+    getCurrentWindowInfo: async () =>
+      await electron.ipcRenderer.invoke('internal:get-current-window-info'),
     pinToSuperPanel: async (command) =>
       await electron.ipcRenderer.invoke('super-panel:pin-command', command),
     unpinSuperPanelCommand: async (path, featureCode) =>

--- a/src/main/api/plugin/internal.ts
+++ b/src/main/api/plugin/internal.ts
@@ -2,6 +2,7 @@ import { app, IpcMainInvokeEvent, ipcMain } from 'electron'
 import type { PluginManager } from '../../managers/pluginManager'
 import windowManager from '../../managers/windowManager.js'
 import logCollector from '../../core/logCollector.js'
+import clipboardManager from '../../managers/clipboardManager.js'
 import detachedWindowManager from '../../core/detachedWindowManager.js'
 import floatingBallManager from '../../core/floatingBallManager.js'
 import httpServer from '../../core/httpServer.js'
@@ -708,6 +709,24 @@ export class InternalPluginAPI {
         return { success: true }
       }
     )
+
+    ipcMain.handle(
+      'internal:update-super-panel-blocked-apps',
+      async (event, blockedApps: Array<{ app: string; bundleId?: string; label?: string }>) => {
+        if (!requireInternalPlugin(this.pluginManager, event)) {
+          throw new PermissionDeniedError('internal:update-super-panel-blocked-apps')
+        }
+        superPanelManager.updateBlockedApps(blockedApps)
+        return { success: true }
+      }
+    )
+
+    ipcMain.handle('internal:get-current-window-info', async (event) => {
+      if (!requireInternalPlugin(this.pluginManager, event)) {
+        throw new PermissionDeniedError('internal:get-current-window-info')
+      }
+      return clipboardManager.getCurrentWindow()
+    })
 
     // ==================== 图片分析 API ====================
     // 直接转发到共享的 analyze-image handler（已在 imageAnalysis.ts 中注册）

--- a/src/main/core/native/index.ts
+++ b/src/main/core/native/index.ts
@@ -36,7 +36,7 @@ interface NativeAddon {
   startMouseMonitor: (
     buttonType: MouseButtonType,
     longPressMs: number,
-    callback: () => void
+    callback: () => void | { shouldBlock?: boolean }
   ) => void
   stopMouseMonitor: () => void
   getUwpApps: () => UwpAppInfo[]
@@ -375,8 +375,10 @@ export class WindowManager {
 /**
  * 鼠标监控类
  */
+export type MouseMonitorResult = { shouldBlock?: boolean } | void
+
 export class MouseMonitor {
-  private static _callback: (() => void) | null = null
+  private static _callback: (() => MouseMonitorResult) | null = null
   private static _isMonitoring = false
 
   /**
@@ -387,9 +389,14 @@ export class MouseMonitor {
    *   - >0: 监听长按（按住达到该时长后触发）
    *   - 注意：'right' 只支持长按（longPressMs 必须 > 0）
    * @param callback - 鼠标事件回调函数
-   * - 参数: 无
+   * - 返回值: 无返回值或 { shouldBlock?: boolean }
+   *   - shouldBlock: true 时 C++ 侧拦截原始鼠标事件，不传递给目标窗口
    */
-  static start(buttonType: MouseButtonType, longPressMs: number, callback: () => void): void {
+  static start(
+    buttonType: MouseButtonType,
+    longPressMs: number,
+    callback: () => MouseMonitorResult
+  ): void {
     if (MouseMonitor._isMonitoring) {
       throw new Error('Mouse monitor is already running')
     }
@@ -415,7 +422,7 @@ export class MouseMonitor {
     MouseMonitor._isMonitoring = true
     ;(addon as NativeAddon).startMouseMonitor(buttonType, longPressMs, () => {
       if (MouseMonitor._callback) {
-        MouseMonitor._callback()
+        return MouseMonitor._callback()
       }
     })
   }

--- a/src/main/core/superPanelManager.ts
+++ b/src/main/core/superPanelManager.ts
@@ -4,7 +4,12 @@ import os from 'os'
 import path from 'path'
 import plist from 'simple-plist'
 import { is } from '@electron-toolkit/utils'
-import { ClipboardMonitor, MouseMonitor, WindowManager } from './native/index.js'
+import {
+  ClipboardMonitor,
+  MouseMonitor,
+  WindowManager,
+  type MouseMonitorResult
+} from './native/index.js'
 import { launchApp } from './commandLauncher/index.js'
 import databaseAPI from '../api/shared/database.js'
 import windowManager from '../managers/windowManager.js'
@@ -26,10 +31,17 @@ interface ClipboardContent {
   files?: Array<{ path: string; name: string; isDirectory: boolean }>
 }
 
+interface BlockedApp {
+  app: string
+  bundleId?: string
+  label?: string
+}
+
 interface SuperPanelConfig {
   enabled: boolean
   mouseButton: 'middle' | 'right' | 'back' | 'forward'
   longPressMs: number
+  blockedApps: BlockedApp[]
 }
 
 /**
@@ -44,7 +56,8 @@ class SuperPanelManager {
   private config: SuperPanelConfig = {
     enabled: false,
     mouseButton: 'middle',
-    longPressMs: 500
+    longPressMs: 500,
+    blockedApps: []
   }
 
   /**
@@ -66,7 +79,8 @@ class SuperPanelManager {
         this.config = {
           enabled: data.superPanelEnabled ?? false,
           mouseButton: data.superPanelMouseButton ?? 'middle',
-          longPressMs: data.superPanelLongPressMs ?? 500
+          longPressMs: data.superPanelLongPressMs ?? 500,
+          blockedApps: data.superPanelBlockedApps ?? []
         }
         if (this.config.enabled) {
           this.startMonitor()
@@ -85,7 +99,8 @@ class SuperPanelManager {
     this.config = {
       enabled: config.enabled,
       mouseButton: config.mouseButton as SuperPanelConfig['mouseButton'],
-      longPressMs: config.longPressMs
+      longPressMs: config.longPressMs,
+      blockedApps: this.config.blockedApps
     }
 
     if (this.config.enabled) {
@@ -99,6 +114,40 @@ class SuperPanelManager {
   }
 
   /**
+   * 单独更新屏蔽列表
+   */
+  updateBlockedApps(blockedApps: BlockedApp[]): void {
+    this.config.blockedApps = blockedApps
+    console.log('[SuperPanel] 超级面板屏蔽列表已更新:', blockedApps.length, '项')
+  }
+
+  /**
+   * 判断当前窗口是否被屏蔽
+   */
+  private isWindowBlocked(windowInfo: { app: string; bundleId?: string }): boolean {
+    if (!this.config.blockedApps || this.config.blockedApps.length === 0) {
+      return false
+    }
+
+    const appName = windowInfo.app.toLowerCase()
+
+    for (const blocked of this.config.blockedApps) {
+      // macOS 优先匹配 bundleId
+      if (blocked.bundleId && windowInfo.bundleId) {
+        if (blocked.bundleId.toLowerCase() === windowInfo.bundleId.toLowerCase()) {
+          return true
+        }
+      }
+      // 进程名大小写不敏感匹配
+      if (blocked.app.toLowerCase() === appName) {
+        return true
+      }
+    }
+
+    return false
+  }
+
+  /**
    * 启动鼠标监听
    */
   private startMonitor(): void {
@@ -109,7 +158,7 @@ class SuperPanelManager {
 
     try {
       MouseMonitor.start(this.config.mouseButton, this.config.longPressMs, () => {
-        this.onMouseTrigger()
+        return this.onMouseTrigger()
       })
       console.log(
         `[SuperPanel] 超级面板鼠标监听已启动: ${this.config.mouseButton}, ${this.config.longPressMs}ms`
@@ -212,15 +261,37 @@ class SuperPanelManager {
   /**
    * 鼠标触发回调
    */
-  private async onMouseTrigger(): Promise<void> {
+  private onMouseTrigger(): MouseMonitorResult {
     try {
       // 1. 记录鼠标位置
       const cursorPoint = screen.getCursorScreenPoint()
 
       // 1.5. 记录触发前的窗口信息
-      const windowInfo = clipboardManager.getCurrentWindow()
+      // 优先使用 getActiveWindow() 实时获取前台窗口（更准确），回退到缓存的窗口信息
+      const cachedWindow = clipboardManager.getCurrentWindow()
+      const activeWindow = WindowManager.getActiveWindow()
+      const windowInfo = activeWindow ? { ...cachedWindow, ...activeWindow } : cachedWindow
       this.currentWindowInfo = windowInfo ?? null
 
+      // 1.6. 检查当前窗口是否被屏蔽
+      const windowToCheck = activeWindow || cachedWindow
+      if (windowToCheck && this.isWindowBlocked(windowToCheck)) {
+        console.log('[SuperPanel] 当前窗口被屏蔽，跳过触发:', windowToCheck.app)
+        return { shouldBlock: false }
+      }
+
+      // 异步部分：模拟复制、读取剪贴板、显示面板
+      this.onMouseTriggerAsync(cursorPoint)
+
+      return { shouldBlock: true }
+    } catch (error) {
+      console.error('[SuperPanel] 超级面板触发失败:', error)
+      return { shouldBlock: false }
+    }
+  }
+
+  private async onMouseTriggerAsync(cursorPoint: { x: number; y: number }): Promise<void> {
+    try {
       // 2. 记录当前剪贴板内容快照（用于对比是否有新内容）
       const oldContent = this.readClipboardContent()
       const oldClipboardText = clipboard.readText()
@@ -719,6 +790,56 @@ class SuperPanelManager {
         return flattened
       } catch {
         return []
+      }
+    })
+
+    // 超级面板添加当前窗口到屏蔽列表
+    ipcMain.handle('super-panel:add-blocked-app', async () => {
+      try {
+        if (!this.currentWindowInfo?.app) {
+          return { success: false, error: '无法获取当前窗口信息' }
+        }
+
+        const appName = this.currentWindowInfo.app
+
+        // 去重检查（app 名称忽略大小写）
+        const alreadyBlocked = this.config.blockedApps.some(
+          (b) => b.app.toLowerCase() === appName.toLowerCase()
+        )
+        if (alreadyBlocked) {
+          this.hideWindow()
+          return { success: true, app: appName.replace(/\.(exe|app)$/i, '') }
+        }
+
+        // 生成 label（去掉 .exe / .app 后缀）
+        const label = appName.replace(/\.(exe|app)$/i, '')
+
+        // 构造 BlockedApp 对象
+        const blockedApp: BlockedApp = {
+          app: appName,
+          bundleId: this.currentWindowInfo.bundleId,
+          label
+        }
+
+        // 添加到内存中的屏蔽列表
+        this.config.blockedApps.push(blockedApp)
+
+        // 持久化到数据库
+        const data = databaseAPI.dbGet('settings-general') || {}
+        data.superPanelBlockedApps = this.config.blockedApps
+        databaseAPI.dbPut('settings-general', data)
+
+        // 隐藏超级面板窗口
+        this.hideWindow()
+
+        console.log('[SuperPanel] 已将应用添加到屏蔽列表:', label)
+        return { success: true, app: label }
+      } catch (error) {
+        console.error('[SuperPanel] 添加屏蔽应用失败:', error)
+        return {
+          success: false,
+          error: error instanceof Error ? error.message : '未知错误'
+        }
       }
     })
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -369,6 +369,7 @@ const api = {
   ) => {
     ipcRenderer.on('super-panel-launch', (_event, data) => callback(data))
   },
+  superPanelAddBlockedApp: () => ipcRenderer.invoke('super-panel:add-blocked-app'),
   // 超级面板窗口匹配
   superPanelSearchWindowCommands: (windowInfo: { app?: string; title?: string }) =>
     ipcRenderer.invoke('super-panel:search-window-commands', windowInfo),

--- a/src/renderer/src/components/SuperPanel.vue
+++ b/src/renderer/src/components/SuperPanel.vue
@@ -188,6 +188,30 @@
       <span class="loading-text">加载中...</span>
     </div>
 
+    <!-- 底部工具栏 -->
+    <div v-if="mode !== 'loading'" class="panel-footer">
+      <div class="footer-spacer" />
+      <div
+        class="header-menu-btn"
+        :class="{ 'btn-disabled': !currentWindowInfo }"
+        :title="currentWindowInfo ? `屏蔽 ${currentWindowInfo.app} 弹出面板` : '屏蔽面板弹出'"
+        @click="addBlockedApp"
+      >
+        <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
+          <circle cx="8" cy="8" r="6.5" stroke="currentColor" stroke-width="1.3" fill="none" />
+          <line
+            x1="3.4"
+            y1="12.6"
+            x2="12.6"
+            y2="3.4"
+            stroke="currentColor"
+            stroke-width="1.3"
+            stroke-linecap="round"
+          />
+        </svg>
+      </div>
+    </div>
+
     <!-- 文件夹弹窗 - 覆盖式 -->
     <Transition name="slide-up">
       <div v-if="showFolderPopup && currentFolder" class="folder-popup-overlay">
@@ -695,6 +719,12 @@ function showPinned(): void {
 // 点击头像：隐藏超级面板，显示主搜索窗口
 function showMainWindow(): void {
   window.ztools.superPanelShowMainWindow()
+}
+
+// 添加当前窗口到屏蔽列表
+async function addBlockedApp(): Promise<void> {
+  if (!currentWindowInfo.value) return
+  await window.ztools.superPanelAddBlockedApp()
 }
 
 // 打开窗口匹配面板
@@ -1364,6 +1394,24 @@ onUnmounted(() => {
 /* ========== 标题栏间距 ========== */
 .header-spacer {
   flex: 1;
+}
+
+/* ========== 底部工具栏 ========== */
+.panel-footer {
+  display: flex;
+  align-items: center;
+  padding: 6px 16px;
+  border-top: 1px solid var(--divider-color);
+  flex-shrink: 0;
+}
+
+.footer-spacer {
+  flex: 1;
+}
+
+.btn-disabled {
+  opacity: 0.3;
+  pointer-events: none;
 }
 
 /* ========== 窗口匹配底部滑出面板 ========== */

--- a/src/renderer/src/env.d.ts
+++ b/src/renderer/src/env.d.ts
@@ -363,6 +363,7 @@ declare global {
       onSuperPanelLaunch: (
         callback: (data: { command: any; clipboardContent?: any; windowInfo?: any }) => void
       ) => void
+      superPanelAddBlockedApp: () => Promise<{ success: boolean; app?: string; error?: string }>
       // 超级面板窗口匹配
       superPanelSearchWindowCommands: (windowInfo: {
         app?: string


### PR DESCRIPTION
涵盖内容：
- 新增 super-panel:add-blocked-app IPC handler，支持将当前聚焦应用添加到屏蔽列表
- 超级面板底部添加工具栏，右侧禁止图标一键屏蔽