### PR TITLE
fix: 应用内更新后同步 Windows 注册表版本信息

### DIFF
--- a/src/main/api/updater.ts
+++ b/src/main/api/updater.ts
@@ -8,6 +8,7 @@ import { spawn } from 'child_process'
 import yaml from 'yaml'
 import databaseAPI from './shared/database.js'
 import { applyWindowMaterial, getDefaultWindowMaterial } from '../utils/windowUtils.js'
+import { syncWindowsUninstallVersion } from '../utils/registrySync.js'
 
 /**
  * 更新路径配置
@@ -37,6 +38,7 @@ export class UpdaterAPI {
     this.mainWindow = mainWindow
     this.setupIPC()
     this.startAutoCheck()
+    syncWindowsUninstallVersion()
   }
 
   private setupIPC(): void {

--- a/src/main/utils/registrySync.ts
+++ b/src/main/utils/registrySync.ts
@@ -1,0 +1,93 @@
+import { app } from 'electron'
+import { exec } from 'child_process'
+
+const UNINSTALL_KEY_PATHS = [
+  'HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\Uninstall',
+  'HKLM\\Software\\Microsoft\\Windows\\CurrentVersion\\Uninstall'
+]
+
+function execAsync(command: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    exec(command, { encoding: 'utf-8', windowsHide: true }, (error, stdout) => {
+      if (error) reject(error)
+      else resolve(stdout)
+    })
+  })
+}
+
+/**
+ * Finds the registry subkey path where DisplayName matches the given product name.
+ * Returns the full subkey path or null if not found.
+ */
+async function findUninstallKeyPath(productName: string): Promise<string | null> {
+  for (const basePath of UNINSTALL_KEY_PATHS) {
+    try {
+      const output = await execAsync(
+        `reg query "${basePath}" /s /v DisplayName /f "${productName}" /e`
+      )
+      const match = output.match(
+        new RegExp(`^(${basePath.replace(/\\/g, '\\\\')}\\\\[^\\r\\n]+)`, 'm')
+      )
+      if (match) return match[1]
+    } catch {
+      // HKLM may fail without admin privileges; continue to next hive
+    }
+  }
+  return null
+}
+
+async function getRegistryValue(keyPath: string, valueName: string): Promise<string | null> {
+  try {
+    const output = await execAsync(`reg query "${keyPath}" /v "${valueName}"`)
+    const match = output.match(new RegExp(`${valueName}\\s+REG_SZ\\s+(.+)`))
+    return match ? match[1].trim() : null
+  } catch {
+    return null
+  }
+}
+
+async function setRegistryValue(
+  keyPath: string,
+  valueName: string,
+  value: string
+): Promise<boolean> {
+  try {
+    await execAsync(`reg add "${keyPath}" /v "${valueName}" /t REG_SZ /d "${value}" /f`)
+    return true
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Syncs the Windows registry DisplayVersion with the current app version.
+ * This fixes the issue where in-app updates replace app.asar but leave
+ * the NSIS-installed registry entry with the old version.
+ */
+export async function syncWindowsUninstallVersion(): Promise<void> {
+  if (process.platform !== 'win32') return
+  if (!app.isPackaged) return
+
+  const currentVersion = app.getVersion()
+  const productName = app.getName()
+
+  try {
+    const keyPath = await findUninstallKeyPath(productName)
+    if (!keyPath) {
+      console.log('[RegistrySync] No uninstall registry entry found (portable install?)')
+      return
+    }
+
+    const registryVersion = await getRegistryValue(keyPath, 'DisplayVersion')
+    if (registryVersion === currentVersion) return
+
+    const success = await setRegistryValue(keyPath, 'DisplayVersion', currentVersion)
+    if (success) {
+      console.log(`[RegistrySync] Updated DisplayVersion: ${registryVersion} -> ${currentVersion}`)
+    } else {
+      console.warn('[RegistrySync] Failed to update DisplayVersion (insufficient permissions?)')
+    }
+  } catch (error) {
+    console.error('[RegistrySync] Error syncing registry version:', error)
+  }
+}


### PR DESCRIPTION
## Summary

修复 #430：Windows 安装版应用内更新后，系统中的版本信息（如 winget 显示的版本）不会同步更新。

### 根因

- NSIS 安装器在安装时向注册表 `HKCU\Software\Microsoft\Windows\CurrentVersion\Uninstall\` 写入 `DisplayVersion`
- 应用内更新仅通过 `ztools-agent.exe` 替换 `app.asar`，不会更新注册表中的版本信息
- 导致系统工具（winget、"程序和功能"）仍显示旧版本号

### 修复方案

- 新增 `src/main/utils/registrySync.ts`，在应用启动时自动检测并同步注册表版本
- 通过 Windows 原生 `reg` 命令搜索匹配的卸载注册表项，更新 `DisplayVersion`
- 优先搜索 HKCU（per-user 安装），再尝试 HKLM（per-machine 安装）
- 仅在 Windows 打包环境下生效，便携版（zip）和开发模式自动跳过

### 变更文件

- `src/main/utils/registrySync.ts`（新增）- 注册表版本同步工具
- `src/main/api/updater.ts`（修改）- 在 updater 初始化时调用同步逻辑

## Test plan

- [x] Windows 安装版：安装旧版本 → 应用内更新 → 验证"程序和功能"中版本号已更新
- [ ] Windows 安装版：正常启动（无更新）→ 验证不会产生错误日志
- [ ] Windows 便携版（zip）：启动 → 验证无注册表操作，无错误日志
- [ ] macOS / Linux：启动 → 验证函数直接跳过，无副作用
