### PR TITLE
fix(system): 改用 PowerShell 明确触发 Windows 睡眠

### DIFF
--- a/src/main/api/renderer/systemCommands.ts
+++ b/src/main/api/renderer/systemCommands.ts
@@ -62,9 +62,8 @@ export async function executeSystemCommand(
       if (platform === 'darwin') {
         cmd = 'osascript -e "tell application \\"System Events\\" to sleep"'
       } else if (platform === 'win32') {
-        cmd =
-          `powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass -Command "Add-Type -AssemblyName System.Windows.Forms; ` +
-          `[System.Windows.Forms.Application]::SetSuspendState('Suspend', $false, $false)"`
+        ctx.mainWindow?.hide()
+        cmd = `powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass -WindowStyle Hidden -Command "Add-Type -AssemblyName System.Windows.Forms; [System.Windows.Forms.Application]::SetSuspendState('Suspend', $false, $false)"`
       }
       break
 


### PR DESCRIPTION
## 问题

在我的 WinToGo 环境里，原来的 `rundll32.exe powrprof.dll,SetSuspendState ...` 写法会导致执行 `sleep` 指令后系统自动重启，而使用系统自带的睡眠不会出现这个问题。

## 解决

将 Windows 平台的睡眠实现改为通过 PowerShell 直接调用 `SetSuspendState('Suspend', ...)`，明确指定进入睡眠状态。

## 结果

修改后，这个自动重启的问题不再出现，`sleep` 指令的行为也和系统自带的睡眠保持一致。
