### PR TITLE
feat: 超级面板 AI 格式化文本 & 剪贴板自动文本清理

### DIFF
--- a/internal-plugins/setting/src/views/GeneralSetting/GeneralSetting.vue
+++ b/internal-plugins/setting/src/views/GeneralSetting/GeneralSetting.vue
@@ -131,6 +131,9 @@ const recentRows = ref(2)
 const pinnedRows = ref(2)
 const searchMode = ref<'aggregate' | 'list'>('aggregate')
 
+// 剪贴板设置
+const clipboardAutoFormatText = ref(false)
+
 // Tab 键目标指令
 const tabTargetCommand = ref('')
 
@@ -148,6 +151,7 @@ const superPanelBlockedApps = ref<Array<{ app: string; bundleId?: string; label?
 
 // 超级面板翻译设置
 const superPanelTranslateEnabled = ref(false)
+const superPanelAiFormatEnabled = ref(false)
 const translationStatus = ref<'idle' | 'downloading' | 'initializing' | 'ready' | 'error'>('idle')
 
 // 超级面板触发模式（计算属性）
@@ -419,6 +423,18 @@ async function handleAutoPasteChange(): Promise<void> {
   }
 }
 
+// 处理剪贴板自动格式化变化
+async function handleClipboardAutoFormatTextChange(): Promise<void> {
+  try {
+    await saveSettings()
+    await window.ztools.internal.updateClipboardConfig({
+      autoFormatText: clipboardAutoFormatText.value
+    })
+  } catch (error) {
+    console.error('保存剪贴板自动格式化配置失败:', error)
+  }
+}
+
 // 处理自动清空配置变化
 async function handleAutoClearChange(): Promise<void> {
   try {
@@ -631,6 +647,10 @@ async function handleSuperPanelTranslateChange(): Promise<void> {
   } catch (err) {
     console.error('更新超级面板翻译开关失败:', err)
   }
+}
+
+async function handleSuperPanelAiFormatChange(): Promise<void> {
+  await saveSettings()
 }
 
 // 轮询翻译引擎状态
@@ -1042,6 +1062,9 @@ async function loadSettings(): Promise<void> {
       primaryColor.value = data.primaryColor ?? 'blue'
       searchMode.value = data.searchMode ?? 'aggregate'
       autoCheckUpdate.value = data.autoCheckUpdate ?? true
+      // 剪贴板设置
+      clipboardAutoFormatText.value = data.clipboardAutoFormatText ?? false
+
       // Tab 键目标指令
       tabTargetCommand.value = data.tabTargetCommand ?? ''
       // 空格打开指令
@@ -1055,6 +1078,7 @@ async function loadSettings(): Promise<void> {
       superPanelLongPressMs.value = data.superPanelLongPressMs ?? 500
       superPanelBlockedApps.value = data.superPanelBlockedApps ?? []
       superPanelTranslateEnabled.value = data.superPanelTranslateEnabled ?? false
+      superPanelAiFormatEnabled.value = data.superPanelAiFormatEnabled ?? false
       if (superPanelTranslateEnabled.value) {
         pollTranslationStatus()
       }
@@ -1134,6 +1158,7 @@ async function saveSettings(): Promise<void> {
       superPanelLongPressMs: superPanelLongPressMs.value,
       superPanelBlockedApps: superPanelBlockedApps.value.map((item) => ({ ...item })),
       superPanelTranslateEnabled: superPanelTranslateEnabled.value,
+      superPanelAiFormatEnabled: superPanelAiFormatEnabled.value,
       theme: theme.value,
       primaryColor: primaryColor.value,
       customColor: customColor.value,
@@ -1146,7 +1171,8 @@ async function saveSettings(): Promise<void> {
       proxyUrl: proxyUrl.value,
       pluginMarketCustom: pluginMarketCustom.value,
       pluginMarketUrl: pluginMarketUrl.value,
-      autoCheckUpdate: autoCheckUpdate.value
+      autoCheckUpdate: autoCheckUpdate.value,
+      clipboardAutoFormatText: clipboardAutoFormatText.value
     })
   } catch (error) {
     console.error('保存设置失败:', error)
@@ -1692,6 +1718,28 @@ onUnmounted(() => {
       </div>
     </div>
 
+    <!-- ==================== 剪贴板 ==================== -->
+    <div class="setting-group">
+      <h3 class="setting-group-title">剪贴板</h3>
+
+      <div class="setting-item">
+        <div class="setting-label">
+          <span>自动格式化文本</span>
+          <span class="setting-desc">复制文本时自动清理多余空白、统一换行，不改变文字内容</span>
+        </div>
+        <div class="setting-control">
+          <label class="toggle">
+            <input
+              v-model="clipboardAutoFormatText"
+              type="checkbox"
+              @change="handleClipboardAutoFormatTextChange"
+            />
+            <span class="toggle-slider"></span>
+          </label>
+        </div>
+      </div>
+    </div>
+
     <!-- ==================== 超级面板 ==================== -->
     <div class="setting-group">
       <h3 class="setting-group-title">超级面板</h3>
@@ -1788,6 +1836,25 @@ onUnmounted(() => {
               v-model="superPanelTranslateEnabled"
               type="checkbox"
               @change="handleSuperPanelTranslateChange"
+            />
+            <span class="toggle-slider"></span>
+          </label>
+        </div>
+      </div>
+
+      <div v-if="superPanelEnabled" class="setting-item">
+        <div class="setting-label">
+          <span>AI 格式化文本</span>
+          <span class="setting-desc"
+            >触发超级面板时，若剪贴板为文本，显示"格式化为 Markdown"选项（需配置 AI 模型）</span
+          >
+        </div>
+        <div class="setting-control">
+          <label class="toggle">
+            <input
+              v-model="superPanelAiFormatEnabled"
+              type="checkbox"
+              @change="handleSuperPanelAiFormatChange"
             />
             <span class="toggle-slider"></span>
           </label>

--- a/resources/preload.js
+++ b/resources/preload.js
@@ -879,6 +879,10 @@ window.ztools = {
       await electron.ipcRenderer.invoke('super-panel:unpin-command', path, featureCode),
     getSuperPanelPinned: async () => await electron.ipcRenderer.invoke('super-panel:get-pinned'),
 
+    // ==================== 剪贴板配置 API ====================
+    updateClipboardConfig: async (config) =>
+      await electron.ipcRenderer.invoke('internal:update-clipboard-config', config),
+
     // ==================== AI 模型管理 API ====================
     aiModels: {
       getAll: async () => await electron.ipcRenderer.invoke('internal:ai-models-get-all'),

--- a/src/main/api/plugin/ai.ts
+++ b/src/main/api/plugin/ai.ts
@@ -81,6 +81,7 @@ class PluginAiAPI {
   private pluginManager: PluginManager | null = null
   private mainWindow: Electron.BrowserWindow | null = null
   private abortControllers: Map<string, AbortController> = new Map()
+  private clientCache: Map<string, OpenAI> = new Map()
 
   public init(mainWindow: Electron.BrowserWindow, pluginManager: PluginManager): void {
     this.mainWindow = mainWindow
@@ -222,10 +223,17 @@ class PluginAiAPI {
   }
 
   private createClient(modelConfig: AiModel): OpenAI {
-    return new OpenAI({
-      apiKey: modelConfig.apiKey,
-      baseURL: modelConfig.apiUrl
-    })
+    const cacheKey = `${modelConfig.id}:${modelConfig.apiKey}:${modelConfig.apiUrl}`
+    if (!this.clientCache.has(cacheKey)) {
+      this.clientCache.set(
+        cacheKey,
+        new OpenAI({
+          apiKey: modelConfig.apiKey,
+          baseURL: modelConfig.apiUrl
+        })
+      )
+    }
+    return this.clientCache.get(cacheKey)!
   }
   /**
    * 将 Message[] 转为 OpenAI SDK 格式
@@ -523,6 +531,45 @@ class PluginAiAPI {
     if (abortController) {
       abortController.abort()
       this.abortControllers.delete(requestId)
+    }
+  }
+
+  public async formatTextForSuperPanel(
+    text: string
+  ): Promise<{ success: boolean; text?: string; error?: string }> {
+    const modelConfig = await this.getModelConfig()
+    if (!modelConfig) {
+      return { success: false, error: '未找到 AI 模型配置，请先在设置中添加模型' }
+    }
+
+    try {
+      const client = this.createClient(modelConfig)
+      const response = await client.chat.completions.create({
+        model: modelConfig.id,
+        messages: [
+          {
+            role: 'system',
+            content:
+              '你是一个文本格式整理助手。请对用户提供的文本做最小化的 Markdown 格式修正：修复错误换行、合并被截断的句子、去除多余空行、统一标点间距。如果原文已有列表或标题结构，用对应的 Markdown 语法（- 或 #）规范化；如果原文是连续段落，保持段落形式不变，不得主动拆分或增加结构。严格保留所有原始文字内容和原有结构，不得增删、改写、重组任何内容，不得添加原文中不存在的表情（包括 emoji）。只返回整理后的文本，不要添加任何说明或解释。'
+          },
+          {
+            role: 'user',
+            content: text
+          }
+        ]
+      })
+
+      const result = response.choices[0]?.message?.content
+      if (!result) {
+        return { success: false, error: 'AI 返回结果为空' }
+      }
+      return { success: true, text: result.trim() }
+    } catch (error: unknown) {
+      console.error('[AI] 超级面板格式整理失败:', error)
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : '未知错误'
+      }
     }
   }
 }

--- a/src/main/api/plugin/internal.ts
+++ b/src/main/api/plugin/internal.ts
@@ -747,6 +747,18 @@ export class InternalPluginAPI {
       return translationManager.getStatus()
     })
 
+    // ==================== 剪贴板配置 API ====================
+    ipcMain.handle(
+      'internal:update-clipboard-config',
+      async (event, config: { autoFormatText?: boolean }) => {
+        if (!requireInternalPlugin(this.pluginManager, event)) {
+          throw new PermissionDeniedError('internal:update-clipboard-config')
+        }
+        clipboardManager.updateConfig(config)
+        return { success: true }
+      }
+    )
+
     // ==================== 图片分析 API ====================
     // 直接转发到共享的 analyze-image handler（已在 imageAnalysis.ts 中注册）
     ipcMain.handle('internal:analyze-image', async (event, imagePath: string) => {

--- a/src/main/api/renderer/settings.ts
+++ b/src/main/api/renderer/settings.ts
@@ -5,6 +5,7 @@ import { getCurrentShortcut, updateShortcut } from '../../index.js'
 import doubleTapManager from '../../core/doubleTapManager.js'
 import proxyManager from '../../managers/proxyManager.js'
 import windowManager from '../../managers/windowManager.js'
+import clipboardManager from '../../managers/clipboardManager.js'
 import databaseAPI from '../shared/database'
 
 /**
@@ -104,6 +105,11 @@ export class SettingsAPI {
         if (data.windowDefaultHeight !== undefined) {
           this.pluginManager?.setPluginDefaultHeight(data.windowDefaultHeight)
           console.log('[Settings] 启动时应用插件默认高度设置:', data.windowDefaultHeight)
+        }
+        // 应用剪贴板自动格式化设置
+        if (data.clipboardAutoFormatText !== undefined) {
+          clipboardManager.updateConfig({ autoFormatText: data.clipboardAutoFormatText })
+          console.log('[Settings] 启动时应用剪贴板自动格式化设置:', data.clipboardAutoFormatText)
         }
       }
 

--- a/src/main/core/superPanelManager.ts
+++ b/src/main/core/superPanelManager.ts
@@ -10,6 +10,7 @@ import clipboardManager from '../managers/clipboardManager.js'
 import { readClipboardFiles } from '../utils/clipboardFiles.js'
 import { applyWindowMaterial, getDefaultWindowMaterial } from '../utils/windowUtils.js'
 import translationManager from './translationManager.js'
+import pluginAiAPI from '../api/plugin/ai.js'
 
 // 超级面板窗口尺寸
 const SUPER_PANEL_WIDTH = 250
@@ -632,6 +633,11 @@ class SuperPanelManager {
     // 超级面板请求加载固定列表（从搜索模式切换回固定模式）
     ipcMain.on('super-panel:show-pinned', () => {
       this.loadPinnedCommands()
+    })
+
+    // 超级面板 AI 格式化文本
+    ipcMain.handle('super-panel:ai-format', async (_event, text: string) => {
+      return await pluginAiAPI.formatTextForSuperPanel(text)
     })
 
     // 超级面板头像点击：隐藏超级面板，显示主搜索窗口

--- a/src/main/managers/clipboardManager.ts
+++ b/src/main/managers/clipboardManager.ts
@@ -12,6 +12,7 @@ import {
   readClipboardFiles,
   writeClipboardFiles
 } from '../utils/clipboardFiles'
+import { formatText } from '../utils/textFormatter'
 import { sleep } from '../utils/common'
 import pluginManager from './pluginManager'
 import ClipboardMonitor, { WindowMonitor, WindowManager } from '../core/native'
@@ -40,6 +41,7 @@ interface ClipboardItem {
   appName?: string // 复制时的应用名称
   bundleId?: string // 复制时的应用 Bundle ID
   content?: string // text: 文本内容
+  formattedContent?: string // text: 格式化前的原始文本（仅当自动格式化且与格式化后不同时存在）
   files?: FileItem[] // file: 文件列表
   imagePath?: string // image: 保存的图片路径
   resolution?: string // image: 图片分辨率 "width * height"
@@ -66,13 +68,15 @@ interface ClipboardConfig {
   maxItems: number // 最大条数
   maxImageSize: number // 单张图片最大大小（bytes）
   maxTotalImageSize: number // 图片总大小限制（bytes）
+  autoFormatText: boolean // 复制文本时自动格式化（清理多余空白）
 }
 
 // 默认配置
 const DEFAULT_CONFIG: ClipboardConfig = {
   maxItems: 1000,
   maxImageSize: 10 * 1024 * 1024, // 10MB
-  maxTotalImageSize: 500 * 1024 * 1024 // 500MB
+  maxTotalImageSize: 500 * 1024 * 1024, // 500MB
+  autoFormatText: false
 }
 
 // 剪贴板准备等待时间（复制后有些应用需要一点时间才能真正写入剪贴板）
@@ -348,10 +352,24 @@ class ClipboardManager {
       return null as any
     }
 
-    // 记录最后一次复制的文本
+    let finalText = text
+    let formattedContent: string | undefined
+
+    // 自动格式化：若开启则格式化文本并写回剪贴板
+    if (this.config.autoFormatText) {
+      const formatted = formatText(text)
+      if (formatted !== text) {
+        formattedContent = text // 保存原始文本供参考
+        this.temporaryCancelWatch()
+        clipboard.writeText(formatted)
+        finalText = formatted
+      }
+    }
+
+    // 记录最后一次复制的文本（使用格式化后的内容）
     this.lastCopiedContent = {
       type: 'text',
-      data: text,
+      data: finalText,
       timestamp: Date.now()
     }
 
@@ -359,9 +377,10 @@ class ClipboardManager {
       id: uuidv4(),
       type: 'text',
       timestamp: Date.now(),
-      hash: createHash('md5').update(text).digest('hex'),
-      content: text,
-      preview: text.length > 100 ? text.slice(0, 100) + '...' : text
+      hash: createHash('md5').update(finalText).digest('hex'),
+      content: finalText,
+      formattedContent,
+      preview: finalText.length > 100 ? finalText.slice(0, 100) + '...' : finalText
     }
   }
 
@@ -383,6 +402,7 @@ class ClipboardManager {
         appName: item.appName,
         bundleId: item.bundleId,
         content: item.content,
+        formattedContent: item.formattedContent,
         files: item.files,
         imagePath: item.imagePath,
         resolution: item.resolution,
@@ -501,8 +521,12 @@ class ClipboardManager {
       if (filter) {
         const keyword = filter.toLowerCase()
         allItems = allItems.filter((item) => {
-          // 搜索文本内容
+          // 搜索文本内容（格式化后）
           if (item.content?.toLowerCase().includes(keyword)) {
+            return true
+          }
+          // 搜索原始文本（格式化前，若存在）
+          if (item.formattedContent?.toLowerCase().includes(keyword)) {
             return true
           }
           // 搜索文件名（搜索 files 数组中的所有文件名）

--- a/src/main/utils/textFormatter.ts
+++ b/src/main/utils/textFormatter.ts
@@ -1,0 +1,39 @@
+/**
+ * 剪贴板文本格式化工具
+ * 仅清理排版/空白，不改变实际文字内容
+ */
+
+/**
+ * 格式化文本：
+ * 1. 统一换行符（\r\n / \r → \n）
+ * 2. 去除每行行尾多余空白
+ * 3. 连续超过 2 个空行合并为 1 个空行
+ * 4. 去除行内连续多个空格（保留缩进，仅压缩行中间的多余空格）
+ * 5. 去除零宽字符和其他不可见控制字符
+ * 6. 去除整体首尾空白
+ */
+export function formatText(text: string): string {
+  // 1. 统一换行符
+  let result = text.replace(/\r\n/g, '\n').replace(/\r/g, '\n')
+
+  // 2. 去除零宽字符和不可见控制字符（保留制表符和普通换行）
+  // 去掉：零宽空格 U+200B、零宽非断行空格 U+FEFF、软连字符 U+00AD 等
+  result = result.replace(/[\u200B\u200C\u200D\uFEFF\u00AD\u2028\u2029]/g, '')
+
+  // 3. 逐行处理
+  const lines = result.split('\n')
+  const processedLines = lines.map((line) => {
+    const trimmed = line.trimEnd()
+    const body = trimmed.trimStart()
+    const indent = trimmed.slice(0, trimmed.length - body.length)
+    return indent + body.replace(/ {2,}/g, ' ')
+  })
+
+  // 4. 合并连续超过 2 个的空行为 1 个
+  result = processedLines.join('\n').replace(/\n{3,}/g, '\n\n')
+
+  // 5. 去除整体首尾空白
+  result = result.trim()
+
+  return result
+}

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -346,6 +346,12 @@ const api = {
     ipcRenderer.on('super-panel-data', (_event, data) => callback(data))
   },
   superPanelLaunch: (command: any) => ipcRenderer.invoke('super-panel:launch', command),
+  superPanelAiFormat: (text: string) =>
+    ipcRenderer.invoke('super-panel:ai-format', text) as Promise<{
+      success: boolean
+      text?: string
+      error?: string
+    }>,
   superPanelReady: () => ipcRenderer.send('super-panel:ready'),
   superPanelShowPinned: () => ipcRenderer.send('super-panel:show-pinned'),
   superPanelShowMainWindow: () => ipcRenderer.send('super-panel:show-main-window'),

--- a/src/renderer/src/components/SuperPanel.vue
+++ b/src/renderer/src/components/SuperPanel.vue
@@ -160,30 +160,76 @@
       <!-- 搜索结果列表 -->
       <div class="search-list">
         <div
-          v-for="(result, index) in searchResults"
-          :key="`${result.name}|${result.path}-${result.featureCode || ''}`"
+          v-for="(item, index) in displayItems"
+          :key="
+            '__aiFormat' in item
+              ? '__ai_format__'
+              : `${(item as CommandItem).name}|${(item as CommandItem).path}-${(item as CommandItem).featureCode || ''}`
+          "
           class="list-item"
           :class="{ selected: index === selectedIndex }"
-          @click="launch(result)"
+          @click="'__aiFormat' in item ? requestAiFormat() : launch(item as CommandItem)"
           @mouseenter="selectedIndex = index"
         >
-          <img
-            v-if="result.icon && !iconErrors.has(getItemKey(result))"
-            :src="result.icon"
-            class="list-icon"
-            draggable="false"
-            @error="iconErrors.add(getItemKey(result))"
-          />
-          <div v-else class="list-icon-placeholder">
-            {{ result.name.charAt(0).toUpperCase() }}
-          </div>
-          <div class="list-info">
-            <span class="list-name">{{ result.name }}</span>
-            <span v-if="result.pluginExplain" class="list-desc">{{ result.pluginExplain }}</span>
-          </div>
+          <!-- AI 格式化项 -->
+          <template v-if="'__aiFormat' in item">
+            <div class="md-format-icon">
+              <svg
+                v-if="aiFormatLoading"
+                class="spin-icon"
+                width="13"
+                height="13"
+                viewBox="0 0 13 13"
+                fill="none"
+              >
+                <circle
+                  cx="6.5"
+                  cy="6.5"
+                  r="5"
+                  stroke="currentColor"
+                  stroke-width="1.6"
+                  stroke-dasharray="14 7"
+                />
+              </svg>
+              <span v-else class="md-format-icon-text">MD</span>
+            </div>
+            <div class="list-info">
+              <span class="list-name">
+                <template v-if="aiFormatLoading">格式化中…</template>
+                <template v-else-if="aiFormatDone">✓ 已格式化，可直接粘贴</template>
+                <template v-else-if="aiFormatError">{{ aiFormatError }}</template>
+                <template v-else>格式化为 Markdown</template>
+              </span>
+              <span v-if="!aiFormatDone && !aiFormatError && !aiFormatLoading" class="list-desc"
+                >使用 AI 整理为规范 Markdown 格式</span
+              >
+            </div>
+          </template>
+          <!-- 普通搜索结果项 -->
+          <template v-else>
+            <img
+              v-if="(item as CommandItem).icon && !iconErrors.has(getItemKey(item as CommandItem))"
+              :src="(item as CommandItem).icon"
+              class="list-icon"
+              draggable="false"
+              @error="iconErrors.add(getItemKey(item as CommandItem))"
+            />
+            <div v-else class="list-icon-placeholder">
+              {{ (item as CommandItem).name.charAt(0).toUpperCase() }}
+            </div>
+            <div class="list-info">
+              <span class="list-name">{{ (item as CommandItem).name }}</span>
+              <span v-if="(item as CommandItem).pluginExplain" class="list-desc">{{
+                (item as CommandItem).pluginExplain
+              }}</span>
+            </div>
+          </template>
         </div>
         <!-- 空状态 -->
-        <div v-if="searchResults.length === 0" class="empty-state">
+        <div
+          v-if="searchResults.length === 0 && !currentClipboardContent?.text"
+          class="empty-state"
+        >
           <span class="empty-text">无匹配结果</span>
         </div>
       </div>
@@ -394,12 +440,31 @@ const mode = ref<'pinned' | 'search' | 'loading'>('loading')
 const pinnedCommands = ref<GridItem[]>([])
 const searchResults = ref<CommandItem[]>([])
 const selectedIndex = ref(0)
+
+type AiFormatItem = { __aiFormat: true }
+const AI_FORMAT_ITEM: AiFormatItem = { __aiFormat: true }
+const aiFormatFeatureEnabled = ref(false)
+const displayItems = computed<(CommandItem | AiFormatItem)[]>(() => {
+  if (
+    aiFormatFeatureEnabled.value &&
+    currentClipboardContent.value?.type === 'text' &&
+    currentClipboardContent.value.text
+  ) {
+    return [AI_FORMAT_ITEM, ...searchResults.value]
+  }
+  return searchResults.value
+})
 const iconErrors = ref<Set<string>>(new Set())
 // 保存当前的剪贴板内容（由搜索结果携带）
 const currentClipboardContent = ref<ClipboardContent | null>(null)
 // 翻译结果
 const translationText = ref('')
 const pendingTranslation = ref<{ text: string; sourceText?: string } | null>(null)
+// AI 整理状态
+const aiFormatLoading = ref(false)
+const aiFormatDone = ref(false)
+const aiFormatError = ref('')
+let aiFormatResetTimer: ReturnType<typeof setTimeout> | null = null
 // 头像（默认使用内置头像）
 const avatar = ref(defaultAvatar)
 const acrylicLightOpacity = ref(78)
@@ -782,9 +847,54 @@ function getItemKey(item: GridItem): string {
   return `${item.path}-${item.featureCode || ''}-${item.name}`
 }
 
+function resetAiFormatState(): void {
+  if (aiFormatResetTimer !== null) {
+    clearTimeout(aiFormatResetTimer)
+    aiFormatResetTimer = null
+  }
+  aiFormatLoading.value = false
+  aiFormatDone.value = false
+  aiFormatError.value = ''
+}
+
+function scheduleAiFormatReset(): void {
+  if (aiFormatResetTimer !== null) clearTimeout(aiFormatResetTimer)
+  aiFormatResetTimer = setTimeout(() => {
+    aiFormatDone.value = false
+    aiFormatError.value = ''
+    aiFormatResetTimer = null
+  }, 3000)
+}
+
+async function requestAiFormat(): Promise<void> {
+  const text = currentClipboardContent.value?.text
+  if (!text || aiFormatLoading.value || aiFormatDone.value) return
+
+  aiFormatLoading.value = true
+  aiFormatError.value = ''
+
+  try {
+    const result = await window.ztools.superPanelAiFormat(text)
+    if (result.success && result.text) {
+      await window.ztools.copyToClipboard(result.text)
+      aiFormatDone.value = true
+      if (currentClipboardContent.value) {
+        currentClipboardContent.value = { ...currentClipboardContent.value, text: result.text }
+      }
+    } else {
+      aiFormatError.value = result.error || 'AI 整理失败'
+    }
+  } catch (e: unknown) {
+    aiFormatError.value = e instanceof Error ? e.message : 'AI 整理失败'
+  } finally {
+    aiFormatLoading.value = false
+    scheduleAiFormatReset()
+  }
+}
+
 // 获取当前显示的列表
-function getCurrentList(): (GridItem | CommandItem)[] {
-  return mode.value === 'pinned' ? pinnedCommands.value : searchResults.value
+function getCurrentList(): (GridItem | CommandItem | AiFormatItem)[] {
+  return mode.value === 'pinned' ? pinnedCommands.value : displayItems.value
 }
 
 // 启动指令（携带剪贴板内容和窗口信息）
@@ -842,9 +952,9 @@ function handleKeydown(event: KeyboardEvent): void {
         event.preventDefault()
         {
           const item = list[selectedIndex.value]
-          if (item && isFolder(item)) {
+          if (item && !('__aiFormat' in item) && isFolder(item)) {
             openFolderPopup(item, selectedIndex.value)
-          } else if (item) {
+          } else if (item && !('__aiFormat' in item)) {
             launch(item as CommandItem)
           }
         }
@@ -876,7 +986,12 @@ function handleKeydown(event: KeyboardEvent): void {
       case 'Enter':
         event.preventDefault()
         if (list[selectedIndex.value]) {
-          launch(list[selectedIndex.value] as CommandItem)
+          const selected = list[selectedIndex.value]
+          if ('__aiFormat' in selected) {
+            requestAiFormat()
+          } else {
+            launch(selected as CommandItem)
+          }
         }
         break
       case 'Escape':
@@ -948,6 +1063,7 @@ onMounted(() => {
       selectedIndex.value = 0
       currentClipboardContent.value = null
       syncTranslationForClipboardContent(null)
+      resetAiFormatState()
       scrollToTop()
     } else if (data.type === 'search') {
       mode.value = 'search'
@@ -956,6 +1072,7 @@ onMounted(() => {
       // 保存搜索结果携带的剪贴板内容
       currentClipboardContent.value = data.clipboardContent || null
       syncTranslationForClipboardContent(currentClipboardContent.value)
+      resetAiFormatState()
       scrollToTop()
     }
   })
@@ -978,6 +1095,7 @@ onMounted(() => {
         avatar.value = settings.avatar
       }
       if (settings) {
+        aiFormatFeatureEnabled.value = settings.superPanelAiFormatEnabled ?? false
         acrylicLightOpacity.value = settings.acrylicLightOpacity ?? 78
         acrylicDarkOpacity.value = settings.acrylicDarkOpacity ?? 50
         if (settings.primaryColor) {
@@ -1162,6 +1280,7 @@ onUnmounted(() => {
   document.removeEventListener('focusout', handleFocusOut)
   cleanupContextMenuListener?.()
   cleanupContextMenuListener = null
+  if (aiFormatResetTimer !== null) clearTimeout(aiFormatResetTimer)
 })
 </script>
 
@@ -1375,6 +1494,39 @@ onUnmounted(() => {
   line-clamp: 3;
   overflow: hidden;
   word-break: break-all;
+}
+
+.md-format-icon {
+  width: 28px;
+  height: 28px;
+  border-radius: 6px;
+  border: 1.5px solid var(--text-secondary);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  color: var(--text-secondary);
+}
+
+.md-format-icon-text {
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: -0.3px;
+  line-height: 1;
+}
+
+.spin-icon {
+  animation: spin 1s linear infinite;
+  flex-shrink: 0;
+}
+
+@keyframes spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 /* ========== 列表模式 ========== */

--- a/src/renderer/src/env.d.ts
+++ b/src/renderer/src/env.d.ts
@@ -353,6 +353,9 @@ declare global {
         }) => void
       ) => void
       superPanelLaunch: (command: any) => Promise<{ success: boolean; error?: string }>
+      superPanelAiFormat: (
+        text: string
+      ) => Promise<{ success: boolean; text?: string; error?: string }>
       superPanelReady: () => void
       superPanelShowPinned: () => void
       superPanelShowMainWindow: () => void


### PR DESCRIPTION
## 功能说明

本 PR 新增两个独立功能，均可在「通用设置」中按需开启。

### 1. 超级面板 AI 格式化文本

触发超级面板时，若剪贴板内容为文本，列表顶部会出现「格式化为 Markdown」选项。

- 点击或按 Enter 后，调用已配置的 AI 模型对文本做最小化 Markdown 格式修正（修复换行、规范化列表/标题语法、去除多余空行）
- 格式化结果自动写入剪贴板，可直接粘贴
- 需在「AI 模型设置」中配置 API Key，默认关闭

### 2. 剪贴板自动文本清理

复制文本时自动清理排版噪音，不改变任何文字内容：

- 统一换行符（`\r\n` / `\r` → `\n`）
- 去除零宽字符（U+200B、U+FEFF 等）
- 压缩行内多余空格（保留缩进）
- 合并连续超过 2 个的空行
- 默认关闭

## 改动文件

| 文件 | 说明 |
|---|---|
| `src/main/utils/textFormatter.ts` | 新增纯函数文本清理工具 |
| `src/main/managers/clipboardManager.ts` | 接入自动格式化逻辑 |
| `src/main/api/plugin/ai.ts` | 新增 `formatTextForSuperPanel` 方法 + OpenAI 客户端缓存 |
| `src/main/core/superPanelManager.ts` | 注册 `super-panel:ai-format` IPC handler |
| `src/main/api/plugin/internal.ts` | 注册 `internal:update-clipboard-config` IPC handler |
| `src/main/api/renderer/settings.ts` | 启动时应用剪贴板配置 |
| `src/preload/index.ts` | 暴露 `superPanelAiFormat` API |
| `resources/preload.js` | 暴露 `updateClipboardConfig` 内置插件 API |
| `src/renderer/src/components/SuperPanel.vue` | AI 格式化列表项 UI 及交互逻辑 |
| `src/renderer/src/env.d.ts` | 补充类型声明 |
| `internal-plugins/setting/src/views/GeneralSetting/GeneralSetting.vue` | 新增两个设置开关 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)