### PR TITLE
Feature 插件下载列表

### DIFF
--- a/internal-plugins/setting/src/views/PluginMarketSetting/PluginMarketSetting.vue
+++ b/internal-plugins/setting/src/views/PluginMarketSetting/PluginMarketSetting.vue
@@ -221,7 +221,7 @@ async function fetchPlugins(): Promise<void> {
 }
 
 async function loadDownloadList(): Promise<void> {
-  let downListRecord = db.get('downList')
+  let downListRecord = await db.get('downList')
   downloadList.value = JSON.parse(downListRecord?.list || '[]') as Plugin[]
   const typeInstalledPluginsList = await Promise.resolve(window.ztools.internal.getPlugins())
   downloadList.value.forEach((plugin) => {
@@ -248,8 +248,12 @@ async function loadDownloadList(): Promise<void> {
 }
 
 // 更新数据库中的插件状态
-function updatePluginStatusInDb(pluginName: string, status: string, progress: number = 0): void {
-  const downListRecord = db.get('downList')
+async function updatePluginStatusInDb(
+  pluginName: string,
+  status: string,
+  progress: number = 0
+): Promise<void> {
+  const downListRecord = await db.get('downList')
   if (downListRecord) {
     const list = JSON.parse(downListRecord.list) as Plugin[]
     const plugin = list.find((p) => p.name === pluginName)
@@ -286,11 +290,11 @@ async function retryFailedDownload(pluginName: string): Promise<void> {
 }
 
 // 从下载列表删除
-function removeFromDownloadList(pluginName: string): void {
+async function removeFromDownloadList(pluginName: string): Promise<void> {
   const index = downloadList.value.findIndex((p) => p.name === pluginName)
   if (index !== -1) {
     downloadList.value.splice(index, 1)
-    const downListRecord = db.get('downList')
+    const downListRecord = await db.get('downList')
     if (downListRecord) {
       const list = JSON.parse(downListRecord.list) as Plugin[]
       const pluginIndex = list.findIndex((p) => p.name === pluginName)
@@ -425,7 +429,7 @@ async function handleUpgradePlugin(plugin: Plugin): Promise<void> {
 
 // 将插件加入待安装列表（仅 UI 状态，实际安装在 downloadPlugin 中处理）
 async function addPlugin2DownList(plugin: Plugin): Promise<void> {
-  let downList = db.get('downList')
+  let downList = await db.get('downList')
   let list: Plugin[] = []
   if (!downList) {
     downList = {

--- a/internal-plugins/setting/src/views/PluginMarketSetting/PluginMarketSetting.vue
+++ b/internal-plugins/setting/src/views/PluginMarketSetting/PluginMarketSetting.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
-import { computed, onMounted, onUnmounted, ref } from 'vue'
-import { useToast } from '@/components'
+import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
+import { useToast, AdaptiveIcon } from '@/components'
 import {
   compareVersions,
   shuffleArray,
@@ -11,7 +11,7 @@ import { PluginDetail, PluginCard, CategoryCard, CategoryDetail, RefreshButton }
 import type { Plugin, CategoryInfo, CategoryLayoutSection } from './components'
 import { useJumpFunction, useZtoolsSubInput } from '@/composables'
 import { PluginMarketSettingJumpFunction } from '@/views/PluginMarketSetting/PluginMarketSetting'
-
+import { db } from '@ztools-center/ztools-api-types'
 const { success, error, confirm } = useToast()
 
 interface BannerItem {
@@ -77,6 +77,10 @@ const storefrontCategories = ref<Record<string, CategoryInfo>>({})
 const categoryLayouts = ref<Record<string, CategoryLayoutSection[]>>({})
 const isLoading = ref(false)
 const installingPlugin = ref<string | null>(null)
+const activeTab = ref<'market' | 'download'>('market')
+const downloadList = ref<Plugin[]>([])
+// 下载队列检查定时器
+let downloadQueueTimer: number | null = null
 
 const { value: searchQuery, setSubInput } = useZtoolsSubInput('', '搜索插件市场...')
 
@@ -105,7 +109,6 @@ const selectedCategory = ref<CategoryInfo | null>(null)
 const showScrollableContent = computed(
   () => !isDetailVisible.value && !isCategoryDetailVisible.value
 )
-
 // 将市场插件数据标记已安装状态
 function enrichPlugins(
   marketPlugins: MarketPlugin[],
@@ -132,13 +135,13 @@ async function fetchPlugins(): Promise<void> {
   isLoading.value = true
   try {
     const currentPlatform = window.ztools.internal.getPlatform()
-    const [marketResult, installedPlugins] = await Promise.all([
+    const [marketResult, installedPluginsList] = await Promise.all([
       window.ztools.internal.fetchPluginMarket(),
       window.ztools.internal.getPlugins()
     ])
 
+    const typedInstalledPlugins = installedPluginsList as InstalledPlugin[]
     const typedMarketResult = marketResult as PluginMarketResponse
-    const typedInstalledPlugins = installedPlugins as InstalledPlugin[]
 
     if (typedMarketResult.success && typedMarketResult.data) {
       const marketPlugins = typedMarketResult.data
@@ -214,6 +217,118 @@ async function fetchPlugins(): Promise<void> {
     console.error('获取插件列表出错:', error)
   } finally {
     isLoading.value = false
+  }
+}
+
+async function loadDownloadList(): Promise<void> {
+  let downListRecord = db.get('downList')
+  downloadList.value = JSON.parse(downListRecord?.list || '[]') as Plugin[]
+  const typeInstalledPluginsList = await Promise.resolve(window.ztools.internal.getPlugins())
+  downloadList.value.forEach((plugin) => {
+    const installedPlugin = typeInstalledPluginsList.find((p) => p.name === plugin.name)
+    if (installedPlugin) {
+      plugin.status = 'installed'
+      plugin.installed = true
+      plugin.path = installedPlugin.path
+      // console.log(`插件 ${plugin.title} 已安装，状态设置为 ${plugin.status}`)
+    } else {
+      plugin.installed = false
+      // console.log(`插件 ${plugin.title} 未安装，状态设置为 ${plugin.status}`)
+    }
+  })
+  if (downListRecord) {
+    downListRecord.list = JSON.stringify(downloadList.value)
+    db.put(downListRecord)
+  } else {
+    db.put({
+      _id: 'downList',
+      list: JSON.stringify(downloadList.value)
+    })
+  }
+}
+
+// 更新数据库中的插件状态
+function updatePluginStatusInDb(pluginName: string, status: string, progress: number = 0): void {
+  const downListRecord = db.get('downList')
+  if (downListRecord) {
+    const list = JSON.parse(downListRecord.list) as Plugin[]
+    const plugin = list.find((p) => p.name === pluginName)
+    if (plugin) {
+      plugin.status = status as any
+      if (status === 'installed') {
+        plugin.installed = true
+      } else {
+        plugin.installed = false
+      }
+      plugin.progress = progress
+      downListRecord.list = JSON.stringify(list)
+      db.put(downListRecord)
+      // 更新内存中的状态
+      const memoryPlugin = downloadList.value.find((p) => p.name === pluginName)
+      if (memoryPlugin) {
+        memoryPlugin.status = status as any
+        memoryPlugin.progress = progress
+      }
+    }
+  }
+}
+
+// 重试失败的下载
+async function retryFailedDownload(pluginName: string): Promise<void> {
+  const installedPluginsList = await Promise.resolve(window.ztools.internal.getPlugins())
+  const typedInstalledPlugins = installedPluginsList as InstalledPlugin[]
+  const plugin = downloadList.value.find((p) => p.name === pluginName)
+  const exsits = typedInstalledPlugins.some((p) => p.name === pluginName)
+  if (!exsits && plugin) {
+    plugin.errorMessage = undefined
+    updatePluginStatusInDb(pluginName, 'waiting', 0)
+  }
+}
+
+// 从下载列表删除
+function removeFromDownloadList(pluginName: string): void {
+  const index = downloadList.value.findIndex((p) => p.name === pluginName)
+  if (index !== -1) {
+    downloadList.value.splice(index, 1)
+    const downListRecord = db.get('downList')
+    if (downListRecord) {
+      const list = JSON.parse(downListRecord.list) as Plugin[]
+      const pluginIndex = list.findIndex((p) => p.name === pluginName)
+      if (pluginIndex !== -1) {
+        list.splice(pluginIndex, 1)
+        downListRecord.list = JSON.stringify(list)
+        db.put(downListRecord)
+      }
+    }
+  }
+}
+
+// 检查下载队列并启动下载的函数
+function checkDownloadQueue(): void {
+  // 只有在有下载列表数据时才检查
+  if (downloadList.value.length > 0) {
+    // 查找第一个状态为 'waiting' 的插件
+    const nextPlugin = downloadList.value.find((plugin) => plugin.status === 'waiting')
+    if (nextPlugin && !installingPlugin.value) {
+      downloadPlugin(nextPlugin)
+    }
+  }
+}
+
+// 启动下载队列检查定时器
+function startDownloadQueueTimer(): void {
+  if (downloadQueueTimer) {
+    clearInterval(downloadQueueTimer)
+  }
+  // 每1秒检查一次下载队列
+  downloadQueueTimer = window.setInterval(checkDownloadQueue, 1000)
+}
+
+// 停止下载队列检查定时器
+function stopDownloadQueueTimer(): void {
+  if (downloadQueueTimer) {
+    clearInterval(downloadQueueTimer)
+    downloadQueueTimer = null
   }
 }
 
@@ -308,25 +423,63 @@ async function handleUpgradePlugin(plugin: Plugin): Promise<void> {
   }
 }
 
+// 将插件加入待安装列表（仅 UI 状态，实际安装在 downloadPlugin 中处理）
+async function addPlugin2DownList(plugin: Plugin): Promise<void> {
+  let downList = db.get('downList')
+  let list: Plugin[] = []
+  if (!downList) {
+    downList = {
+      _id: 'downList',
+      list: JSON.stringify(list)
+    }
+  } else {
+    list = JSON.parse(downList.list) as Plugin[]
+  }
+  const exists = list.some((p) => p.name === plugin.name)
+  if (!exists) {
+    plugin.status = 'waiting'
+    plugin.progress = 0
+    list.push(plugin)
+    downList.list = JSON.stringify(list)
+    db.put(downList)
+  } else {
+    //todo 如果已存在，且之前下载失败了，这次重新加入下载，状态改为等待中
+    list = list.map((p) => {
+      if (p.name === plugin.name) {
+        return { ...p, status: 'waiting' }
+      }
+      return p
+    })
+    downList.list = JSON.stringify(list)
+    db.put(downList)
+  }
+  downloadList.value = list
+  success(`插件 ${plugin.title} 已加入下载列表`)
+}
+
 async function downloadPlugin(plugin: Plugin): Promise<void> {
   if (installingPlugin.value) return
 
   installingPlugin.value = plugin.name
   try {
+    updatePluginStatusInDb(plugin.name, 'downloading')
     const result = await window.ztools.internal.installPluginFromMarket(
       JSON.parse(JSON.stringify(plugin))
     )
     if (result.success) {
       plugin.installed = true
       plugin.localVersion = plugin.version
+      updatePluginStatusInDb(plugin.name, 'installed', 100)
       if (result.plugin && result.plugin.path) {
         plugin.path = result.plugin.path
       }
     } else {
+      updatePluginStatusInDb(plugin.name, 'failed', 0)
       console.error('插件安装失败:', result.error)
       error(`安装失败: ${result.error}`)
     }
   } catch (err: unknown) {
+    updatePluginStatusInDb(plugin.name, 'failed', 0)
     console.error('安装出错:', err)
     error(`安装出错: ${err instanceof Error ? err.message : '未知错误'}`)
   } finally {
@@ -410,20 +563,47 @@ useJumpFunction<PluginMarketSettingJumpFunction>((state) => {
   }
 })
 
+watch(activeTab, (tab) => {
+  if (tab === 'download') {
+    loadDownloadList()
+  }
+})
+
 onMounted(() => {
   fetchPlugins()
+  loadDownloadList()
+  // 启动下载队列检查定时器
+  startDownloadQueueTimer()
   window.addEventListener('keydown', handleKeydown, true)
 })
 
 onUnmounted(() => {
+  // 停止下载队列检查定时器
+  stopDownloadQueueTimer()
   window.removeEventListener('keydown', handleKeydown, true)
 })
 </script>
 <template>
   <div class="plugin-market">
     <!-- 可滚动内容区 -->
+    <div v-show="showScrollableContent" class="tab-header">
+      <div class="tab-group">
+        <button
+          :class="['tab-btn', { active: activeTab === 'market' }]"
+          @click="activeTab = 'market'"
+        >
+          插件商店
+        </button>
+        <button
+          :class="['tab-btn', { active: activeTab === 'download' }]"
+          @click="activeTab = 'download'"
+        >
+          下载列表
+        </button>
+      </div>
+    </div>
     <Transition name="list-slide">
-      <div v-show="showScrollableContent" class="scrollable-content">
+      <div v-show="showScrollableContent && activeTab === 'market'" class="scrollable-content">
         <div v-if="isLoading" class="loading-state">
           <div class="loading-spinner"></div>
           <span>加载中...</span>
@@ -458,7 +638,7 @@ onUnmounted(() => {
               :can-upgrade="canUpgrade(plugin)"
               @click="openPluginDetail(plugin)"
               @open="handleOpenPlugin(plugin)"
-              @download="downloadPlugin(plugin)"
+              @download="addPlugin2DownList(plugin)"
               @upgrade="handleUpgradePlugin(plugin)"
             />
           </div>
@@ -522,7 +702,7 @@ onUnmounted(() => {
                     :can-upgrade="canUpgrade(plugin)"
                     @click="openPluginDetail(plugin)"
                     @open="handleOpenPlugin(plugin)"
-                    @download="downloadPlugin(plugin)"
+                    @download="addPlugin2DownList(plugin)"
                     @upgrade="handleUpgradePlugin(plugin)"
                   />
                 </div>
@@ -560,9 +740,121 @@ onUnmounted(() => {
               :can-upgrade="canUpgrade(plugin)"
               @click="openPluginDetail(plugin)"
               @open="handleOpenPlugin(plugin)"
-              @download="downloadPlugin(plugin)"
+              @download="addPlugin2DownList(plugin)"
               @upgrade="handleUpgradePlugin(plugin)"
             />
+          </div>
+        </template>
+      </div>
+    </Transition>
+
+    <Transition name="list-slide">
+      <div v-show="showScrollableContent && activeTab === 'download'" class="scrollable-content">
+        <template v-if="downloadList">
+          <div v-if="downloadList.length === 0" class="empty-state">
+            <svg
+              width="48"
+              height="48"
+              viewBox="0 0 24 24"
+              fill="none"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <circle cx="11" cy="11" r="7" stroke="currentColor" stroke-width="2" />
+              <path
+                d="M16 16L20 20"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+              />
+            </svg>
+            <span>暂无下载列表</span>
+          </div>
+          <div v-else class="download-list">
+            <div
+              v-for="plugin in downloadList"
+              :key="plugin.name"
+              class="download-item"
+              @click="openPluginDetail(plugin)"
+            >
+              <div class="download-item-content">
+                <div class="download-item-icon">
+                  <AdaptiveIcon
+                    :src="plugin.logo ?? ''"
+                    class="download-item-logo"
+                    alt="icon"
+                    draggable="false"
+                  />
+                </div>
+                <div class="download-item-info">
+                  <div class="download-item-name">{{ plugin.title || plugin.name }}</div>
+                  <div class="download-item-description">{{ plugin.description }}</div>
+                </div>
+              </div>
+
+              <!-- 状态显示区域 -->
+              <div class="download-item-status">
+                <!-- waiting 状态 -->
+                <template v-if="plugin.status === 'waiting'">
+                  <span :class="`status-text status-waiting`"> 等待中 </span>
+                </template>
+
+                <!-- downloading 状态 -->
+                <template v-else-if="plugin.status === 'downloading'">
+                  <div class="progress-container">
+                    <div class="progress-bar">
+                      <div class="progress-fill" :style="{ width: `${plugin.progress}%` }"></div>
+                    </div>
+                    <span class="progress-text">{{ Math.round(plugin.progress) }}%</span>
+                  </div>
+                </template>
+
+                <!-- installed 状态 -->
+                <template v-else-if="plugin.status === 'downloaded'">
+                  <div v-if="plugin.installed" class="installed-container">
+                    <span :class="`status-text status-installed`"> 已下载完成 </span>
+                  </div>
+                </template>
+                <!-- installed 状态 -->
+                <template v-else-if="plugin.status === 'installed'">
+                  <div v-if="plugin.installed" class="installed-container">
+                    <span :class="`status-text status-installed`"> ✓ 已安装 </span>
+                  </div>
+                </template>
+
+                <!-- failed 状态 -->
+                <template
+                  v-if="
+                    plugin.status === 'failed' ||
+                    (plugin.status === 'installed' && !plugin.installed)
+                  "
+                >
+                  <div class="failed-container">
+                    <div class="failed-info">
+                      <span :class="`status-text status-failed`"> 失败或已卸载 </span>
+                      <span v-if="plugin.errorMessage" class="error-msg">{{
+                        plugin.errorMessage
+                      }}</span>
+                    </div>
+                    <div class="btn-group">
+                      <button
+                        class="btn-action btn-retry"
+                        title="重试"
+                        @click.stop="retryFailedDownload(plugin.name)"
+                      >
+                        🔄
+                      </button>
+                      <button
+                        class="btn-action btn-delete"
+                        title="删除"
+                        @click.stop="removeFromDownloadList(plugin.name)"
+                      >
+                        🗑
+                      </button>
+                    </div>
+                  </div>
+                </template>
+              </div>
+            </div>
           </div>
         </template>
       </div>
@@ -584,7 +876,7 @@ onUnmounted(() => {
           @back="closeCategoryDetail"
           @click-plugin="openPluginDetail"
           @open-plugin="handleOpenPlugin"
-          @download-plugin="downloadPlugin"
+          @download-plugin="addPlugin2DownList"
           @upgrade-plugin="handleUpgradePlugin"
         />
       </div>
@@ -598,7 +890,7 @@ onUnmounted(() => {
         :is-loading="installingPlugin === selectedPlugin.name"
         @back="closePluginDetail"
         @open="handleOpenPlugin(selectedPlugin)"
-        @download="downloadPlugin(selectedPlugin)"
+        @download="addPlugin2DownList(selectedPlugin)"
         @upgrade="handleUpgradePlugin(selectedPlugin)"
         @uninstall="handleUninstallPlugin(selectedPlugin)"
       />
@@ -618,7 +910,10 @@ onUnmounted(() => {
 /* 可滚动内容区 */
 .scrollable-content {
   position: absolute;
-  inset: 0;
+  top: 60px;
+  left: 0;
+  right: 0;
+  bottom: 0;
   overflow-y: auto;
   overflow-x: hidden;
   padding: 20px;
@@ -787,5 +1082,235 @@ onUnmounted(() => {
   to {
     transform: rotate(360deg);
   }
+}
+
+/* 下载列表项 */
+.download-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px;
+  border: 1px solid var(--divider-color);
+  border-radius: 6px;
+  margin-bottom: 8px;
+  transition: all 0.2s;
+}
+
+.download-item:hover {
+  background: var(--hover-bg);
+  border-color: var(--primary-color);
+}
+
+.download-item-content {
+  display: flex;
+  align-items: center;
+  flex: 1;
+  min-width: 0;
+  cursor: pointer;
+}
+
+.download-item-icon {
+  flex-shrink: 0;
+  margin-right: 12px;
+}
+
+.download-item-logo {
+  width: 48px;
+  height: 48px;
+  border-radius: 6px;
+  object-fit: cover;
+}
+
+.download-item-info {
+  flex: 1;
+  min-width: 0;
+}
+
+.download-item-name {
+  font-weight: 500;
+  font-size: 14px;
+  color: var(--text-primary);
+  margin-bottom: 4px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.download-item-description {
+  font-size: 12px;
+  color: var(--text-secondary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.download-item-status {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
+  margin-left: 12px;
+}
+
+.status-text {
+  font-size: 12px;
+  font-weight: 500;
+  padding: 4px 8px;
+  border-radius: 4px;
+  white-space: nowrap;
+  display: inline-block;
+}
+
+.status-waiting {
+  color: var(--warning-color, #f59e0b);
+  background: rgba(245, 158, 11, 0.1);
+}
+
+.status-downloading {
+  color: var(--primary-color, #3b82f6);
+  background: rgba(59, 130, 246, 0.1);
+}
+
+.status-installed {
+  color: var(--success-color, #10b981);
+  background: rgba(16, 185, 129, 0.1);
+}
+
+.status-failed {
+  color: var(--error-color, #ef4444);
+  background: rgba(239, 68, 68, 0.1);
+}
+
+.progress-container {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 100px;
+}
+
+.progress-bar {
+  width: 80px;
+  height: 4px;
+  background: var(--bg-secondary, #f0f0f0);
+  border-radius: 2px;
+  overflow: hidden;
+  flex-shrink: 0;
+}
+
+.progress-fill {
+  height: 100%;
+  background: var(--primary-color, #3b82f6);
+  transition: width 0.3s ease;
+}
+
+.progress-text {
+  font-size: 11px;
+  color: var(--text-secondary);
+  font-weight: 500;
+  min-width: 28px;
+  text-align: right;
+}
+
+.failed-container {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.failed-info {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 2px;
+}
+
+.error-msg {
+  font-size: 11px;
+  color: var(--error-color, #ef4444);
+  max-width: 150px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.btn-group {
+  display: flex;
+  gap: 4px;
+}
+
+.btn-action {
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  border: 1px solid var(--divider-color);
+  background: var(--bg-color);
+  border-radius: 4px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 14px;
+  transition: all 0.2s;
+  flex-shrink: 0;
+}
+
+.btn-action:hover {
+  background: var(--hover-bg);
+  border-color: var(--primary-color);
+}
+
+.btn-retry {
+  color: var(--primary-color, #3b82f6);
+}
+
+.btn-delete {
+  color: var(--error-color, #ef4444);
+}
+
+.tab-header {
+  position: sticky;
+  top: 0;
+  left: 0;
+  right: 0;
+  gap: 8px;
+  padding: 12px 20px;
+  background: var(--bg-color);
+  z-index: 5;
+}
+
+.tab-group {
+  display: flex;
+  gap: 6px;
+  background: var(--control-bg);
+  padding: 3px;
+  border-radius: 8px;
+}
+
+.tab-btn {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex: 1;
+  justify-content: center;
+  padding: 6px 14px;
+  font-size: 13px;
+  border: none;
+  background: transparent;
+  color: var(--text-secondary);
+  border-radius: 6px;
+  cursor: pointer;
+  transition: all 0.2s;
+  font-weight: 500;
+}
+
+.tab-btn:hover {
+  background: var(--hover-bg);
+  color: var(--text-color);
+}
+
+.tab-btn.active {
+  background: var(--active-bg);
+  color: var(--primary-color);
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
 }
 </style>

--- a/internal-plugins/setting/src/views/PluginMarketSetting/components/types.ts
+++ b/internal-plugins/setting/src/views/PluginMarketSetting/components/types.ts
@@ -12,6 +12,9 @@ export interface Plugin {
   installed: boolean
   path?: string
   localVersion?: string
+  status: 'waiting' | 'downloading' | 'downloaded' | 'installed' | 'failed'
+  progress: number
+  errorMessage?: string
 }
 
 export interface CategoryInfo {

--- a/src/main/api/renderer/systemCommands.ts
+++ b/src/main/api/renderer/systemCommands.ts
@@ -2,6 +2,7 @@ import { exec, spawn } from 'child_process'
 import type { PluginManager } from '../../managers/pluginManager'
 import { BrowserWindow, clipboard, nativeImage, Notification, shell } from 'electron'
 import { promisify } from 'util'
+import os from 'os'
 import { GLOBAL_SCROLLBAR_CSS } from '../../core/globalStyles'
 import { screenCapture } from '../../core/screenCapture'
 import windowManager from '../../managers/windowManager'
@@ -447,11 +448,11 @@ async function handleOpenTerminal(
   } else if (process.platform === 'linux') {
     try {
       // 获取当前用户主目录作为默认路径
-      const folderPath = require('os').homedir()
+      const folderPath = os.homedir()
 
       // 依次尝试常用的终端启动方式，由于 spawn 不会像 exec 那样容易受到注入攻击
       // 我们通过尝试启动不同的进程来实现兼容性
-      const tryLaunch = (cmd: string, args: string[]) => {
+      const tryLaunch = (cmd: string, args: string[]): Promise<boolean> => {
         return new Promise<boolean>((resolve) => {
           const child = spawn(cmd, args, { detached: true, stdio: 'ignore' })
           child.on('error', () => resolve(false))

--- a/src/main/utils/download.ts
+++ b/src/main/utils/download.ts
@@ -1,7 +1,11 @@
 import { net, session } from 'electron'
-import { promises as fs } from 'fs'
+import { createWriteStream } from 'fs'
 
-export async function downloadFile(url: string, filePath: string): Promise<void> {
+export async function downloadFile(
+  url: string,
+  filePath: string,
+  progressCallback?: (percent: number) => void
+): Promise<void> {
   return new Promise<void>((resolve, reject) => {
     const request = net.request({
       url,
@@ -35,22 +39,50 @@ export async function downloadFile(url: string, filePath: string): Promise<void>
       'user-agent',
       'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36 Edg/142.0.0.0'
     )
-
+    // 🔥新增：进度统计变量
+    let receivedBytes = 0
+    let totalBytes = 0
+    let lastPercent = -1
     request.on('response', (response) => {
       if (response.statusCode !== 200) {
         reject(new Error(`下载失败: HTTP ${response.statusCode}`))
         return
       }
 
-      const chunks: Buffer[] = []
+      // 获取文件总大小
+      totalBytes = parseInt(response.headers['content-length'] as string) || 0
+      console.log(`\n📥 开始下载：${url}`)
+      console.log(`📦 文件大小：${(totalBytes / 1024 / 1024).toFixed(2)} MB`)
+
+      // ==============================================
+      // 🔥 改用流式写入（支持大文件，不爆内存）
+      // ==============================================
+      const writeStream = createWriteStream(filePath)
+      // const chunks: Buffer[] = []
       response.on('data', (chunk) => {
-        chunks.push(chunk)
+        writeStream.write(chunk)
+        receivedBytes += chunk.length
+
+        if (totalBytes > 0) {
+          //传递进度状态
+          if (progressCallback) {
+            const percent = Math.floor((receivedBytes / totalBytes) * 100)
+            if (percent !== lastPercent && percent % 2 === 0) {
+              // 每2%打印一次，避免刷屏
+              lastPercent = percent
+              console.log(
+                `✅ 下载进度：${percent}% (${(receivedBytes / 1024 / 1024).toFixed(2)}MB / ${(totalBytes / 1024 / 1024).toFixed(2)}MB)`
+              )
+            }
+            progressCallback(percent)
+          }
+        }
       })
 
       response.on('end', async () => {
         try {
-          const buffer = Buffer.concat(chunks)
-          await fs.writeFile(filePath, buffer)
+          writeStream.end()
+          console.log(`\n✅ 下载完成！保存到：${filePath}`)
           resolve()
         } catch (err) {
           reject(err)

--- a/src/main/utils/download.ts
+++ b/src/main/utils/download.ts
@@ -79,14 +79,13 @@ export async function downloadFile(
         }
       })
 
-      response.on('end', async () => {
-        try {
-          writeStream.end()
-          console.log(`\n✅ 下载完成！保存到：${filePath}`)
-          resolve()
-        } catch (err) {
-          reject(err)
-        }
+      response.on('end', () => {
+        writeStream.end()
+      })
+
+      writeStream.on('finish', () => {
+        console.log(`\n✅ 下载完成！保存到：${filePath}`)
+        resolve()
       })
 
       response.on('error', (err) => {


### PR DESCRIPTION
对应issue #410
1. 在插件市场面板新增下载列表，展示插件下载与安装状态
2. 点击「下载插件」时，任务加入下载队列
3. 按串行顺序依次执行下载安装（原下载功能命令）
4. 提供状态反馈（等待中 / 已安装 / 安装失败)
<img width="517" height="191" alt="image" src="https://github.com/user-attachments/assets/79c6a4e7-c079-4881-b899-8a609ed1c9a4" />
<img width="1039" height="637" alt="image" src="https://github.com/user-attachments/assets/ec7aab96-ce41-4998-9c7c-d13d54f76aea" />
