### PR TITLE
feat: 支持通过 WebDAV 同步已安装插件到其他设备

### DIFF
--- a/internal-plugins/setting/src/env.d.ts
+++ b/internal-plugins/setting/src/env.d.ts
@@ -282,6 +282,7 @@ declare global {
             password: string
             syncInterval: number
             lastSyncTime: number
+            syncPlugins?: boolean
           }
           error?: string
         }>
@@ -308,6 +309,7 @@ declare global {
           username: string
           password: string
           syncInterval: number
+          syncPlugins?: boolean
         }) => Promise<{
           success: boolean
           error?: string
@@ -318,6 +320,9 @@ declare global {
             uploaded: number
             downloaded: number
             errors: number
+            pluginsUploaded?: number
+            pluginsDownloaded?: number
+            pluginsDeleted?: number
           }
           error?: string
         }>

--- a/internal-plugins/setting/src/views/SyncSetting/SyncSetting.vue
+++ b/internal-plugins/setting/src/views/SyncSetting/SyncSetting.vue
@@ -14,6 +14,7 @@ const syncIntervalOptions = [
 
 // 同步配置
 const syncEnabled = ref(false)
+const syncPluginsEnabled = ref(false)
 const config = ref({
   serverUrl: '',
   username: '',
@@ -52,6 +53,7 @@ async function loadConfig(): Promise<void> {
     const result = await window.ztools.internal.syncGetConfig()
     if (result.success && result.config) {
       syncEnabled.value = result.config.enabled
+      syncPluginsEnabled.value = result.config.syncPlugins || false
       config.value = {
         serverUrl: result.config.serverUrl || '',
         username: result.config.username || '',
@@ -96,7 +98,8 @@ async function handleSyncToggle(): Promise<void> {
       serverUrl: config.value.serverUrl,
       username: config.value.username,
       password: config.value.password,
-      syncInterval: config.value.syncInterval
+      syncInterval: config.value.syncInterval,
+      syncPlugins: syncPluginsEnabled.value
     })
 
     if (!result.success) {
@@ -109,6 +112,29 @@ async function handleSyncToggle(): Promise<void> {
     error(`操作失败：${err.message}`)
     // 回滚开关状态
     syncEnabled.value = !syncEnabled.value
+  }
+}
+
+// 同步插件开关切换
+async function handleSyncPluginsToggle(): Promise<void> {
+  try {
+    const result = await window.ztools.internal.syncSaveConfig({
+      enabled: syncEnabled.value,
+      serverUrl: config.value.serverUrl,
+      username: config.value.username,
+      password: config.value.password,
+      syncInterval: config.value.syncInterval,
+      syncPlugins: syncPluginsEnabled.value
+    })
+
+    if (!result.success) {
+      error(`保存状态失败：${result.error}`)
+      syncPluginsEnabled.value = !syncPluginsEnabled.value
+    }
+  } catch (err: any) {
+    console.error('切换插件同步状态失败:', err)
+    error(`操作失败：${err.message}`)
+    syncPluginsEnabled.value = !syncPluginsEnabled.value
   }
 }
 
@@ -153,7 +179,8 @@ async function saveConfig(): Promise<void> {
       serverUrl: config.value.serverUrl,
       username: config.value.username,
       password: config.value.password,
-      syncInterval: config.value.syncInterval
+      syncInterval: config.value.syncInterval,
+      syncPlugins: syncPluginsEnabled.value
     })
 
     if (result.success) {
@@ -182,10 +209,16 @@ async function syncNow(): Promise<void> {
       lastSyncResult.value = result.result
       config.value.lastSyncTime = Date.now()
       loadUnsyncedCount()
-      success(
-        `同步完成！上传 ${result.result.uploaded} 项，下载 ${result.result.downloaded} 项，错误 ${result.result.errors} 项`,
-        4000
-      )
+
+      let msg = `同步完成！上传 ${result.result.uploaded} 项，下载 ${result.result.downloaded} 项，错误 ${result.result.errors} 项`
+      if (
+        result.result.pluginsUploaded ||
+        result.result.pluginsDownloaded ||
+        result.result.pluginsDeleted
+      ) {
+        msg += `\n插件：上传 ${result.result.pluginsUploaded || 0}，下载 ${result.result.pluginsDownloaded || 0}，删除 ${result.result.pluginsDeleted || 0}`
+      }
+      success(msg, 4000)
     } else {
       error(`同步失败：${result.error}`)
     }
@@ -283,6 +316,18 @@ onMounted(() => {
         <Dropdown v-model="config.syncInterval" :options="syncIntervalOptions" />
       </div>
 
+      <!-- 同步插件开关 -->
+      <div class="setting-item sync-plugins-toggle">
+        <div class="setting-label">
+          <span>同步插件</span>
+          <span class="setting-desc">开启后将自动同步已安装的插件到其他设备（不包括开发插件）</span>
+        </div>
+        <label class="toggle">
+          <input v-model="syncPluginsEnabled" type="checkbox" @change="handleSyncPluginsToggle" />
+          <span class="toggle-slider"></span>
+        </label>
+      </div>
+
       <!-- 操作按钮 -->
       <div class="action-buttons">
         <button class="btn btn-primary" :disabled="testing" @click="testConnection">
@@ -313,6 +358,18 @@ onMounted(() => {
           <span class="status-label">上次同步:</span>
           <span class="status-value">
             上传 {{ lastSyncResult.uploaded }} / 下载 {{ lastSyncResult.downloaded }}
+            <span
+              v-if="
+                lastSyncResult.pluginsUploaded ||
+                lastSyncResult.pluginsDownloaded ||
+                lastSyncResult.pluginsDeleted
+              "
+            >
+              / 插件 ↑{{ lastSyncResult.pluginsUploaded || 0 }} ↓{{
+                lastSyncResult.pluginsDownloaded || 0
+              }}
+              ✕{{ lastSyncResult.pluginsDeleted || 0 }}
+            </span>
             <span v-if="lastSyncResult.errors > 0" class="error-text">
               / 错误 {{ lastSyncResult.errors }}
             </span>
@@ -327,6 +384,7 @@ onMounted(() => {
           <li>推荐使用坚果云等支持 WebDAV 的云存储服务</li>
           <li>服务器地址必须使用 HTTPS 协议</li>
           <li>同步数据包括：固定列表、通用设置、插件配置</li>
+          <li>开启「同步插件」后，已安装的非开发插件会自动同步到其他设备</li>
           <li>应用使用历史不会同步（每个设备独立）</li>
           <li>
             <strong>强制从云端同步</strong
@@ -392,6 +450,12 @@ onMounted(() => {
   flex-direction: column;
   align-items: flex-start;
   gap: 8px;
+}
+
+.sync-config .setting-item.sync-plugins-toggle {
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
 }
 
 .sync-config .setting-label {

--- a/src/main/api/index.ts
+++ b/src/main/api/index.ts
@@ -71,7 +71,7 @@ class APIManager {
     settingsAPI.init(mainWindow, pluginManager)
     systemAPI.init(mainWindow)
     systemSettingsAPI.init()
-    syncAPI.init()
+    syncAPI.init(mainWindow)
     localShortcutsAPI.init(mainWindow)
     webSearchAPI.init()
 

--- a/src/main/api/renderer/sync.ts
+++ b/src/main/api/renderer/sync.ts
@@ -1,10 +1,11 @@
-import { ipcMain } from 'electron'
+import { BrowserWindow, ipcMain } from 'electron'
 import { SyncEngine } from '../../core/sync/syncEngine'
 import { SyncConfig } from '../../core/sync/types'
 import lmdbInstance from '../../core/lmdb/lmdbInstance'
 import { safeStorage } from 'electron'
 import pluginDeviceAPI from '../plugin/device'
 import { WebDAVSyncClient } from '../../core/sync/webdavClient'
+import pluginSyncWatcher from '../../core/sync/pluginSyncWatcher'
 
 /**
  * 同步 API
@@ -12,8 +13,11 @@ import { WebDAVSyncClient } from '../../core/sync/webdavClient'
 export class SyncAPI {
   private syncEngine: SyncEngine | null = null
 
-  public init(): void {
+  public init(mainWindow?: BrowserWindow): void {
     this.syncEngine = new SyncEngine(lmdbInstance)
+    if (mainWindow) {
+      this.syncEngine.setMainWindow(mainWindow)
+    }
     this.setupIPC()
 
     // 应用启动时初始化同步引擎
@@ -55,6 +59,13 @@ export class SyncAPI {
           await this.syncEngine!.init()
         } else {
           this.syncEngine!.stopAutoSync()
+        }
+
+        // 管理插件同步监听器生命周期
+        if (config.enabled && config.syncPlugins) {
+          pluginSyncWatcher.start()
+        } else {
+          pluginSyncWatcher.stop()
         }
 
         return { success: true }

--- a/src/main/core/sync/pluginHasher.ts
+++ b/src/main/core/sync/pluginHasher.ts
@@ -1,0 +1,95 @@
+import crypto from 'crypto'
+import fs from 'fs'
+import path from 'path'
+import { app } from 'electron'
+import { PluginHashMap } from './types'
+
+const STAGING_DIR = path.join(app.getPath('userData'), 'plugin-sync')
+const HASH_RECORDS_FILE = path.join(STAGING_DIR, 'hash-records.json')
+
+/**
+ * 递归获取目录下所有文件的相对路径（已排序）
+ */
+function getAllFiles(dir: string, baseDir: string): string[] {
+  const results: string[] = []
+  const entries = fs.readdirSync(dir, { withFileTypes: true })
+
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name)
+    if (entry.isDirectory()) {
+      results.push(...getAllFiles(fullPath, baseDir))
+    } else if (entry.isFile()) {
+      results.push(path.relative(baseDir, fullPath).replace(/\\/g, '/'))
+    }
+  }
+
+  return results.sort()
+}
+
+/**
+ * 计算插件目录的确定性哈希
+ * 递归读取所有文件，排序路径后用 SHA-256 生成哈希
+ */
+export function computePluginHash(pluginDir: string): string {
+  const hash = crypto.createHash('sha256')
+  const files = getAllFiles(pluginDir, pluginDir)
+
+  for (const relativePath of files) {
+    hash.update(relativePath)
+    const content = fs.readFileSync(path.join(pluginDir, relativePath))
+    hash.update(content)
+  }
+
+  return hash.digest('hex')
+}
+
+/**
+ * 加载本地哈希记录
+ */
+export function loadHashRecords(): PluginHashMap {
+  try {
+    if (fs.existsSync(HASH_RECORDS_FILE)) {
+      const content = fs.readFileSync(HASH_RECORDS_FILE, 'utf-8')
+      return JSON.parse(content)
+    }
+  } catch (error) {
+    console.error('[PluginHasher] 加载哈希记录失败:', error)
+  }
+  return {}
+}
+
+/**
+ * 保存本地哈希记录
+ */
+export function saveHashRecords(records: PluginHashMap): void {
+  try {
+    ensureStagingDir()
+    fs.writeFileSync(HASH_RECORDS_FILE, JSON.stringify(records, null, 2), 'utf-8')
+  } catch (error) {
+    console.error('[PluginHasher] 保存哈希记录失败:', error)
+  }
+}
+
+/**
+ * 确保 zip 暂存目录存在
+ */
+function ensureStagingDir(): void {
+  if (!fs.existsSync(STAGING_DIR)) {
+    fs.mkdirSync(STAGING_DIR, { recursive: true })
+  }
+}
+
+/**
+ * 获取 zip 暂存目录路径
+ */
+export function getZipStagingDir(): string {
+  ensureStagingDir()
+  return STAGING_DIR
+}
+
+/**
+ * 获取插件 zip 文件路径
+ */
+export function getZipPath(pluginName: string): string {
+  return path.join(getZipStagingDir(), `${pluginName}.zip`)
+}

--- a/src/main/core/sync/pluginSyncWatcher.ts
+++ b/src/main/core/sync/pluginSyncWatcher.ts
@@ -1,0 +1,135 @@
+import chokidar, { FSWatcher } from 'chokidar'
+import { app } from 'electron'
+import fs from 'fs'
+import path from 'path'
+
+const PLUGIN_DIR = path.join(app.getPath('userData'), 'plugins')
+
+/**
+ * 插件同步监视器
+ * 监听插件目录变更，仅标记脏数据，不执行重操作（hash/zip 在同步时处理）
+ */
+class PluginSyncWatcher {
+  private watcher: FSWatcher | null = null
+  private dirtyPlugins: Set<string> = new Set()
+  private paused = false
+
+  /**
+   * 启动监听
+   */
+  start(): void {
+    if (this.watcher) {
+      return
+    }
+
+    // 确保插件目录存在
+    if (!fs.existsSync(PLUGIN_DIR)) {
+      fs.mkdirSync(PLUGIN_DIR, { recursive: true })
+    }
+
+    console.log('[PluginSyncWatcher] 开始监听插件目录:', PLUGIN_DIR)
+
+    // 初始全量标脏
+    this.markAllDirty()
+
+    this.watcher = chokidar.watch(PLUGIN_DIR, {
+      depth: 5,
+      persistent: true,
+      ignoreInitial: true,
+      followSymlinks: false,
+      usePolling: process.platform === 'win32',
+      interval: process.platform === 'win32' ? 5000 : undefined,
+      awaitWriteFinish: {
+        stabilityThreshold: 500,
+        pollInterval: 100
+      }
+    })
+
+    // 标脏操作是幂等的 Set.add()，无需防抖，直接标记
+    const handleChange = (changedPath: string): void => {
+      if (this.paused) return
+
+      const relativePath = path.relative(PLUGIN_DIR, changedPath)
+      const pluginName = relativePath.split(path.sep)[0]
+      if (!pluginName || pluginName === '.') return
+
+      this.dirtyPlugins.add(pluginName)
+      console.log(`[PluginSyncWatcher] 标记脏插件: ${pluginName}`)
+    }
+
+    this.watcher.on('add', handleChange)
+    this.watcher.on('change', handleChange)
+    this.watcher.on('unlink', handleChange)
+    this.watcher.on('addDir', handleChange)
+    this.watcher.on('unlinkDir', handleChange)
+
+    this.watcher.on('error', (error: unknown) => {
+      console.error('[PluginSyncWatcher] 监听错误:', error)
+    })
+
+    this.watcher.on('ready', () => {
+      console.log('[PluginSyncWatcher] 监听器已就绪')
+    })
+  }
+
+  /**
+   * 停止监听并清理
+   */
+  stop(): void {
+    if (this.watcher) {
+      console.log('[PluginSyncWatcher] 停止监听')
+      this.watcher.close()
+      this.watcher = null
+    }
+    this.dirtyPlugins.clear()
+  }
+
+  /**
+   * 获取当前脏插件集合
+   */
+  getDirtyPlugins(): Set<string> {
+    return new Set(this.dirtyPlugins)
+  }
+
+  /**
+   * 清除单个插件的脏标记
+   */
+  clearDirty(pluginName: string): void {
+    this.dirtyPlugins.delete(pluginName)
+  }
+
+  /**
+   * 将所有现有插件标记为脏
+   */
+  markAllDirty(): void {
+    if (!fs.existsSync(PLUGIN_DIR)) return
+
+    try {
+      const entries = fs.readdirSync(PLUGIN_DIR, { withFileTypes: true })
+      for (const entry of entries) {
+        if (entry.isDirectory()) {
+          this.dirtyPlugins.add(entry.name)
+        }
+      }
+      console.log(`[PluginSyncWatcher] 初始标脏 ${this.dirtyPlugins.size} 个插件`)
+    } catch (error) {
+      console.error('[PluginSyncWatcher] 标记所有插件为脏失败:', error)
+    }
+  }
+
+  /**
+   * 暂停监听（同步引擎安装/卸载插件时使用）
+   */
+  pause(): void {
+    this.paused = true
+  }
+
+  /**
+   * 恢复监听
+   */
+  resume(): void {
+    this.paused = false
+  }
+}
+
+export default new PluginSyncWatcher()

--- a/src/main/core/sync/syncEngine.ts
+++ b/src/main/core/sync/syncEngine.ts
@@ -1,7 +1,14 @@
 import { WebDAVSyncClient } from './webdavClient'
 import { SyncConfig, SyncResult } from './types'
 import LmdbDatabase from '../lmdb/index'
-import { safeStorage } from 'electron'
+import { app, BrowserWindow, safeStorage } from 'electron'
+import { computePluginHash, loadHashRecords, saveHashRecords, getZipPath } from './pluginHasher'
+import pluginSyncWatcher from './pluginSyncWatcher'
+import AdmZip from 'adm-zip'
+import fs from 'fs'
+import path from 'path'
+
+const PLUGIN_DIR = path.join(app.getPath('userData'), 'plugins')
 
 /**
  * 同步引擎
@@ -10,10 +17,18 @@ export class SyncEngine {
   private webdavClient: WebDAVSyncClient
   private db: LmdbDatabase
   private syncTimer: NodeJS.Timeout | null = null
+  private mainWindow: BrowserWindow | null = null
 
   constructor(db: LmdbDatabase) {
     this.db = db
     this.webdavClient = new WebDAVSyncClient()
+  }
+
+  /**
+   * 设置主窗口引用（用于发送 plugins-changed 事件）
+   */
+  setMainWindow(mainWindow: BrowserWindow): void {
+    this.mainWindow = mainWindow
   }
 
   /**
@@ -43,6 +58,11 @@ export class SyncEngine {
 
     // 启动定时同步
     this.startAutoSync(config.syncInterval)
+
+    // 如果启用了插件同步，启动插件目录监听
+    if (config.syncPlugins) {
+      pluginSyncWatcher.start()
+    }
 
     console.log('[Sync] 同步引擎初始化完成')
   }
@@ -135,6 +155,16 @@ export class SyncEngine {
           downloadAttachmentResult.errors
       }
 
+      // 6. 插件文件同步
+      const config = await this.loadSyncConfig()
+      if (config?.syncPlugins) {
+        const pluginResult = await this.syncPlugins(config)
+        result.pluginsUploaded = pluginResult.pluginsUploaded
+        result.pluginsDownloaded = pluginResult.pluginsDownloaded
+        result.pluginsDeleted = pluginResult.pluginsDeleted
+        result.errors += pluginResult.errors
+      }
+
       console.log('[Sync] 同步完成:', result)
       return result
     } catch (error) {
@@ -184,6 +214,45 @@ export class SyncEngine {
         }
       }
 
+      // 如果启用了插件同步，强制从远端下载所有插件
+      let pluginsDownloaded = 0
+      const config = await this.loadSyncConfig()
+      if (config?.syncPlugins) {
+        try {
+          pluginSyncWatcher.pause()
+          const remoteManifest = await this.webdavClient.downloadPluginManifest()
+          const hashRecords = loadHashRecords()
+
+          for (const [pluginName, entry] of Object.entries(remoteManifest)) {
+            try {
+              console.log(`[Sync] 强制下载插件: ${pluginName}`)
+              const zipBuffer = await this.webdavClient.downloadPluginZip(pluginName)
+              if (!zipBuffer) {
+                console.warn(`[Sync] 远端插件 zip 不存在: ${pluginName}`)
+                continue
+              }
+
+              await this.installPluginFromSyncZip(pluginName, zipBuffer)
+
+              hashRecords[pluginName] = {
+                hash: entry.hash,
+                version: entry.version,
+                lastSyncTime: Date.now()
+              }
+
+              pluginsDownloaded++
+            } catch (err) {
+              console.error(`[Sync] 强制下载插件失败: ${pluginName}`, err)
+              errors++
+            }
+          }
+
+          saveHashRecords(hashRecords)
+        } finally {
+          pluginSyncWatcher.resume()
+        }
+      }
+
       // 更新同步时间
       await this.updateLastSyncTime()
 
@@ -191,7 +260,8 @@ export class SyncEngine {
         uploaded: 0,
         downloaded,
         conflicts: 0,
-        errors
+        errors,
+        pluginsDownloaded
       }
 
       console.log('[Sync] 强制同步完成:', result)
@@ -703,5 +773,317 @@ export class SyncEngine {
       // 保存元数据
       metaDb.putSync(docId, JSON.stringify(meta))
     })
+  }
+
+  // ==================== 插件文件同步 ====================
+
+  /**
+   * 同步插件文件
+   */
+  private async syncPlugins(
+    config: SyncConfig
+  ): Promise<{
+    pluginsUploaded: number
+    pluginsDownloaded: number
+    pluginsDeleted: number
+    errors: number
+  }> {
+    console.log('[Sync] 开始插件文件同步...')
+
+    let pluginsUploaded = 0
+    let pluginsDownloaded = 0
+    let pluginsDeleted = 0
+    let errors = 0
+
+    try {
+      // 1. 暂停 watcher 避免同步操作触发循环
+      pluginSyncWatcher.pause()
+
+      // 2. 处理脏数据：计算 hash、压缩 zip
+      const dirtyPlugins = pluginSyncWatcher.getDirtyPlugins()
+      const hashRecords = loadHashRecords()
+
+      for (const pluginName of dirtyPlugins) {
+        try {
+          const pluginDir = path.join(PLUGIN_DIR, pluginName)
+
+          if (!fs.existsSync(pluginDir)) {
+            // 本地插件已不存在，从记录中移除
+            delete hashRecords[pluginName]
+            const zipPath = getZipPath(pluginName)
+            if (fs.existsSync(zipPath)) {
+              fs.unlinkSync(zipPath)
+            }
+            pluginSyncWatcher.clearDirty(pluginName)
+            continue
+          }
+
+          // 计算新 hash
+          const newHash = computePluginHash(pluginDir)
+
+          // 读取 plugin.json 获取版本号
+          const pluginJsonPath = path.join(pluginDir, 'plugin.json')
+          let version = '0.0.0'
+          if (fs.existsSync(pluginJsonPath)) {
+            try {
+              const pluginJson = JSON.parse(fs.readFileSync(pluginJsonPath, 'utf-8'))
+              version = pluginJson.version || '0.0.0'
+            } catch {
+              // 解析失败使用默认版本号
+            }
+          }
+
+          const existingRecord = hashRecords[pluginName]
+
+          // hash 未变化且 zip 存在，跳过
+          const zipPath = getZipPath(pluginName)
+          if (existingRecord?.hash === newHash && fs.existsSync(zipPath)) {
+            pluginSyncWatcher.clearDirty(pluginName)
+            continue
+          }
+
+          // hash 变化或 zip 缺失，重新压缩
+          console.log(`[Sync] 压缩插件: ${pluginName}`)
+          const zip = new AdmZip()
+          zip.addLocalFolder(pluginDir)
+          zip.writeZip(zipPath)
+
+          // 更新记录
+          hashRecords[pluginName] = {
+            hash: newHash,
+            version,
+            lastSyncTime: Date.now()
+          }
+
+          pluginSyncWatcher.clearDirty(pluginName)
+        } catch (error) {
+          console.error(`[Sync] 处理脏插件失败: ${pluginName}`, error)
+          errors++
+        }
+      }
+
+      // 3. 读取远端 manifest
+      const remoteManifest = await this.webdavClient.downloadPluginManifest()
+      const deviceId = config.deviceId
+
+      // 4. 上传阶段：本地有而远端无或 hash 不同的插件
+      for (const [pluginName, record] of Object.entries(hashRecords)) {
+        try {
+          const remoteEntry = remoteManifest[pluginName]
+
+          // 远端无此插件，或 hash 不同
+          if (!remoteEntry || remoteEntry.hash !== record.hash) {
+            const zipPath = getZipPath(pluginName)
+            if (!fs.existsSync(zipPath)) {
+              console.warn(`[Sync] 插件 zip 不存在，跳过上传: ${pluginName}`)
+              continue
+            }
+
+            console.log(`[Sync] 上传插件: ${pluginName}`)
+            const zipBuffer = fs.readFileSync(zipPath)
+            await this.webdavClient.uploadPluginZip(pluginName, zipBuffer)
+
+            // 更新 manifest
+            remoteManifest[pluginName] = {
+              hash: record.hash,
+              version: record.version,
+              lastModified: Date.now(),
+              deviceId
+            }
+
+            pluginsUploaded++
+          }
+        } catch (error) {
+          console.error(`[Sync] 上传插件失败: ${pluginName}`, error)
+          errors++
+        }
+      }
+
+      // 5. 本地删除 → 远端删除：本设备上传过但本地已不存在的
+      for (const [pluginName, entry] of Object.entries(remoteManifest)) {
+        if (entry.deviceId === deviceId && !hashRecords[pluginName]) {
+          try {
+            console.log(`[Sync] 删除远端插件: ${pluginName}`)
+            await this.webdavClient.deletePluginZip(pluginName)
+            delete remoteManifest[pluginName]
+            pluginsDeleted++
+          } catch (error) {
+            console.error(`[Sync] 删除远端插件失败: ${pluginName}`, error)
+            errors++
+          }
+        }
+      }
+
+      // 6. 下载阶段：远端有而本地无或 hash 不同的（非本设备上传的）
+      for (const [pluginName, entry] of Object.entries(remoteManifest)) {
+        try {
+          const localRecord = hashRecords[pluginName]
+
+          // 跳过本设备刚上传的
+          if (entry.deviceId === deviceId) continue
+
+          // 本地无此插件或 hash 不同
+          if (!localRecord || localRecord.hash !== entry.hash) {
+            console.log(`[Sync] 下载插件: ${pluginName}`)
+            const zipBuffer = await this.webdavClient.downloadPluginZip(pluginName)
+            if (!zipBuffer) {
+              console.warn(`[Sync] 远端插件 zip 不存在: ${pluginName}`)
+              continue
+            }
+
+            await this.installPluginFromSyncZip(pluginName, zipBuffer)
+
+            // 更新本地 hash 记录
+            hashRecords[pluginName] = {
+              hash: entry.hash,
+              version: entry.version,
+              lastSyncTime: Date.now()
+            }
+
+            pluginsDownloaded++
+          }
+        } catch (error) {
+          console.error(`[Sync] 下载插件失败: ${pluginName}`, error)
+          errors++
+        }
+      }
+
+      // 7. 远端删除 → 本地删除：本地存在但远端 manifest 已无的
+      for (const pluginName of Object.keys(hashRecords)) {
+        if (!remoteManifest[pluginName]) {
+          const pluginDir = path.join(PLUGIN_DIR, pluginName)
+          if (fs.existsSync(pluginDir)) {
+            try {
+              console.log(`[Sync] 本地卸载插件（远端已删除）: ${pluginName}`)
+              await this.uninstallSyncedPlugin(pluginName)
+              delete hashRecords[pluginName]
+              pluginsDeleted++
+            } catch (error) {
+              console.error(`[Sync] 本地卸载插件失败: ${pluginName}`, error)
+              errors++
+            }
+          }
+        }
+      }
+
+      // 8. 保存更新后的 manifest 和 hash 记录
+      await this.webdavClient.uploadPluginManifest(remoteManifest)
+      saveHashRecords(hashRecords)
+    } catch (error) {
+      console.error('[Sync] 插件同步失败:', error)
+      errors++
+    } finally {
+      // 9. 恢复 watcher
+      pluginSyncWatcher.resume()
+    }
+
+    console.log(
+      `[Sync] 插件同步完成: 上传 ${pluginsUploaded}, 下载 ${pluginsDownloaded}, 删除 ${pluginsDeleted}, 错误 ${errors}`
+    )
+
+    return { pluginsUploaded, pluginsDownloaded, pluginsDeleted, errors }
+  }
+
+  /**
+   * 从同步下载的 zip 安装插件
+   */
+  private async installPluginFromSyncZip(pluginName: string, zipBuffer: Buffer): Promise<void> {
+    const targetDir = path.join(PLUGIN_DIR, pluginName)
+
+    // 确保插件目录存在
+    if (!fs.existsSync(PLUGIN_DIR)) {
+      fs.mkdirSync(PLUGIN_DIR, { recursive: true })
+    }
+
+    // 如果已存在则先删除
+    if (fs.existsSync(targetDir)) {
+      fs.rmSync(targetDir, { recursive: true, force: true })
+    }
+
+    // 解压 zip
+    const zip = new AdmZip(zipBuffer)
+    zip.extractAllTo(targetDir, true)
+
+    // 读取 plugin.json
+    const pluginJsonPath = path.join(targetDir, 'plugin.json')
+    if (!fs.existsSync(pluginJsonPath)) {
+      console.warn(`[Sync] 安装的插件缺少 plugin.json: ${pluginName}`)
+      return
+    }
+
+    const pluginJson = JSON.parse(fs.readFileSync(pluginJsonPath, 'utf-8'))
+
+    // 更新 LMDB 插件列表
+    const pluginsDoc = await this.db.promises.get('ZTOOLS/plugins')
+    const plugins: any[] = pluginsDoc?.data ? JSON.parse(JSON.stringify(pluginsDoc.data)) : []
+
+    // 检查是否已存在
+    const existingIndex = plugins.findIndex((p: any) => p.name === pluginName)
+    const pluginEntry = {
+      name: pluginJson.name || pluginName,
+      title: pluginJson.title || pluginJson.name || pluginName,
+      path: targetDir,
+      version: pluginJson.version || '0.0.0',
+      description: pluginJson.description || '',
+      logo: pluginJson.logo || '',
+      features: pluginJson.features || [],
+      isDevelopment: false
+    }
+
+    if (existingIndex >= 0) {
+      plugins[existingIndex] = pluginEntry
+    } else {
+      plugins.push(pluginEntry)
+    }
+
+    await this.db.promises.put({
+      _id: 'ZTOOLS/plugins',
+      _rev: pluginsDoc?._rev,
+      data: plugins
+    })
+
+    // 通知渲染进程
+    this.notifyPluginsChanged()
+  }
+
+  /**
+   * 卸载通过同步安装的插件
+   */
+  private async uninstallSyncedPlugin(pluginName: string): Promise<void> {
+    const pluginDir = path.join(PLUGIN_DIR, pluginName)
+
+    // 删除目录
+    if (fs.existsSync(pluginDir)) {
+      fs.rmSync(pluginDir, { recursive: true, force: true })
+    }
+
+    // 从 LMDB 插件列表移除
+    const pluginsDoc = await this.db.promises.get('ZTOOLS/plugins')
+    if (pluginsDoc?.data) {
+      const plugins = pluginsDoc.data.filter((p: any) => p.name !== pluginName)
+      await this.db.promises.put({
+        _id: 'ZTOOLS/plugins',
+        _rev: pluginsDoc._rev,
+        data: plugins
+      })
+    }
+
+    // 删除本地 zip
+    const zipPath = getZipPath(pluginName)
+    if (fs.existsSync(zipPath)) {
+      fs.unlinkSync(zipPath)
+    }
+
+    // 通知渲染进程
+    this.notifyPluginsChanged()
+  }
+
+  /**
+   * 通知渲染进程插件列表已变更
+   */
+  private notifyPluginsChanged(): void {
+    if (this.mainWindow && !this.mainWindow.isDestroyed()) {
+      this.mainWindow.webContents.send('plugins-changed')
+    }
   }
 }

--- a/src/main/core/sync/types.ts
+++ b/src/main/core/sync/types.ts
@@ -13,6 +13,7 @@ export interface SyncConfig {
   syncInterval: number // 同步间隔（秒）
   lastSyncTime: number // 最后同步时间
   deviceId: string // 当前设备唯一 ID（自动生成）
+  syncPlugins?: boolean // 是否同步插件文件
 }
 
 /**
@@ -43,6 +44,42 @@ export interface SyncResult {
   downloaded: number // 下载数量
   conflicts: number // 冲突数量
   errors: number // 错误数量
+  pluginsUploaded?: number // 上传插件数量
+  pluginsDownloaded?: number // 下载插件数量
+  pluginsDeleted?: number // 删除插件数量
+}
+
+/**
+ * 插件哈希记录
+ */
+export interface PluginHashRecord {
+  hash: string
+  version: string
+  lastSyncTime: number
+}
+
+/**
+ * 插件哈希映射
+ */
+export interface PluginHashMap {
+  [pluginName: string]: PluginHashRecord
+}
+
+/**
+ * 远端插件清单条目
+ */
+export interface RemotePluginManifestEntry {
+  hash: string
+  version: string
+  lastModified: number
+  deviceId: string
+}
+
+/**
+ * 远端插件清单
+ */
+export interface RemotePluginManifest {
+  [pluginName: string]: RemotePluginManifestEntry
 }
 
 /**

--- a/src/main/core/sync/webdavClient.ts
+++ b/src/main/core/sync/webdavClient.ts
@@ -1,5 +1,5 @@
 import { createClient, WebDAVClient } from 'webdav'
-import { SyncConfig, RemoteFileMeta } from './types'
+import { SyncConfig, RemoteFileMeta, RemotePluginManifest } from './types'
 
 /**
  * WebDAV 同步客户端
@@ -56,6 +56,13 @@ export class WebDAVSyncClient {
     const attachmentExists = await this.client.exists(attachmentPath)
     if (!attachmentExists) {
       await this.client.createDirectory(attachmentPath)
+    }
+
+    // 确保插件目录存在
+    const pluginsPath = '/ztools-sync/plugins'
+    const pluginsExists = await this.client.exists(pluginsPath)
+    if (!pluginsExists) {
+      await this.client.createDirectory(pluginsPath)
     }
   }
 
@@ -258,5 +265,103 @@ export class WebDAVSyncClient {
         const encodedId = item.basename.replace('.bin', '')
         return decodeURIComponent(encodedId)
       })
+  }
+
+  // ==================== 插件同步相关方法 ====================
+
+  /**
+   * 上传插件 zip 到云端
+   */
+  async uploadPluginZip(pluginName: string, zipBuffer: Buffer): Promise<void> {
+    if (!this.client) {
+      throw new Error('WebDAV 客户端未初始化')
+    }
+
+    const encoded = encodeURIComponent(pluginName)
+    const remotePath = `/ztools-sync/plugins/${encoded}.zip`
+
+    try {
+      await this.client.putFileContents(remotePath, zipBuffer, {
+        overwrite: true
+      })
+    } catch (error: any) {
+      console.error(`[WebDAV] 上传插件 zip 失败: ${pluginName}`, error.message)
+      throw error
+    }
+  }
+
+  /**
+   * 从云端下载插件 zip
+   */
+  async downloadPluginZip(pluginName: string): Promise<Buffer | null> {
+    if (!this.client) {
+      throw new Error('WebDAV 客户端未初始化')
+    }
+
+    const encoded = encodeURIComponent(pluginName)
+    const remotePath = `/ztools-sync/plugins/${encoded}.zip`
+    const exists = await this.client.exists(remotePath)
+    if (!exists) return null
+
+    const data = (await this.client.getFileContents(remotePath, {
+      format: 'binary'
+    })) as Buffer
+
+    return Buffer.from(data)
+  }
+
+  /**
+   * 删除云端插件 zip
+   */
+  async deletePluginZip(pluginName: string): Promise<void> {
+    if (!this.client) {
+      throw new Error('WebDAV 客户端未初始化')
+    }
+
+    const encoded = encodeURIComponent(pluginName)
+    const remotePath = `/ztools-sync/plugins/${encoded}.zip`
+    const exists = await this.client.exists(remotePath)
+    if (exists) {
+      await this.client.deleteFile(remotePath)
+    }
+  }
+
+  /**
+   * 上传插件清单到云端
+   */
+  async uploadPluginManifest(manifest: RemotePluginManifest): Promise<void> {
+    if (!this.client) {
+      throw new Error('WebDAV 客户端未初始化')
+    }
+
+    const remotePath = '/ztools-sync/plugins/manifest.json'
+    const content = JSON.stringify(manifest, null, 2)
+
+    await this.client.putFileContents(remotePath, content, {
+      overwrite: true
+    })
+  }
+
+  /**
+   * 从云端下载插件清单
+   */
+  async downloadPluginManifest(): Promise<RemotePluginManifest> {
+    if (!this.client) {
+      throw new Error('WebDAV 客户端未初始化')
+    }
+
+    const remotePath = '/ztools-sync/plugins/manifest.json'
+    const exists = await this.client.exists(remotePath)
+    if (!exists) return {}
+
+    try {
+      const content = (await this.client.getFileContents(remotePath, {
+        format: 'text'
+      })) as string
+      return JSON.parse(content)
+    } catch (error) {
+      console.warn('[WebDAV] 解析插件清单失败:', error)
+      return {}
+    }
   }
 }


### PR DESCRIPTION
fix #46
- 新增插件目录监听器(pluginSyncWatcher)，实时标记变更插件
- 新增插件哈希计算(pluginHasher)，基于 SHA-256 实现增量同步
- syncEngine 增加插件同步流程：上传/下载/删除，基于 manifest 对账
- webdavClient 增加插件 zip 和 manifest 的上传/下载/删除方法
- 设置界面增加「同步插件」开关及插件同步统计展示
- 强制从云端同步支持同时恢复插件
- 开发插件不参与同步（仅同步 userData/plugins 目录）