### PR TITLE
feat: 支持插件禁用功能

### DIFF
--- a/internal-plugins/setting/src/env.d.ts
+++ b/internal-plugins/setting/src/env.d.ts
@@ -40,6 +40,11 @@ declare global {
             isDevelopment?: boolean
           }>
         >
+        getDisabledPlugins: () => Promise<string[]>
+        setPluginDisabled: (
+          pluginPath: string,
+          disabled: boolean
+        ) => Promise<{ success: boolean; error?: string }>
         getAllPlugins: () => Promise<
           Array<{
             name: string

--- a/internal-plugins/setting/src/views/PluginsSetting/PluginsSetting.vue
+++ b/internal-plugins/setting/src/views/PluginsSetting/PluginsSetting.vue
@@ -14,6 +14,7 @@ const { success, error, warning, info, confirm } = useToast()
 
 // 插件相关状态
 const plugins = ref<any[]>([])
+const disabledPluginPaths = ref<string[]>([])
 const runningPlugins = ref<string[]>([])
 const isLoading = ref(true)
 const isImporting = ref(false)
@@ -101,6 +102,10 @@ function isPluginPinned(pluginPath: string): boolean {
   return pinnedPluginPaths.value.includes(pluginPath)
 }
 
+function isPluginDisabled(pluginPath: string): boolean {
+  return disabledPluginPaths.value.includes(pluginPath)
+}
+
 async function togglePin(plugin: any): Promise<void> {
   const path = plugin.path
   const idx = pinnedPluginPaths.value.indexOf(path)
@@ -122,7 +127,11 @@ async function togglePin(plugin: any): Promise<void> {
 async function loadPlugins(): Promise<void> {
   isLoading.value = true
   try {
-    const installedPlugins = await window.ztools.internal.getPlugins()
+    const [installedPlugins, disabledPlugins] = await Promise.all([
+      window.ztools.internal.getPlugins(),
+      window.ztools.internal.getDisabledPlugins()
+    ])
+    disabledPluginPaths.value = disabledPlugins
     plugins.value = buildPluginList(installedPlugins)
     await loadRunningPlugins()
   } catch (err) {
@@ -467,6 +476,11 @@ async function handleKillAllPlugins(): Promise<void> {
 
 // 打开插件
 async function handleOpenPlugin(plugin: any): Promise<void> {
+  if (isPluginDisabled(plugin.path)) {
+    warning('插件已禁用，请先在设置中启用')
+    return
+  }
+
   try {
     const result = await window.ztools.internal.launch({
       path: plugin.path,
@@ -541,6 +555,27 @@ async function handleReloadPluginFromDetail(plugin: any): Promise<void> {
     error(`重载插件失败: ${err.message || '未知错误'}`)
   } finally {
     isReloading.value = false
+  }
+}
+
+async function handleTogglePluginDisabled(plugin: any, disabled: boolean): Promise<void> {
+  try {
+    const result = await window.ztools.internal.setPluginDisabled(plugin.path, disabled)
+    if (!result.success) {
+      error(`更新插件状态失败: ${result.error || '未知错误'}`)
+      return
+    }
+
+    await loadPlugins()
+    const updated = plugins.value.find((p) => p.path === plugin.path)
+    if (updated && selectedPlugin.value?.path === plugin.path) {
+      selectedPlugin.value = updated
+    }
+
+    success(disabled ? '插件已禁用' : '插件已启用')
+  } catch (err: any) {
+    console.error('更新插件禁用状态失败:', err)
+    error(`更新插件状态失败: ${err.message || '未知错误'}`)
   }
 }
 
@@ -911,6 +946,7 @@ async function handleInstallFromNpm(data: {
                 {{ plugin.title || plugin.name }}
                 <span class="plugin-version">v{{ plugin.version }}</span>
                 <span v-if="plugin.isDevelopment" class="dev-badge">开发中</span>
+                <span v-if="isPluginDisabled(plugin.path)" class="disabled-badge">已禁用</span>
                 <span v-if="isPluginRunning(plugin.path)" class="running-badge">
                   <span class="status-dot"></span>
                   运行中
@@ -922,6 +958,7 @@ async function handleInstallFromNpm(data: {
             <div class="plugin-meta">
               <button
                 class="icon-btn open-btn"
+                :disabled="isPluginDisabled(plugin.path)"
                 title="打开插件"
                 @click.stop="handleOpenPlugin(plugin)"
               >
@@ -1057,6 +1094,7 @@ async function handleInstallFromNpm(data: {
         :plugin="selectedPlugin"
         :is-running="isPluginRunning(selectedPlugin.path)"
         :is-pinned="isPluginPinned(selectedPlugin.path)"
+        :is-disabled="isPluginDisabled(selectedPlugin.path)"
         @back="closePluginDetail"
         @open="handleOpenPlugin(selectedPlugin)"
         @uninstall="handleUninstallFromDetail(selectedPlugin)"
@@ -1065,6 +1103,7 @@ async function handleInstallFromNpm(data: {
         @package="handlePackagePlugin(selectedPlugin)"
         @reload="handleReloadPluginFromDetail(selectedPlugin)"
         @toggle-pin="togglePin(selectedPlugin)"
+        @toggle-disabled="handleTogglePluginDisabled(selectedPlugin, $event)"
       />
     </Transition>
 
@@ -1269,6 +1308,17 @@ async function handleInstallFromNpm(data: {
   padding: 2px 8px;
   border-radius: 4px;
   border: 1px solid var(--purple-border);
+}
+
+.disabled-badge {
+  display: inline-block;
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--warning-color);
+  background: color-mix(in srgb, var(--warning-color) 12%, transparent);
+  padding: 2px 8px;
+  border-radius: 4px;
+  border: 1px solid color-mix(in srgb, var(--warning-color) 35%, transparent);
 }
 
 .running-badge {

--- a/internal-plugins/setting/src/views/PluginsSetting/components/PluginDetail/PluginDetail.vue
+++ b/internal-plugins/setting/src/views/PluginsSetting/components/PluginDetail/PluginDetail.vue
@@ -37,6 +37,7 @@ const props = defineProps<{
   isLoading?: boolean
   isRunning?: boolean
   isPinned?: boolean
+  isDisabled?: boolean
 }>()
 
 const emit = defineEmits<{
@@ -50,6 +51,7 @@ const emit = defineEmits<{
   (e: 'package'): void
   (e: 'reload'): void
   (e: 'toggle-pin'): void
+  (e: 'toggle-disabled', disabled: boolean): void
 }>()
 
 const { success, error, confirm } = useToast()
@@ -168,6 +170,13 @@ async function toggleAutoStart(): Promise<void> {
 
   await window.ztools.internal.dbPut('autoStartPlugin', list)
   isAutoStart.value = list.includes(props.plugin.name)
+}
+
+function handleDisabledToggle(event: Event): void {
+  const target = event.target
+  if (!(target instanceof HTMLInputElement)) return
+  // checkbox.checked 表示"启用"状态，发射的参数表示"禁用"状态，所以取反
+  emit('toggle-disabled', !target.checked)
 }
 
 // Tab 状态
@@ -619,7 +628,12 @@ watch(
   <DetailPanel title="插件详情" @back="emit('back')">
     <template #header-right>
       <template v-if="plugin.installed && !canUpgrade">
-        <button class="icon-btn topbar-action-btn open-btn" title="打开" @click="emit('open')">
+        <button
+          class="icon-btn topbar-action-btn open-btn"
+          title="打开"
+          :disabled="isDisabled"
+          @click="emit('open')"
+        >
           <div class="i-z-play font-size-16px" />
         </button>
         <button
@@ -690,6 +704,16 @@ watch(
             <div v-if="showSettingsDropdown" class="settings-dropdown" @click.stop>
               <div class="settings-dropdown-item">
                 <div class="settings-item-info">
+                  <span class="settings-item-label">启用插件</span>
+                  <span class="settings-item-desc">关闭后插件会从搜索和运行入口中隐藏</span>
+                </div>
+                <label class="toggle">
+                  <input type="checkbox" :checked="!isDisabled" @change="handleDisabledToggle" />
+                  <span class="toggle-slider"></span>
+                </label>
+              </div>
+              <div class="settings-dropdown-item">
+                <div class="settings-item-info">
                   <span class="settings-item-label">退出即结束</span>
                   <span class="settings-item-desc">退出到后台时立即终止插件进程</span>
                 </div>
@@ -739,6 +763,7 @@ watch(
           <div class="detail-info">
             <div class="detail-title">
               <span class="detail-name">{{ plugin.title || plugin.name }}</span>
+              <span v-if="isDisabled" class="detail-disabled-badge">已禁用</span>
             </div>
             <div class="detail-desc">{{ plugin.description || '暂无描述' }}</div>
           </div>
@@ -1336,6 +1361,17 @@ watch(
   font-size: 18px;
   font-weight: 700;
   color: var(--text-color);
+}
+
+.detail-disabled-badge {
+  display: inline-block;
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--warning-color);
+  background: color-mix(in srgb, var(--warning-color) 12%, transparent);
+  padding: 2px 8px;
+  border-radius: 4px;
+  border: 1px solid color-mix(in srgb, var(--warning-color) 35%, transparent);
 }
 
 .detail-desc {

--- a/resources/preload.js
+++ b/resources/preload.js
@@ -805,6 +805,10 @@ window.ztools = {
 
     // ==================== 插件管理 API ====================
     getPlugins: async () => await electron.ipcRenderer.invoke('internal:get-plugins'),
+    getDisabledPlugins: async () =>
+      await electron.ipcRenderer.invoke('internal:get-disabled-plugins'),
+    setPluginDisabled: async (pluginPath, disabled) =>
+      await electron.ipcRenderer.invoke('internal:set-plugin-disabled', pluginPath, disabled),
     getAllPlugins: async () => await electron.ipcRenderer.invoke('internal:get-all-plugins'),
     selectPluginFile: async () => await electron.ipcRenderer.invoke('internal:select-plugin-file'),
     importPlugin: async () => await electron.ipcRenderer.invoke('internal:import-plugin'),

--- a/src/main/api/index.ts
+++ b/src/main/api/index.ts
@@ -309,7 +309,10 @@ class APIManager {
   private async handleGlobalShortcut(target: string): Promise<void> {
     try {
       const plugins: any = databaseAPI.dbGet('plugins')
-      const pluginList = Array.isArray(plugins) ? plugins : []
+      const disabledPlugins = pluginsAPI.getDisabledPluginSet()
+      const pluginList = Array.isArray(plugins)
+        ? plugins.filter((plugin: any) => !disabledPlugins.has(plugin.path))
+        : []
 
       const parts = target.split('/')
 

--- a/src/main/api/plugin/internal.ts
+++ b/src/main/api/plugin/internal.ts
@@ -157,6 +157,23 @@ export class InternalPluginAPI {
       return await (pluginsAPI as any).getPlugins()
     })
 
+    ipcMain.handle('internal:get-disabled-plugins', async (event) => {
+      if (!requireInternalPlugin(this.pluginManager, event)) {
+        throw new PermissionDeniedError('internal:get-disabled-plugins')
+      }
+      return (pluginsAPI as any).getDisabledPlugins()
+    })
+
+    ipcMain.handle(
+      'internal:set-plugin-disabled',
+      async (event, pluginPath: string, disabled: boolean) => {
+        if (!requireInternalPlugin(this.pluginManager, event)) {
+          throw new PermissionDeniedError('internal:set-plugin-disabled')
+        }
+        return await (pluginsAPI as any).setPluginDisabled(pluginPath, disabled)
+      }
+    )
+
     ipcMain.handle('internal:get-all-plugins', async (event) => {
       if (!requireInternalPlugin(this.pluginManager, event)) {
         throw new PermissionDeniedError('internal:get-all-plugins')

--- a/src/main/api/renderer/commands.ts
+++ b/src/main/api/renderer/commands.ts
@@ -292,6 +292,9 @@ export class AppsAPI {
     try {
       // 判断是插件还是直接启动
       if (type === 'plugin') {
+        if (pluginsAPI.isPluginDisabled(appPath)) {
+          return { success: false, error: '插件已禁用' }
+        }
         // 如果没有传 featureCode，自动查找第一个非匹配 feature
         if (!featureCode) {
           const result = await this.getDefaultFeatureCode(appPath)

--- a/src/main/api/renderer/plugins.ts
+++ b/src/main/api/renderer/plugins.ts
@@ -23,6 +23,7 @@ import databaseAPI from '../shared/database'
 const PLUGIN_DIR = path.join(app.getPath('userData'), 'plugins')
 const PLUGIN_MARKET_STOREFRONT_CACHE_KEY = 'plugin-market-storefront'
 const PLUGIN_MARKET_STOREFRONT_FINGERPRINT_CACHE_KEY = 'plugin-market-storefront-fingerprint'
+const DISABLED_PLUGINS_KEY = 'disabled-plugins'
 
 type PluginMarketPlugin = {
   name: string
@@ -120,6 +121,7 @@ type PluginMarketResult = {
 export class PluginsAPI {
   private mainWindow: Electron.BrowserWindow | null = null
   private pluginManager: PluginManager | null = null
+  private disabledPluginPathSet: Set<string> | null = null
 
   public init(mainWindow: Electron.BrowserWindow, pluginManager: PluginManager): void {
     this.mainWindow = mainWindow
@@ -130,6 +132,10 @@ export class PluginsAPI {
   private setupIPC(): void {
     ipcMain.handle('get-plugins', () => this.getPlugins())
     ipcMain.handle('get-all-plugins', () => this.getAllPlugins())
+    ipcMain.handle('get-disabled-plugins', () => this.getDisabledPlugins())
+    ipcMain.handle('set-plugin-disabled', (_event, pluginPath: string, disabled: boolean) =>
+      this.setPluginDisabled(pluginPath, disabled)
+    )
     ipcMain.handle('import-plugin', () => this.importPlugin())
     ipcMain.handle('import-dev-plugin', (_event, pluginJsonPath?: string) =>
       this.importDevPlugin(pluginJsonPath)
@@ -162,6 +168,9 @@ export class PluginsAPI {
       'query-main-push',
       async (_event, pluginPath: string, featureCode: string, queryData: any) => {
         try {
+          if (this.isPluginDisabled(pluginPath)) {
+            return []
+          }
           return await this.pluginManager?.queryMainPush(pluginPath, featureCode, queryData)
         } catch (error: unknown) {
           console.error('[Plugins] mainPush 查询失败:', error)
@@ -175,6 +184,9 @@ export class PluginsAPI {
       'select-main-push',
       async (_event, pluginPath: string, featureCode: string, selectData: any) => {
         try {
+          if (this.isPluginDisabled(pluginPath)) {
+            return false
+          }
           return await this.pluginManager?.selectMainPush(pluginPath, featureCode, selectData)
         } catch (error: unknown) {
           console.error('[Plugins] mainPush 选择失败:', error)
@@ -187,6 +199,9 @@ export class PluginsAPI {
       'call-headless-plugin',
       async (_event, pluginPath: string, featureCode: string, action: any) => {
         try {
+          if (this.isPluginDisabled(pluginPath)) {
+            return { success: false, error: '插件已禁用' }
+          }
           const result = await this.pluginManager?.callHeadlessPluginMethod(
             pluginPath,
             featureCode,
@@ -224,6 +239,77 @@ export class PluginsAPI {
     const allPlugins = await this.getAllPlugins()
     // 过滤掉所有内置插件（system、setting 等）
     return allPlugins.filter((plugin: any) => !isBundledInternalPlugin(plugin.name))
+  }
+
+  public getDisabledPlugins(): string[] {
+    if (this.disabledPluginPathSet) {
+      return [...this.disabledPluginPathSet]
+    }
+
+    const data = databaseAPI.dbGet(DISABLED_PLUGINS_KEY)
+    const disabledPlugins = Array.isArray(data)
+      ? data.filter((item): item is string => typeof item === 'string')
+      : []
+
+    this.disabledPluginPathSet = new Set(disabledPlugins)
+    return disabledPlugins
+  }
+
+  public getDisabledPluginSet(): Set<string> {
+    if (!this.disabledPluginPathSet) {
+      this.getDisabledPlugins()
+    }
+    // getDisabledPlugins() 确保 disabledPluginPathSet 被初始化
+    return this.disabledPluginPathSet!
+  }
+
+  public isPluginDisabled(pluginPath: string): boolean {
+    return this.getDisabledPluginSet().has(pluginPath)
+  }
+
+  public async setPluginDisabled(
+    pluginPath: string,
+    disabled: boolean
+  ): Promise<{ success: boolean; error?: string }> {
+    try {
+      const plugins = databaseAPI.dbGet('plugins')
+      if (!Array.isArray(plugins)) {
+        return { success: false, error: '插件列表不存在' }
+      }
+
+      const plugin = plugins.find((item: any) => item.path === pluginPath)
+      if (!plugin) {
+        return { success: false, error: '插件不存在' }
+      }
+      if (isBundledInternalPlugin(plugin.name)) {
+        return { success: false, error: '内置插件不能禁用' }
+      }
+
+      const disabledPlugins = this.getDisabledPluginSet()
+      const isCurrentlyDisabled = disabledPlugins.has(pluginPath)
+      if (isCurrentlyDisabled === disabled) {
+        return { success: true }
+      }
+
+      if (disabled) {
+        disabledPlugins.add(pluginPath)
+      } else {
+        disabledPlugins.delete(pluginPath)
+      }
+      this.disabledPluginPathSet = disabledPlugins
+      databaseAPI.dbPut(DISABLED_PLUGINS_KEY, [...disabledPlugins])
+
+      if (disabled && this.pluginManager) {
+        this.pluginManager.killPlugin(pluginPath)
+      }
+
+      this.mainWindow?.webContents.send('plugins-changed')
+      this.mainWindow?.webContents.send('super-panel-pinned-changed')
+      return { success: true }
+    } catch (error: unknown) {
+      console.error('[Plugins] 更新插件禁用状态失败:', error)
+      return { success: false, error: error instanceof Error ? error.message : '未知错误' }
+    }
   }
 
   // 获取所有插件列表（包括 system 插件，用于生成搜索指令）
@@ -817,6 +903,7 @@ export class PluginsAPI {
       console.log('[Plugins] =========================\n')
 
       this.mainWindow?.webContents.send('plugins-changed')
+      this.mainWindow?.webContents.send('super-panel-pinned-changed')
       return { success: true }
     } catch (error: unknown) {
       console.error('[Plugins] 添加开发中插件失败:', error)
@@ -862,6 +949,12 @@ export class PluginsAPI {
       if (newPinned.length !== pinned.length) {
         databaseAPI.dbPut('pinned-commands', newPinned)
         this.mainWindow?.webContents.send('pinned-changed')
+      }
+
+      const disabledPlugins = this.getDisabledPluginSet()
+      if (disabledPlugins.delete(pluginPath)) {
+        this.disabledPluginPathSet = disabledPlugins
+        databaseAPI.dbPut(DISABLED_PLUGINS_KEY, [...disabledPlugins])
       }
 
       await databaseAPI.clearPluginData(pluginInfo.name)

--- a/src/main/core/superPanelManager.ts
+++ b/src/main/core/superPanelManager.ts
@@ -5,6 +5,7 @@ import { is } from '@electron-toolkit/utils'
 import { MouseMonitor, WindowManager, type MouseMonitorResult } from './native/index.js'
 import { launchApp } from './commandLauncher/index.js'
 import databaseAPI from '../api/shared/database.js'
+import pluginsAPI from '../api/renderer/plugins.js'
 import windowManager from '../managers/windowManager.js'
 import clipboardManager from '../managers/clipboardManager.js'
 import { readClipboardFiles } from '../utils/clipboardFiles.js'
@@ -521,6 +522,37 @@ class SuperPanelManager {
     }
   }
 
+  private filterPinnedCommandsForDisplay(commands: any[]): any[] {
+    const disabledPluginPaths = pluginsAPI.getDisabledPluginSet()
+    const visibleCommands: any[] = []
+
+    for (const command of commands) {
+      if (command?.isFolder && Array.isArray(command.items)) {
+        const visibleItems = command.items.filter(
+          (item: any) => !(item?.type === 'plugin' && disabledPluginPaths.has(item.path))
+        )
+
+        if (visibleItems.length === 1) {
+          visibleCommands.push(visibleItems[0])
+        } else if (visibleItems.length > 1) {
+          visibleCommands.push({
+            ...command,
+            items: visibleItems
+          })
+        }
+        continue
+      }
+
+      if (command?.type === 'plugin' && disabledPluginPaths.has(command.path)) {
+        continue
+      }
+
+      visibleCommands.push(command)
+    }
+
+    return visibleCommands
+  }
+
   /**
    * 加载固定列表
    */
@@ -533,10 +565,12 @@ class SuperPanelManager {
         pinnedCommands = []
       }
 
+      const visiblePinnedCommands = this.filterPinnedCommandsForDisplay(pinnedCommands)
+
       // 发送固定列表到超级面板窗口
       this.sendToSuperPanel('super-panel-data', {
         type: 'pinned',
-        commands: pinnedCommands,
+        commands: visiblePinnedCommands,
         windowInfo: this.currentWindowInfo
       })
     } catch (error) {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -3,6 +3,7 @@ import { app, BrowserWindow, session, webContents } from 'electron'
 import log from 'electron-log'
 import path from 'path'
 import api from './api/index'
+import pluginsAPI from './api/renderer/plugins'
 import appWatcher from './appWatcher'
 import detachedWindowManager from './core/detachedWindowManager'
 import floatingBallManager from './core/floatingBallManager'
@@ -134,12 +135,13 @@ app.whenReady().then(async () => {
   if (mainWindow) {
     try {
       const autoStartPlugins = api.dbGet('autoStartPlugin')
+      const disabledPlugins = pluginsAPI.getDisabledPluginSet()
       if (autoStartPlugins && Array.isArray(autoStartPlugins) && autoStartPlugins.length > 0) {
         const plugins = api.dbGet('plugins')
         if (plugins && Array.isArray(plugins)) {
           for (const pluginName of autoStartPlugins) {
             const plugin = plugins.find((p: any) => p.name === pluginName)
-            if (plugin?.path) {
+            if (plugin?.path && !disabledPlugins.has(plugin.path)) {
               console.log('[Main] 自动启动插件:', pluginName)
               pluginManager.preloadPlugin(plugin.path).catch((error) => {
                 console.error('[Main] 自动启动插件失败:', pluginName, error)

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -48,6 +48,9 @@ const api = {
   showContextMenu: (menuItems: any[]) => ipcRenderer.invoke('show-context-menu', menuItems),
   getPlugins: () => ipcRenderer.invoke('get-plugins'),
   getAllPlugins: () => ipcRenderer.invoke('get-all-plugins'),
+  getDisabledPlugins: () => ipcRenderer.invoke('get-disabled-plugins'),
+  setPluginDisabled: (pluginPath: string, disabled: boolean) =>
+    ipcRenderer.invoke('set-plugin-disabled', pluginPath, disabled),
   importPlugin: () => ipcRenderer.invoke('import-plugin'),
   importDevPlugin: (pluginJsonPath?: string) =>
     ipcRenderer.invoke('import-dev-plugin', pluginJsonPath),
@@ -460,6 +463,11 @@ declare global {
       showContextMenu: (menuItems: any[]) => Promise<void>
       getPlugins: () => Promise<any[]>
       getAllPlugins: () => Promise<any[]>
+      getDisabledPlugins: () => Promise<string[]>
+      setPluginDisabled: (
+        pluginPath: string,
+        disabled: boolean
+      ) => Promise<{ success: boolean; error?: string }>
       importPlugin: () => Promise<{ success: boolean; error?: string }>
       importDevPlugin: (pluginJsonPath?: string) => Promise<{ success: boolean; error?: string }>
       fetchPluginMarket: () => Promise<{ success: boolean; data?: any; error?: string }>

--- a/src/renderer/src/App.vue
+++ b/src/renderer/src/App.vue
@@ -826,12 +826,10 @@ onMounted(async () => {
     })
   })
 
-  // 监听插件变化事件（安装或删除插件后刷新指令列表）
+  // 监听插件变化事件（安装、删除、禁用状态变化后刷新相关数据）
   window.ztools.onPluginsChanged(async () => {
-    console.log('插件列表已变化，重新加载指令列表和用户数据')
-    // 先刷新指令列表，再刷新历史/固定（历史过滤依赖最新的指令列表）
-    await commandDataStore.loadCommands()
-    await commandDataStore.reloadUserData()
+    console.log('插件列表已变化，重新加载插件可用性相关数据')
+    await commandDataStore.reloadPluginAvailabilityData()
   })
 
   // 监听更新下载完成事件

--- a/src/renderer/src/env.d.ts
+++ b/src/renderer/src/env.d.ts
@@ -68,6 +68,11 @@ declare global {
       showContextMenu: (menuItems: any[]) => Promise<void>
       getPlugins: () => Promise<any[]>
       getAllPlugins: () => Promise<any[]>
+      getDisabledPlugins: () => Promise<string[]>
+      setPluginDisabled: (
+        pluginPath: string,
+        disabled: boolean
+      ) => Promise<{ success: boolean; error?: string }>
       importPlugin: () => Promise<{ success: boolean; error?: string }>
       importDevPlugin: () => Promise<{ success: boolean; error?: string }>
       fetchPluginMarket: () => Promise<{

--- a/src/renderer/src/stores/commandDataStore.ts
+++ b/src/renderer/src/stores/commandDataStore.ts
@@ -167,6 +167,19 @@ export const useCommandDataStore = defineStore('commandData', () => {
   // 禁用指令列表
   const disabledCommands = ref<string[]>([])
   const DISABLED_COMMANDS_KEY = 'disable-commands'
+  const disabledPluginPaths = ref<string[]>([])
+
+  function setDisabledPluginPaths(paths: unknown): void {
+    disabledPluginPaths.value = Array.isArray(paths)
+      ? paths.filter((item): item is string => typeof item === 'string')
+      : []
+  }
+
+  function getEnabledPluginPaths(plugins: any[], disabledPaths?: string[]): Set<string> {
+    const paths = disabledPaths ?? disabledPluginPaths.value
+    const disabledPluginPathSet = new Set(paths)
+    return new Set(plugins.filter((plugin: any) => !disabledPluginPathSet.has(plugin.path)).map((p: any) => p.path))
+  }
   // 搜索偏好记录（搜索词 -> 上次选中的指令标识）
   const searchPreference = ref<
     Record<string, { path: string; featureCode?: string; name: string }>
@@ -216,6 +229,16 @@ export const useCommandDataStore = defineStore('commandData', () => {
     }
   }
 
+  async function loadDisabledPlugins(): Promise<void> {
+    try {
+      const data = await window.ztools.getDisabledPlugins()
+      setDisabledPluginPaths(data)
+    } catch (error) {
+      console.error('加载禁用插件列表失败:', error)
+      disabledPluginPaths.value = []
+    }
+  }
+
   // 加载搜索偏好记录
   async function loadSearchPreference(): Promise<void> {
     try {
@@ -259,7 +282,7 @@ export const useCommandDataStore = defineStore('commandData', () => {
 
     try {
       // 先加载禁用指令列表和指令列表，再加载历史记录和固定列表（历史记录清理需要依赖指令列表）
-      await loadDisabledCommands()
+      await Promise.all([loadDisabledCommands(), loadDisabledPlugins()])
       await loadCommands()
       await Promise.all([
         loadHistoryData(),
@@ -376,13 +399,12 @@ export const useCommandDataStore = defineStore('commandData', () => {
       ])
 
       if (data && Array.isArray(data)) {
-        // 获取所有已安装插件的路径 Set
-        const installedPluginPaths = new Set(plugins.map((p: any) => p.path))
+        const enabledPluginPaths = getEnabledPluginPaths(plugins)
 
-        // 过滤掉已卸载的插件
+        // 过滤掉已卸载或已禁用的插件
         const filteredData = data.filter((item: any) => {
           if (item.type === 'plugin') {
-            return installedPluginPaths.has(item.path)
+            return enabledPluginPaths.has(item.path)
           }
           return true
         })
@@ -402,14 +424,22 @@ export const useCommandDataStore = defineStore('commandData', () => {
     await Promise.all([loadHistoryData(), loadPinnedData()])
   }
 
+  async function reloadPluginAvailabilityData(): Promise<void> {
+    await Promise.all([loadCommands(), reloadUserData()])
+  }
+
   // 加载指令列表
   async function loadCommands(): Promise<void> {
     loading.value = true
     try {
-      const [rawApps, plugins] = await Promise.all([
+      const [rawApps, plugins, disabledPlugins] = await Promise.all([
         window.ztools.getApps(),
-        window.ztools.getAllPlugins() // 使用 getAllPlugins 获取所有插件（包括 system）
+        window.ztools.getAllPlugins(), // 使用 getAllPlugins 获取所有插件（包括 system）
+        window.ztools.getDisabledPlugins()
       ])
+      setDisabledPluginPaths(disabledPlugins)
+      const enabledPluginPaths = getEnabledPluginPaths(plugins)
+      const enabledPlugins = plugins.filter((plugin: any) => enabledPluginPaths.has(plugin.path))
 
       // 处理本地应用指令
       const appItems = rawApps.flatMap((app) => {
@@ -454,7 +484,7 @@ export const useCommandDataStore = defineStore('commandData', () => {
       const regexItems: Command[] = [] // 正则匹配指令
       const mainPushItems: MainPushFeature[] = [] // mainPush 功能列表
 
-      for (const plugin of plugins) {
+      for (const plugin of enabledPlugins) {
         if (plugin.features && Array.isArray(plugin.features) && plugin.features.length > 0) {
           // 检查是否有 feature 的 cmd 名称与插件名称相同
           const hasPluginNameCmd = plugin.features.some((feature: any) =>
@@ -1034,22 +1064,28 @@ export const useCommandDataStore = defineStore('commandData', () => {
   // 获取最近使用（自动同步最新数据）
   function getRecentCommands(limit?: number): Command[] {
     // 同步历史记录数据，确保使用最新的路径和图标
-    const syncedHistory = history.value.map((historyItem) => {
-      // 尝试从当前列表中找到
-      const currentCommand = commands.value.find(
-        (app) =>
-          app.name === historyItem.name &&
-          app.type === historyItem.type &&
-          app.subType === historyItem.subType &&
-          app.featureCode === historyItem.featureCode
-      )
+    const syncedHistory = history.value
+      .map((historyItem) => {
+        // 尝试从当前列表中找到
+        const currentCommand = commands.value.find(
+          (app) =>
+            app.name === historyItem.name &&
+            app.type === historyItem.type &&
+            app.subType === historyItem.subType &&
+            app.featureCode === historyItem.featureCode
+        )
 
-      // 如果找到了最新数据，使用最新的；否则使用历史记录
-      const command = currentCommand || historyItem
+        // 如果找不到最新数据，说明命令已不可用（如插件被禁用），直接过滤掉
+        if (!currentCommand && historyItem.type === 'plugin') {
+          return null
+        }
 
-      // 应用特殊指令配置（统一处理）
-      return applySpecialConfig(command)
-    })
+        const command = currentCommand || historyItem
+
+        // 应用特殊指令配置（统一处理）
+        return applySpecialConfig(command)
+      })
+      .filter((item): item is Command => item !== null)
 
     if (limit) {
       return syncedHistory.slice(0, limit)
@@ -1123,19 +1159,25 @@ export const useCommandDataStore = defineStore('commandData', () => {
   // 获取固定列表（自动同步最新数据）
   function getPinnedCommands(): Command[] {
     // 同步固定列表的数据，确保使用最新的路径和图标
-    return pinnedCommands.value.map((pinnedItem) => {
-      // 尝试从当前列表中找到
-      const currentCommand = commands.value.find(
-        (cmd) =>
-          cmd.name === pinnedItem.name &&
-          cmd.type === pinnedItem.type &&
-          cmd.subType === pinnedItem.subType &&
-          cmd.featureCode === pinnedItem.featureCode
-      )
+    return pinnedCommands.value
+      .map((pinnedItem) => {
+        // 尝试从当前列表中找到
+        const currentCommand = commands.value.find(
+          (cmd) =>
+            cmd.name === pinnedItem.name &&
+            cmd.type === pinnedItem.type &&
+            cmd.subType === pinnedItem.subType &&
+            cmd.featureCode === pinnedItem.featureCode
+        )
 
-      // 如果找到了最新数据，使用最新的；否则使用固定列表中的
-      return currentCommand || pinnedItem
-    })
+        // 如果插件当前不可用（如被禁用），则不展示
+        if (!currentCommand && pinnedItem.type === 'plugin') {
+          return null
+        }
+
+        return currentCommand || pinnedItem
+      })
+      .filter((item): item is Command => item !== null)
   }
 
   // 更新固定列表顺序
@@ -1291,6 +1333,9 @@ export const useCommandDataStore = defineStore('commandData', () => {
     superPanelPinned,
     loadSuperPanelPinnedData,
     isPinnedToSuperPanel,
+
+    // 插件可用性刷新
+    reloadPluginAvailabilityData,
 
     // 搜索偏好
     saveSearchPreference


### PR DESCRIPTION
resolve #250
- 新增插件禁用/启用 API（getDisabledPlugins、setPluginDisabled）
- 设置页面新增插件启用开关和"已禁用"标识
- 禁用插件在搜索结果、历史记录、固定列表、超级面板中隐藏
- 禁用插件无法通过启动入口打开
- 禁用插件不会在应用启动时自动启动
- 卸载插件时自动清理禁用状态