### PR TITLE
feat: 扩展指令别名到系统应用和窗口指令

### DIFF
--- a/internal-plugins/setting/src/env.d.ts
+++ b/internal-plugins/setting/src/env.d.ts
@@ -271,7 +271,7 @@ declare global {
         }>
 
         // 指令管理
-        // 返回设置页使用的原始指令快照，用于构建 alias 目标列表
+        // 返回设置页使用的原始指令快照，用于构建 alias 目标列表（commands 文本指令 + regexCommands 中可直接触发的 window 指令）
         getCommands: () => Promise<{
           commands: any[]
           regexCommands: any[]
@@ -410,6 +410,8 @@ declare global {
           pid?: number
           title?: string
           appPath?: string
+          className?: string
+          hwnd?: number
         } | null>
 
         // 唤醒黑名单

--- a/internal-plugins/setting/src/views/AllCommandsSetting/AllCommandsSetting.vue
+++ b/internal-plugins/setting/src/views/AllCommandsSetting/AllCommandsSetting.vue
@@ -9,12 +9,17 @@ import {
   jumpFunctionShortcutsSetting,
   type ShortcutsSettingAliasDraftTarget
 } from '@/views/ShortcutsSetting/ShortcutsSetting'
-import { getCommandId as _getCommandId } from '@shared/commandShared'
+import {
+  DIRECT_APP_ALIAS_GROUP_KEY,
+  DIRECT_APP_ALIAS_GROUP_TITLE,
+  getCommandId as _getCommandId,
+  getLegacyDirectAppCommandId
+} from '@shared/commandShared'
 
 // 定义 Command 类型（从 commandDataStore 复制）
 export type CommandType = 'direct' | 'plugin' | 'builtin'
 export type CommandSubType = 'app' | 'system-setting' | 'local-shortcut'
-export type CommandCmdType = 'text' | 'regex' | 'over'
+export type CommandCmdType = 'text' | 'regex' | 'over' | 'img' | 'files' | 'window'
 
 export interface Command {
   name: string
@@ -63,14 +68,30 @@ const searchPinned = ref<any[]>([])
 const SEARCH_PINNED_KEY = 'pinned-commands'
 
 // 生成指令唯一标识
-// 格式: pluginName:featureCode:cmdName:cmdType
 function getCommandId(
+  command: Pick<Command, 'name' | 'path' | 'type' | 'subType' | 'featureCode' | 'cmdType'> & {
+    pluginName?: string
+  }
+): string {
+  return _getCommandId({
+    type: command.type,
+    subType: command.subType,
+    path: command.path,
+    pluginName: command.pluginName,
+    featureCode: command.featureCode,
+    name: command.name,
+    cmdType: command.cmdType
+  })
+}
+
+function getPluginCommandId(
   pluginName: string,
   featureCode: string,
   cmdName: string,
   cmdType: string
 ): string {
-  return _getCommandId({
+  return getCommandId({
+    type: 'plugin',
     pluginName,
     featureCode,
     name: cmdName,
@@ -78,79 +99,120 @@ function getCommandId(
   })
 }
 
-function buildAliasDraftTarget(
+function buildPluginAliasDraftTarget(
   pluginName: string,
   featureCode: string,
-  cmdName: string
+  cmdName: string,
+  cmdType: 'text' | 'window'
 ): ShortcutsSettingAliasDraftTarget {
   const pluginTitle = selectedSource.value?.title || pluginName
-  const commandIcon = commands.value.find(
+  const sourceCommands = cmdType === 'window' ? regexCommands.value : commands.value
+  const commandIcon = sourceCommands.find(
     (command) =>
       command.path === selectedSource.value?.path &&
       command.featureCode === featureCode &&
       command.name === cmdName &&
-      command.cmdType === 'text'
+      command.cmdType === cmdType
   )?.icon
 
-  // 路由状态只保留 alias 草稿所需的最小字段，避免把完整 command 对象塞进 history state
   return {
-    commandId: getCommandId(pluginName, featureCode, cmdName, 'text'),
+    commandId: getPluginCommandId(pluginName, featureCode, cmdName, cmdType),
+    type: 'plugin',
+    path: selectedSource.value?.path,
+    groupKey: pluginName,
+    groupTitle: pluginTitle,
+    featureCode,
+    subtitle: featureCode,
     pluginName,
     pluginTitle,
-    featureCode,
     cmdName,
-    cmdType: 'text',
+    cmdType,
     icon: commandIcon || selectedSource.value?.logo
   }
 }
 
-// 检查指令是否被禁用
+function isDirectAppCommand(cmd: Command): boolean {
+  return cmd.type === 'direct' && cmd.subType === 'app'
+}
+
+function buildAppAliasDraftTarget(cmd: Command): ShortcutsSettingAliasDraftTarget {
+  return {
+    commandId: getCommandId(cmd),
+    type: 'direct',
+    subType: 'app',
+    path: cmd.path,
+    groupKey: DIRECT_APP_ALIAS_GROUP_KEY,
+    groupTitle: DIRECT_APP_ALIAS_GROUP_TITLE,
+    featureCode: cmd.path || '',
+    subtitle: cmd.path || '',
+    pluginName: DIRECT_APP_ALIAS_GROUP_KEY,
+    pluginTitle: DIRECT_APP_ALIAS_GROUP_TITLE,
+    cmdName: cmd.name,
+    cmdType: 'text',
+    icon: cmd.icon
+  }
+}
+
 function isCommandDisabled(
   pluginName: string,
   featureCode: string,
   cmdName: string,
   cmdType: string
 ): boolean {
-  const id = getCommandId(pluginName, featureCode, cmdName, cmdType)
+  const id = getPluginCommandId(pluginName, featureCode, cmdName, cmdType)
   return disabledCommands.value.includes(id)
 }
 
-// 切换指令禁用状态
+function isDirectAppCommandDisabled(cmd: Command): boolean {
+  const nextId = getCommandId(cmd)
+  const legacyId = getLegacyDirectAppCommandId(cmd.name, cmd.cmdType || 'text')
+  return disabledCommands.value.includes(nextId) || disabledCommands.value.includes(legacyId)
+}
+
 async function toggleCommandDisabled(
   pluginName: string,
   featureCode: string,
   cmdName: string,
   cmdType: string
 ): Promise<void> {
-  const id = getCommandId(pluginName, featureCode, cmdName, cmdType)
+  const id = getPluginCommandId(pluginName, featureCode, cmdName, cmdType)
   const index = disabledCommands.value.indexOf(id)
 
   if (index === -1) {
-    // 添加到禁用列表
     disabledCommands.value.push(id)
   } else {
-    // 从禁用列表移除
     disabledCommands.value.splice(index, 1)
   }
 
-  // 保存到数据库
   await saveDisabledCommands()
 }
 
-// 保存禁用指令列表到数据库
+async function toggleDirectAppCommandDisabled(cmd: Command): Promise<void> {
+  const nextId = getCommandId(cmd)
+  const legacyId = getLegacyDirectAppCommandId(cmd.name, cmd.cmdType || 'text')
+  const nextIndex = disabledCommands.value.indexOf(nextId)
+  const legacyIndex = disabledCommands.value.indexOf(legacyId)
+  const isDisabled = nextIndex !== -1 || legacyIndex !== -1
+
+  if (isDisabled) {
+    disabledCommands.value = disabledCommands.value.filter((id) => id !== nextId && id !== legacyId)
+  } else {
+    disabledCommands.value = [...disabledCommands.value.filter((id) => id !== legacyId), nextId]
+  }
+
+  await saveDisabledCommands()
+}
+
 async function saveDisabledCommands(): Promise<void> {
   try {
-    // 将 Vue 响应式数组转换为普通数组，避免 IPC 克隆错误
     const plainArray = [...disabledCommands.value]
     await window.ztools.internal.dbPut(DISABLED_COMMANDS_KEY, plainArray)
-    // 通知主渲染进程禁用指令列表已更改
     await window.ztools.internal.notifyDisabledCommandsChanged()
   } catch (error) {
     console.error('保存禁用指令列表失败:', error)
   }
 }
 
-// 加载禁用指令列表
 async function loadDisabledCommands(): Promise<void> {
   try {
     const data = await window.ztools.internal.dbGet(DISABLED_COMMANDS_KEY)
@@ -162,7 +224,6 @@ async function loadDisabledCommands(): Promise<void> {
   }
 }
 
-// 加载超级面板固定列表
 async function loadSuperPanelPinned(): Promise<void> {
   try {
     superPanelPinned.value = await window.ztools.internal.getSuperPanelPinned()
@@ -171,7 +232,6 @@ async function loadSuperPanelPinned(): Promise<void> {
   }
 }
 
-// 检查指令是否已固定到超级面板
 function isPinnedToSuperPanel(pluginName: string, featureCode: string, cmdName: string): boolean {
   return superPanelPinned.value.some(
     (item) =>
@@ -179,14 +239,12 @@ function isPinnedToSuperPanel(pluginName: string, featureCode: string, cmdName: 
   )
 }
 
-// 检查系统应用是否已固定到超级面板（基于 path + name 匹配）
 function isAppPinnedToSuperPanel(cmd: Command): boolean {
   return superPanelPinned.value.some(
     (item) => item.path === cmd.path && item.name === cmd.name && item.type === 'direct'
   )
 }
 
-// 固定/取消固定到超级面板
 async function toggleSuperPanelPin(
   pluginName: string,
   featureCode: string,
@@ -195,7 +253,6 @@ async function toggleSuperPanelPin(
   const isPinned = isPinnedToSuperPanel(pluginName, featureCode, cmdName)
 
   if (isPinned) {
-    // 取消固定 - 需要找到对应的 path
     const item = superPanelPinned.value.find(
       (i) => i.name === cmdName && i.featureCode === featureCode && i.pluginName === pluginName
     )
@@ -203,7 +260,6 @@ async function toggleSuperPanelPin(
       await window.ztools.internal.unpinSuperPanelCommand(item.path, item.featureCode)
     }
   } else {
-    // 查找对应的指令信息
     const command = commands.value.find(
       (c) =>
         c.path === selectedSource.value?.path && c.featureCode === featureCode && c.name === cmdName
@@ -216,18 +272,16 @@ async function toggleSuperPanelPin(
         icon: command.icon || '',
         type: command.type,
         featureCode: command.featureCode || '',
-        pluginName: pluginName,
+        pluginName,
         pluginExplain: command.pluginExplain || '',
         cmdType: command.cmdType || 'text'
       })
     }
   }
 
-  // 刷新本地缓存
   await loadSuperPanelPinned()
 }
 
-// 固定/取消固定系统应用到超级面板
 async function toggleAppSuperPanelPin(cmd: Command): Promise<void> {
   const isPinned = isAppPinnedToSuperPanel(cmd)
 
@@ -246,11 +300,9 @@ async function toggleAppSuperPanelPin(cmd: Command): Promise<void> {
     })
   }
 
-  // 刷新本地缓存
   await loadSuperPanelPinned()
 }
 
-// 加载搜索窗口固定列表
 async function loadSearchPinned(): Promise<void> {
   try {
     const data = await window.ztools.internal.dbGet(SEARCH_PINNED_KEY)
@@ -262,19 +314,16 @@ async function loadSearchPinned(): Promise<void> {
   }
 }
 
-// 检查指令是否已固定到搜索窗口
 function isPinnedToSearch(featureCode: string): boolean {
   return searchPinned.value.some(
     (item) => item.path === selectedSource.value?.path && item.featureCode === featureCode
   )
 }
 
-// 检查系统应用是否已固定到搜索窗口（基于 path + name 匹配）
 function isAppPinnedToSearch(cmd: Command): boolean {
   return searchPinned.value.some((item) => item.path === cmd.path && item.name === cmd.name)
 }
 
-// 固定/取消固定到搜索窗口
 async function toggleSearchPin(
   pluginName: string,
   featureCode: string,
@@ -283,10 +332,8 @@ async function toggleSearchPin(
   const pinned = isPinnedToSearch(featureCode)
 
   if (pinned) {
-    // 取消固定
     await window.ztools.internal.unpinApp(selectedSource.value?.path || '', featureCode, cmdName)
   } else {
-    // 查找对应的指令信息
     const command = commands.value.find(
       (c) =>
         c.path === selectedSource.value?.path && c.featureCode === featureCode && c.name === cmdName
@@ -297,11 +344,9 @@ async function toggleSearchPin(
     }
   }
 
-  // 重新加载固定列表
   await loadSearchPinned()
 }
 
-// 固定/取消固定系统应用到搜索窗口
 async function toggleAppSearchPin(cmd: Command): Promise<void> {
   const pinned = isAppPinnedToSearch(cmd)
 
@@ -314,21 +359,24 @@ async function toggleAppSearchPin(cmd: Command): Promise<void> {
   await loadSearchPinned()
 }
 
-// 系统应用下拉菜单项
 function getAppMenuItems(cmd: Command): TagDropdownMenuItem[] {
   const items: TagDropdownMenuItem[] = []
-  // 与 commandUtils.getCommandId 格式一致：pluginName:featureCode:name:cmdType
-  const cmdId = getCommandId('', '', cmd.name, cmd.cmdType || 'text')
-  const disabled = disabledCommands.value.includes(cmdId)
+  const disabled = isDirectAppCommandDisabled(cmd)
 
-  // 打开应用
   items.push({
     key: 'open',
     label: '打开应用',
     icon: 'i-z-play'
   })
 
-  // 固定到超级面板
+  if (isDirectAppCommand(cmd)) {
+    items.push({
+      key: 'custom-alias',
+      label: '自定义别名',
+      icon: 'i-z-alias'
+    })
+  }
+
   const superPinned = isAppPinnedToSuperPanel(cmd)
   items.push({
     key: 'pin-super-panel',
@@ -336,7 +384,6 @@ function getAppMenuItems(cmd: Command): TagDropdownMenuItem[] {
     icon: 'i-z-pin'
   })
 
-  // 固定到搜索窗口
   const pinned = isAppPinnedToSearch(cmd)
   items.push({
     key: 'pin-search',
@@ -344,7 +391,6 @@ function getAppMenuItems(cmd: Command): TagDropdownMenuItem[] {
     icon: 'i-z-pin'
   })
 
-  // 启用/禁用指令
   items.push({
     key: 'toggle',
     label: disabled ? '启用指令' : '禁用指令',
@@ -355,10 +401,8 @@ function getAppMenuItems(cmd: Command): TagDropdownMenuItem[] {
   return items
 }
 
-// 处理系统应用下拉菜单选择
 async function handleAppMenuSelect(key: string, cmd: Command): Promise<void> {
   if (key === 'open') {
-    // 打开应用
     try {
       await window.ztools.internal.launch({
         path: cmd.path || '',
@@ -369,23 +413,22 @@ async function handleAppMenuSelect(key: string, cmd: Command): Promise<void> {
     } catch (error) {
       console.error('打开应用失败:', error)
     }
+  } else if (key === 'custom-alias') {
+    if (!isDirectAppCommand(cmd)) return
+    openAppAliasShortcut(cmd)
   } else if (key === 'pin-super-panel') {
     await toggleAppSuperPanelPin(cmd)
   } else if (key === 'pin-search') {
     await toggleAppSearchPin(cmd)
   } else if (key === 'toggle') {
-    const cmdId = getCommandId('', '', cmd.name, cmd.cmdType || 'text')
-    const index = disabledCommands.value.indexOf(cmdId)
-    if (index === -1) {
-      disabledCommands.value.push(cmdId)
-    } else {
-      disabledCommands.value.splice(index, 1)
-    }
-    await saveDisabledCommands()
+    await toggleDirectAppCommandDisabled(cmd)
   }
 }
 
-// 下拉菜单项
+function isAliasableCmdType(cmdType?: string): cmdType is 'text' | 'window' {
+  return cmdType === 'text' || cmdType === 'window'
+}
+
 function getMenuItems(
   isDisabled: boolean,
   cmdType?: string,
@@ -393,10 +436,10 @@ function getMenuItems(
   featureCode?: string,
   cmdName?: string
 ): TagDropdownMenuItem[] {
-  // @unocss-include
   const items: TagDropdownMenuItem[] = []
 
-  // 只有功能指令（text 类型）才显示"打开指令"
+  const canAddAlias = isAliasableCmdType(cmdType) && pluginName && featureCode && cmdName
+
   if (cmdType === 'text') {
     items.push({
       key: 'open',
@@ -404,7 +447,6 @@ function getMenuItems(
       icon: 'i-z-play'
     })
 
-    // 功能指令支持固定到超级面板
     if (pluginName && featureCode && cmdName) {
       const pinned = isPinnedToSuperPanel(pluginName, featureCode, cmdName)
       items.push({
@@ -413,7 +455,6 @@ function getMenuItems(
         icon: 'i-z-pin'
       })
 
-      // 固定到搜索窗口
       const searchPinnedState = isPinnedToSearch(featureCode)
       items.push({
         key: 'pin-search',
@@ -421,23 +462,22 @@ function getMenuItems(
         icon: 'i-z-pin'
       })
 
-      // 设置全局快捷键
       items.push({
         key: 'set-global-shortcut',
         label: '设置全局快捷键',
         icon: 'i-z-keyboard'
       })
-
-      // alias 只对插件文本指令开放；direct / builtin / regex 等类型不走这条设置路径
-      items.push({
-        key: 'custom-alias',
-        label: '自定义别名',
-        icon: 'i-z-alias'
-      })
     }
   }
 
-  // 启用/禁用指令（所有类型都支持）
+  if (canAddAlias) {
+    items.push({
+      key: 'custom-alias',
+      label: '自定义别名',
+      icon: 'i-z-alias'
+    })
+  }
+
   items.push({
     key: 'toggle',
     label: isDisabled ? '启用指令' : '禁用指令',
@@ -448,15 +488,27 @@ function getMenuItems(
   return items
 }
 
-function openAliasShortcut(pluginName: string, featureCode: string, cmdName: string): void {
-  // 统一从“所有指令”跳转到 alias tab，并预先带上当前指令作为草稿目标
+function openAliasShortcut(
+  pluginName: string,
+  featureCode: string,
+  cmdName: string,
+  cmdType: 'text' | 'window'
+): void {
   jumpFunctionShortcutsSetting({
     tab: 'alias',
-    draftTarget: buildAliasDraftTarget(pluginName, featureCode, cmdName)
+    draftTarget: buildPluginAliasDraftTarget(pluginName, featureCode, cmdName, cmdType)
   })
 }
 
-// 处理下拉菜单选择
+function openAppAliasShortcut(cmd: Command): void {
+  if (!isDirectAppCommand(cmd)) return
+
+  jumpFunctionShortcutsSetting({
+    tab: 'alias',
+    draftTarget: buildAppAliasDraftTarget(cmd)
+  })
+}
+
 async function handleMenuSelect(
   key: string,
   pluginName: string,
@@ -467,27 +519,22 @@ async function handleMenuSelect(
   if (key === 'toggle') {
     toggleCommandDisabled(pluginName, featureCode, cmdName, cmdType)
   } else if (key === 'open') {
-    // 打开指令
     await openCommand(pluginName, featureCode, cmdName, cmdType)
   } else if (key === 'pin-super-panel') {
-    // 固定/取消固定到超级面板
     await toggleSuperPanelPin(pluginName, featureCode, cmdName)
   } else if (key === 'pin-search') {
-    // 固定/取消固定到搜索窗口
     await toggleSearchPin(pluginName, featureCode, cmdName)
   } else if (key === 'set-global-shortcut') {
-    // 跳转到全局快捷键页面并打开添加面板，预填目标指令（插件标题/指令名称）
     const pluginTitle = selectedSource.value?.title || pluginName
     jumpFunctionShortcutsSetting({
       payload: `${pluginTitle}/${cmdName}`
     })
   } else if (key === 'custom-alias') {
-    // 这里只负责导航到设置页，不直接做 alias 持久化
-    openAliasShortcut(pluginName, featureCode, cmdName)
+    if (!isAliasableCmdType(cmdType)) return
+    openAliasShortcut(pluginName, featureCode, cmdName, cmdType)
   }
 }
 
-// 打开指令
 async function openCommand(
   pluginName: string,
   featureCode: string,
@@ -495,7 +542,6 @@ async function openCommand(
   cmdType: string
 ): Promise<void> {
   try {
-    // 查找对应的指令
     const command = commands.value.find(
       (c) =>
         c.path === selectedSource.value?.path &&
@@ -511,14 +557,13 @@ async function openCommand(
 
     console.log('打开指令:', command)
 
-    // 启动指令（使用内置插件 API）
     await window.ztools.internal.launch({
       path: command.path || '',
       type: command.type,
       featureCode: command.featureCode,
       name: command.name,
       param: {
-        payload: '' // 功能指令默认空 payload
+        payload: ''
       }
     })
   } catch (error) {
@@ -979,7 +1024,10 @@ onMounted(async () => {
               :menu-items="
                 getMenuItems(
                   isCommandDisabled(selectedSource?.name || '', feature.code, cmd.name, cmd.type),
-                  cmd.type
+                  cmd.type,
+                  selectedSource?.name || '',
+                  feature.code,
+                  cmd.name
                 )
               "
               @select="

--- a/internal-plugins/setting/src/views/ShortcutsSetting/ShortcutsSetting.ts
+++ b/internal-plugins/setting/src/views/ShortcutsSetting/ShortcutsSetting.ts
@@ -9,11 +9,17 @@ export type ShortcutsSettingTab = 'global' | 'app' | 'alias'
  */
 export interface ShortcutsSettingAliasDraftTarget extends HistoryState {
   commandId: string
+  type: 'plugin' | 'direct'
+  subType?: 'app' | 'system-setting' | 'local-shortcut'
+  path?: string
+  groupKey: string
+  groupTitle: string
+  featureCode: string
+  subtitle: string
   pluginName: string
   pluginTitle: string
-  featureCode: string
   cmdName: string
-  cmdType: 'text'
+  cmdType: 'text' | 'window'
   icon?: string
 }
 

--- a/internal-plugins/setting/src/views/ShortcutsSetting/ShortcutsSetting.vue
+++ b/internal-plugins/setting/src/views/ShortcutsSetting/ShortcutsSetting.vue
@@ -12,6 +12,8 @@ import type {
 } from '@/views/ShortcutsSetting/ShortcutsSetting'
 import {
   COMMAND_ALIASES_KEY,
+  DIRECT_APP_ALIAS_GROUP_KEY,
+  DIRECT_APP_ALIAS_GROUP_TITLE,
   getCommandId as _getCommandId,
   normalizeCommandAliases
 } from '@shared/commandShared'
@@ -133,7 +135,7 @@ const loading = ref(true)
 const builtInShortcutsEnabled = ref<BuiltInShortcutConfig>({ ...DEFAULT_BUILTIN_SHORTCUTS_ENABLED })
 
 const aliasMappings = ref<CommandAliasStore>({})
-// alias 目标列表来自主进程整理后的 canonical commands，仅包含允许建立映射的插件文本指令
+// alias 目标列表来自主进程整理后的 canonical commands，仅包含允许直接触发的插件指令和系统应用。
 const aliasTargetOptions = ref<ShortcutsSettingAliasCommandOption[]>([])
 const aliasDialogVisible = ref(false)
 const aliasDialogRef = ref<InstanceType<typeof AliasMappingDialog> | null>(null)
@@ -209,18 +211,29 @@ const showEditor = ref(false)
 const editingShortcut = ref<GlobalShortcut | null>(null)
 const prefillTarget = ref('')
 
-function getCommandId(pluginName: string, featureCode: string, cmdName: string): string {
+function getCommandId(command: {
+  name: string
+  path?: string
+  type: 'plugin' | 'direct'
+  subType?: 'app' | 'system-setting' | 'local-shortcut'
+  featureCode?: string
+  cmdType?: 'text' | 'window'
+  pluginName?: string
+}): string {
   return _getCommandId({
-    pluginName,
-    featureCode,
-    name: cmdName,
-    cmdType: 'text'
+    type: command.type,
+    subType: command.subType,
+    path: command.path,
+    pluginName: command.pluginName,
+    featureCode: command.featureCode,
+    name: command.name,
+    cmdType: command.cmdType
   })
 }
 
 function getAliasTargetLabel(target: ShortcutsSettingAliasCommandOption | null): string {
   if (!target) return '目标已失效'
-  return `${target.pluginTitle} / ${target.cmdName}`
+  return target.label
 }
 
 function cloneAliasStore(): CommandAliasStore {
@@ -247,7 +260,7 @@ function resolveAliasTarget(
     // 优先复用当前最新的目标指令数据；若目标已经不在候选列表中，则退回路由里带过来的草稿信息
     aliasTargetMap.value.get(target.commandId) || {
       ...target,
-      label: `${target.pluginTitle} / ${target.cmdName}`
+      label: `${target.groupTitle} / ${target.cmdName}`
     }
   )
 }
@@ -355,25 +368,93 @@ async function loadAliasTargets(): Promise<void> {
     const pluginMap = new Map((result.plugins || []).map((plugin: any) => [plugin.name, plugin]))
     const targetMap = new Map<string, ShortcutsSettingAliasCommandOption>()
 
-    for (const command of result.commands || []) {
-      // alias 目标仅允许插件文本指令，直接启动项和匹配指令都不进入候选列表
-      if (command.type !== 'plugin' || command.cmdType !== 'text') continue
-      if (!command.pluginName || !command.featureCode || !command.name) continue
+    const addTarget = (target: ShortcutsSettingAliasCommandOption): void => {
+      targetMap.set(target.commandId, target)
+    }
+
+    const addPluginTarget = (command: any, cmdType: 'text' | 'window'): void => {
+      if (command.type !== 'plugin') return
+      if (!command.pluginName || !command.featureCode || !command.name) return
 
       const plugin = pluginMap.get(command.pluginName)
       const pluginTitle = command.pluginTitle || plugin?.title || command.pluginName
-      const commandId = getCommandId(command.pluginName, command.featureCode, command.name)
+      const commandId = getCommandId({
+        type: 'plugin',
+        path: command.path,
+        pluginName: command.pluginName,
+        featureCode: command.featureCode,
+        name: command.name,
+        cmdType
+      })
 
-      targetMap.set(commandId, {
+      addTarget({
         commandId,
+        type: 'plugin',
+        path: command.path,
+        groupKey: command.pluginName,
+        groupTitle: pluginTitle,
+        featureCode: command.featureCode,
+        subtitle: command.featureCode,
         pluginName: command.pluginName,
         pluginTitle,
-        featureCode: command.featureCode,
         cmdName: command.name,
-        cmdType: 'text',
+        cmdType,
         icon: command.icon || plugin?.logo,
         label: `${pluginTitle} / ${command.name}`
       })
+    }
+
+    const addDirectAppTarget = (command: any): void => {
+      if (
+        command.type !== 'direct' ||
+        command.subType !== 'app' ||
+        !command.path ||
+        !command.name
+      ) {
+        return
+      }
+
+      const commandId = getCommandId({
+        type: 'direct',
+        subType: 'app',
+        path: command.path,
+        name: command.name,
+        cmdType: 'text'
+      })
+
+      addTarget({
+        commandId,
+        type: 'direct',
+        subType: 'app',
+        path: command.path,
+        groupKey: DIRECT_APP_ALIAS_GROUP_KEY,
+        groupTitle: DIRECT_APP_ALIAS_GROUP_TITLE,
+        featureCode: command.path,
+        subtitle: command.path,
+        pluginName: DIRECT_APP_ALIAS_GROUP_KEY,
+        pluginTitle: DIRECT_APP_ALIAS_GROUP_TITLE,
+        cmdName: command.name,
+        cmdType: 'text',
+        icon: command.icon,
+        label: `${DIRECT_APP_ALIAS_GROUP_TITLE} / ${command.name}`
+      })
+    }
+
+    for (const command of result.commands || []) {
+      if (command.type === 'direct' && command.subType === 'app') {
+        addDirectAppTarget(command)
+        continue
+      }
+
+      if (command.cmdType === 'text') {
+        addPluginTarget(command, 'text')
+      }
+    }
+
+    for (const command of result.regexCommands || []) {
+      if (command.cmdType === 'window') {
+        addPluginTarget(command, 'window')
+      }
     }
 
     aliasTargetOptions.value = Array.from(targetMap.values()).sort((a, b) =>
@@ -890,7 +971,7 @@ useJumpFunction<ShortcutsSettingJumpFunction>(async (state) => {
                   {{ row.targetLabel }}
                 </div>
                 <div class="alias-target-subtitle">
-                  {{ row.missingTarget ? row.commandId : row.target?.featureCode }}
+                  {{ row.missingTarget ? row.commandId : row.target?.subtitle }}
                 </div>
               </div>
 

--- a/internal-plugins/setting/src/views/ShortcutsSetting/components/AliasMappingDialog.vue
+++ b/internal-plugins/setting/src/views/ShortcutsSetting/components/AliasMappingDialog.vue
@@ -94,7 +94,7 @@ watch(
 const pluginOptions = computed<AliasPluginOption[]>(() => {
   const pluginMap = new Map<string, AliasPluginOption>()
 
-  // 目标选择器采用两级结构：先按插件分组，再在插件内选具体文本指令
+  // 目标选择器采用两级结构：先按分组选择，再在分组内选具体指令。
   for (const item of props.targetOptions) {
     const existing = pluginMap.get(item.pluginName)
     if (existing) {
@@ -107,7 +107,7 @@ const pluginOptions = computed<AliasPluginOption[]>(() => {
 
     pluginMap.set(item.pluginName, {
       pluginName: item.pluginName,
-      pluginTitle: item.pluginTitle,
+      pluginTitle: item.groupTitle,
       icon: item.icon,
       commands: [item]
     })
@@ -146,11 +146,11 @@ const filteredPluginCommands = computed(() => {
     return commands
   }
 
-  // 进入插件后，搜索范围收敛到该插件的文本指令列表
+  // 进入插件后，搜索范围收敛到该插件的可选指令列表
   return weightedSearch(commands, query, [
     { value: (item) => item.cmdName || '', weight: 10 },
     { value: (item) => item.label || '', weight: 8 },
-    { value: (item) => item.featureCode || '', weight: 4 }
+    { value: (item) => item.subtitle || '', weight: 4 }
   ])
 })
 
@@ -158,9 +158,9 @@ const filteredPluginCommands = computed(() => {
 const displayIcon = computed(() => icon.value || target.value?.icon)
 const dialogTitle = computed(() => (mode.value === 'edit' ? '编辑指令别名' : '添加指令别名'))
 const selectorTitle = computed(() =>
-  selectedPlugin.value ? `${selectedPlugin.value.pluginTitle} 的指令` : '所有可用插件'
+  selectedPlugin.value ? `${selectedPlugin.value.pluginTitle} 的指令` : '所有可用目标'
 )
-const selectorPlaceholder = computed(() => (selectedPlugin.value ? '搜索该插件的指令' : '搜索插件'))
+const selectorPlaceholder = computed(() => (selectedPlugin.value ? '搜索该分组的指令' : '搜索分组'))
 
 function handleCancel(): void {
   emit('cancel')
@@ -336,7 +336,7 @@ defineExpose({
               </div>
               <div class="target-card-texts">
                 <div class="target-card-title">{{ target.label }}</div>
-                <div class="target-card-subtitle">{{ target.featureCode }}</div>
+                <div class="target-card-subtitle">{{ target.subtitle }}</div>
               </div>
             </div>
             <div v-else class="target-card target-card-empty">
@@ -347,13 +347,13 @@ defineExpose({
               </div>
               <div class="target-card-texts">
                 <div class="target-card-title">请选择目标指令</div>
-                <div class="target-card-subtitle">先选插件，再选指令</div>
+                <div class="target-card-subtitle">先选分组，再选指令</div>
               </div>
             </div>
           </div>
         </div>
 
-        <!-- 目标选择区：先选插件，再选指令 -->
+        <!-- 目标选择区：先选分组，再选指令 -->
         <div class="alias-dialog-selector">
           <div class="selector-header">
             <div class="selector-title">{{ selectorTitle }}</div>
@@ -363,7 +363,7 @@ defineExpose({
               type="button"
               @click="handleBackToPlugins"
             >
-              返回插件列表
+              返回分组列表
             </button>
           </div>
 
@@ -402,7 +402,7 @@ defineExpose({
                 </div>
                 <div class="selector-item-texts">
                   <div class="selector-item-title">{{ item.cmdName }}</div>
-                  <div class="selector-item-subtitle">{{ item.featureCode }}</div>
+                  <div class="selector-item-subtitle">{{ item.subtitle }}</div>
                 </div>
               </button>
               <div v-if="filteredPluginCommands.length === 0" class="selector-empty">
@@ -423,7 +423,7 @@ defineExpose({
                     v-if="plugin.icon"
                     :src="plugin.icon"
                     class="selector-item-icon"
-                    alt="插件图标"
+                    alt="分组图标"
                     draggable="false"
                   />
                   <div v-else class="selector-item-icon icon-placeholder">
@@ -435,7 +435,7 @@ defineExpose({
                   <div class="selector-item-subtitle">{{ plugin.commands.length }} 个指令</div>
                 </div>
               </button>
-              <div v-if="filteredPlugins.length === 0" class="selector-empty">暂无匹配的插件</div>
+              <div v-if="filteredPlugins.length === 0" class="selector-empty">暂无匹配的分组</div>
             </template>
           </div>
         </div>

--- a/internal-plugins/system/public/plugin.json
+++ b/internal-plugins/system/public/plugin.json
@@ -90,7 +90,7 @@
           "type": "window",
           "label": "复制路径",
           "match": {
-            "app": ["Finder.app"]
+            "app": ["Finder.app", "explorer.exe"]
           }
         }
       ]
@@ -104,7 +104,7 @@
           "type": "window",
           "label": "在终端打开",
           "match": {
-            "app": ["Finder.app"]
+            "app": ["Finder.app", "explorer.exe"]
           }
         }
       ]

--- a/src/main/api/plugin/internal.ts
+++ b/src/main/api/plugin/internal.ts
@@ -148,7 +148,7 @@ export class InternalPluginAPI {
         aliasCount: inputAliasCount
       })
 
-      // alias 保存链路：归一化 -> 持久化 -> 失效 commands cache -> 通知主窗口刷新搜索索引。
+      // alias 保存链路：归一化 -> 持久化 -> 通知主窗口按当前缓存重建 alias 搜索索引。
       const normalizedAliases = normalizeCommandAliases(aliases)
       const normalizedCommandCount = Object.keys(normalizedAliases).length
       const normalizedAliasEntries = Object.values(normalizedAliases).flat()
@@ -170,10 +170,8 @@ export class InternalPluginAPI {
           commandCount: normalizedCommandCount,
           aliasCount: normalizedAliasEntries.length
         })
-        commandsAPI.invalidateCommandsCache(false)
-        // 只通知渲染进程刷新别名搜索索引，不触发系统应用扫描
         this.mainWindow?.webContents.send('command-aliases-changed')
-        console.log('[Internal] 指令缓存已失效并通知主窗口刷新 alias 搜索索引')
+        console.log('[Internal] 已通知主窗口按当前缓存刷新 alias 搜索索引')
 
         return { success: true }
       } catch (error) {

--- a/src/main/api/plugin/shell.ts
+++ b/src/main/api/plugin/shell.ts
@@ -1,10 +1,10 @@
 import { execFile } from 'child_process'
 import os from 'os'
-import path from 'path'
-import { app, ipcMain, shell } from 'electron'
+import { ipcMain, shell } from 'electron'
 import { getFileIconAsBase64 } from '../../core/iconProtocol'
 import { WindowManager } from '../../core/native/index.js'
 import type ClipboardManager from '../../managers/clipboardManager'
+import { getExplorerFolderPathFromWindow } from '../../utils/common'
 
 const MAC_BROWSER_APP_MAP = {
   'com.apple.Safari': 'Safari',
@@ -298,41 +298,16 @@ export class PluginShellAPI {
     }
 
     // 3. 根据窗口类名判断并获取路径
-    const { className } = windowInfo
-
-    // CabinetWClass: 标准 Explorer 文件夹窗口
-    // ExploreWClass: 旧版 Explorer 窗口（兼容）
-    if (className === 'CabinetWClass' || className === 'ExploreWClass') {
-      if (windowInfo.hwnd == null) {
-        console.error('[PluginShell] readCurrentFolderPath: Explorer 窗口缺少 hwnd')
-        throw new Error('未读取到当前 "文件资源管理器" 窗口目录')
-      }
-
-      // 通过 COM IShellWindows 查询当前窗口的文件夹路径
-      const folderUrl = WindowManager.getExplorerFolderPath(windowInfo.hwnd)
-      if (!folderUrl) {
-        console.error(`[PluginShell] readCurrentFolderPath: COM 查询失败 (hwnd=${windowInfo.hwnd})`)
-        throw new Error('未读取到当前 "文件资源管理器" 窗口目录')
-      }
-
-      // 解码 file:/// URL 为本地路径（使用 decodeURIComponent 处理 # 等特殊字符）
-      const folderPath = path.resolve(decodeURIComponent(folderUrl.replace(/^file:\/\/\//, '')))
+    const folderPath = getExplorerFolderPathFromWindow(windowInfo, 'PluginShell')
+    if (folderPath) {
       console.log(`[PluginShell] readCurrentFolderPath: Explorer 窗口路径=${folderPath}`)
       return folderPath
     }
 
-    // Progman: 桌面主窗口；WorkerW: 桌面壁纸层窗口
-    if (className === 'Progman' || className === 'WorkerW') {
-      const desktopPath = app.getPath('desktop')
-      console.log(`[PluginShell] readCurrentFolderPath: 桌面路径=${desktopPath}`)
-      return desktopPath
-    }
-
-    // 未知的窗口类名
     console.warn(
-      `[PluginShell] readCurrentFolderPath: 未识别的窗口类 "${className}" (app=${windowInfo.app})`
+      `[PluginShell] readCurrentFolderPath: 未识别的窗口类 "${windowInfo.className}" (app=${windowInfo.app})`
     )
-    throw new Error(`当前活动窗口类 "${className}" 未识别`)
+    throw new Error(`当前活动窗口类 "${windowInfo.className}" 未识别`)
   }
 
   /**

--- a/src/main/api/renderer/commandMatchers.ts
+++ b/src/main/api/renderer/commandMatchers.ts
@@ -3,9 +3,15 @@
  * 提取自 commands.ts 中的匹配逻辑，便于单元测试
  */
 
+function isDirectApp(item: any, type: string): boolean {
+  return item?.type === 'direct' || (item?.type === 'app' && type === 'app')
+}
+
 /**
  * 在列表中查找匹配项的索引
- * 插件类型优先按 pluginName（唯一，开发版含 __dev 后缀）匹配；非插件类型匹配 name + path
+ * 插件类型优先按 pluginName（唯一，开发版含 __dev 后缀）匹配；
+ * direct/app 优先匹配 path + name，name 缺失时降级为仅匹配 path；
+ * 其它非插件类型沿用原有 path/name 逻辑。
  */
 export function findCommandIndex(
   list: any[],
@@ -19,13 +25,19 @@ export function findCommandIndex(
       if (item.featureCode !== featureCode) {
         return false
       }
-      // 优先按 pluginName 匹配（已含 __dev，唯一标识）
       if (name && item.pluginName) {
         return item.pluginName === name
       }
       return item.path === appPath
     }
-    // 非插件类型：优先匹配 name + path，兼容旧数据（name 缺失时降级为仅匹配 path）
+
+    if (isDirectApp(item, type)) {
+      if (name) {
+        return item.path === appPath && item.name === name
+      }
+      return item.path === appPath
+    }
+
     if (name) {
       return item.path === appPath && item.name === name
     }
@@ -35,7 +47,7 @@ export function findCommandIndex(
 
 /**
  * 过滤掉匹配项（用于 removeFromHistory / unpinApp）
- * 插件类型优先按 pluginName 匹配；非插件类型匹配 name + path
+ * 插件类型优先按 pluginName 匹配；direct/app 匹配 path + name。
  */
 export function filterOutCommand(
   list: any[],
@@ -53,7 +65,14 @@ export function filterOutCommand(
       }
       return item.path !== appPath
     }
-    // 非插件类型：同时匹配 name 和 path
+
+    if (isDirectApp(item, item?.type)) {
+      if (name) {
+        return !(item.path === appPath && item.name === name)
+      }
+      return item.path !== appPath
+    }
+
     if (name) {
       return !(item.path === appPath && item.name === name)
     }
@@ -63,7 +82,7 @@ export function filterOutCommand(
 
 /**
  * 检查列表中是否已存在匹配项（用于 pinApp）
- * 插件类型优先按 pluginName 匹配；非插件类型匹配 name + path
+ * 插件类型优先按 pluginName 匹配；direct/app 匹配 path + name。
  */
 export function hasCommand(
   list: any[],
@@ -81,7 +100,14 @@ export function hasCommand(
       }
       return item.path === appPath
     }
-    // 非插件类型：优先匹配 name + path，兼容旧数据（name 缺失时降级为仅匹配 path）
+
+    if (isDirectApp(item, item?.type)) {
+      if (name) {
+        return item.path === appPath && item.name === name
+      }
+      return item.path === appPath
+    }
+
     if (name) {
       return item.path === appPath && item.name === name
     }

--- a/src/main/api/renderer/commands.ts
+++ b/src/main/api/renderer/commands.ts
@@ -507,7 +507,7 @@ export class AppsAPI {
         }
 
         // 添加到历史记录
-        this.addToHistory({ path: appPath, type: 'app', name, cmdType: 'text' })
+        this.addToHistory({ path: appPath, type: type || 'app', name, cmdType: 'text' })
 
         // 隐藏当前插件视图（如果有）
         this.pluginManager?.hidePluginView()
@@ -566,7 +566,7 @@ export class AppsAPI {
       console.log(`[Commands] 以管理员身份启动: ${appPath}`)
 
       // 添加到历史记录
-      this.addToHistory({ path: appPath, type: 'app', name, cmdType: 'text' })
+      this.addToHistory({ path: appPath, type: 'direct', name, cmdType: 'text' })
 
       // 隐藏当前插件视图（如果有）
       this.pluginManager?.hidePluginView()
@@ -584,7 +584,7 @@ export class AppsAPI {
    */
   private async addToHistory(options: {
     path: string
-    type?: 'app' | 'plugin' | 'builtin' | 'file'
+    type?: 'app' | 'direct' | 'plugin' | 'builtin' | 'file'
     featureCode?: string
     param?: any
     name?: string // cmd 名称（用于历史记录显示）
@@ -666,11 +666,14 @@ export class AppsAPI {
         if (app) {
           appInfo = {
             name: cmdName || app.name, // 优先使用传入的 cmd 名称
+            originalName: app.name,
             path: app.path,
             icon: app.icon,
             pinyin: app.pinyin,
             pinyinAbbr: app.pinyinAbbr,
-            type: 'app'
+            type: 'direct',
+            subType: 'app',
+            cmdType: cmdType || 'text'
           }
         } else {
           // 如果不是普通应用，尝试从系统设置中查找
@@ -716,10 +719,12 @@ export class AppsAPI {
       const history: any[] = databaseAPI.dbGet('command-history') || []
 
       // 查找是否已存在（非插件类型需要同时匹配 name 和 path，支持同路径不同名应用）
+      const historyMatchType =
+        appInfo.type === 'direct' && appInfo.subType === 'app' ? 'app' : appInfo.type
       const existingIndex = findCommandIndex(
         history,
         appPath,
-        type,
+        historyMatchType,
         featureCode,
         appInfo.pluginName || appInfo.name
       )
@@ -732,8 +737,12 @@ export class AppsAPI {
         history[existingIndex].path = appInfo.path
         history[existingIndex].name = appInfo.name
         history[existingIndex].icon = appInfo.icon
+        history[existingIndex].type = appInfo.type
+        history[existingIndex].subType = appInfo.subType
+        history[existingIndex].cmdType = appInfo.cmdType
         history[existingIndex].pluginName = appInfo.pluginName
         history[existingIndex].pluginExplain = appInfo.pluginExplain
+        history[existingIndex].originalName = appInfo.originalName
       } else {
         // 新记录
         history.push({
@@ -899,8 +908,13 @@ export class AppsAPI {
     try {
       const pinnedApps: any[] = databaseAPI.dbGet('pinned-commands') || []
 
+      const isDirectApp = app.type === 'direct' && app.subType === 'app'
+      const persistedName = isDirectApp ? app.persistedName || app.name : undefined
+      const matchName =
+        app.type === 'plugin' ? app.pluginName || app.name : persistedName || app.name
+
       // 检查是否已固定（非插件类型需要同时匹配 name 和 path，支持同路径不同名应用）
-      const exists = hasCommand(pinnedApps, app.path, app.featureCode, app.pluginName || app.name)
+      const exists = hasCommand(pinnedApps, app.path, app.featureCode, matchName)
 
       if (exists) {
         console.log('[Commands] 应用已固定:', app.path)
@@ -909,15 +923,19 @@ export class AppsAPI {
 
       // 添加到固定列表
       pinnedApps.push({
-        name: app.name,
+        name: persistedName || app.name,
         path: app.path,
         icon: app.icon,
         type: app.type,
+        subType: app.subType,
         featureCode: app.featureCode,
         pluginExplain: app.pluginExplain,
         pinyin: app.pinyin,
         pinyinAbbr: app.pinyinAbbr,
-        pluginName: app.pluginName
+        pluginName: app.pluginName,
+        cmdType: app.cmdType,
+        originalName: app.originalName,
+        persistedName: app.persistedName
       })
 
       databaseAPI.dbPut('pinned-commands', pinnedApps)
@@ -955,17 +973,24 @@ export class AppsAPI {
   private updatePinnedOrder(newOrder: any[]): void {
     try {
       // 清理数据，只保存必要字段
-      const cleanData = newOrder.map((app) => ({
-        name: app.name,
-        path: app.path,
-        icon: app.icon,
-        type: app.type,
-        featureCode: app.featureCode,
-        pluginExplain: app.pluginExplain,
-        pinyin: app.pinyin,
-        pinyinAbbr: app.pinyinAbbr,
-        pluginName: app.pluginName
-      }))
+      const cleanData = newOrder.map((app) => {
+        const isDirectApp = app.type === 'direct' && app.subType === 'app'
+        return {
+          name: isDirectApp ? app.persistedName || app.name : app.name,
+          path: app.path,
+          icon: app.icon,
+          type: app.type,
+          subType: app.subType,
+          featureCode: app.featureCode,
+          pluginExplain: app.pluginExplain,
+          pinyin: app.pinyin,
+          pinyinAbbr: app.pinyinAbbr,
+          pluginName: app.pluginName,
+          cmdType: app.cmdType,
+          originalName: app.originalName,
+          persistedName: app.persistedName
+        }
+      })
 
       databaseAPI.dbPut('pinned-commands', cleanData)
       console.log('[Commands] 固定列表顺序已更新')

--- a/src/main/api/renderer/systemCommands.ts
+++ b/src/main/api/renderer/systemCommands.ts
@@ -8,10 +8,61 @@ import windowManager from '../../managers/windowManager'
 import webSearchAPI from './webSearch'
 import databaseAPI from '../shared/database'
 import { ColorPicker } from '../../core/native/index.js'
+import { getExplorerFolderPathFromWindow } from '../../utils/common'
 
 interface SystemCommandContext {
   mainWindow: Electron.BrowserWindow | null
   pluginManager: PluginManager | null
+}
+
+function openWindowsCmd(folderPath: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    let settled = false
+    let timeout: ReturnType<typeof setTimeout> | null = null
+
+    const settle = (error?: unknown): void => {
+      if (settled) return
+      settled = true
+      if (timeout) {
+        clearTimeout(timeout)
+        timeout = null
+      }
+
+      if (error) {
+        reject(error)
+        return
+      }
+      resolve()
+    }
+
+    const child = spawn('cmd.exe', ['/c', 'start', '', 'cmd.exe'], {
+      cwd: folderPath,
+      detached: true,
+      stdio: 'ignore',
+      windowsHide: true
+    })
+
+    timeout = setTimeout(() => settle(new Error('启动终端超时')), 3000)
+    child.once('error', settle)
+    child.once('exit', (code) => {
+      if (code && code !== 0) {
+        settle(new Error(`cmd.exe 启动终端失败，退出码: ${code}`))
+        return
+      }
+      settle()
+    })
+    child.once('close', (code) => {
+      if (code && code !== 0) {
+        settle(new Error(`cmd.exe 启动终端失败，退出码: ${code}`))
+        return
+      }
+      settle()
+    })
+    child.once('spawn', () => {
+      child.unref()
+      settle()
+    })
+  })
 }
 
 /**
@@ -107,10 +158,10 @@ export async function executeSystemCommand(
       return handleWindowInfo(ctx)
 
     case 'copy-path':
-      return handleCopyPath(ctx, execAsync)
+      return handleCopyPath(ctx, execAsync, param)
 
     case 'open-terminal':
-      return handleOpenTerminal(ctx, execAsync)
+      return handleOpenTerminal(ctx, execAsync, param)
 
     case 'color-picker':
       return handleColorPicker(ctx)
@@ -378,13 +429,30 @@ function handleWindowInfo(ctx: SystemCommandContext): any {
 
 async function handleCopyPath(
   ctx: SystemCommandContext,
-  execAsync: (cmd: string) => Promise<{ stdout: string; stderr: string }>
+  execAsync: (cmd: string) => Promise<{ stdout: string; stderr: string }>,
+  param?: any
 ): Promise<any> {
   console.log('[SystemCmd] 执行复制路径')
-  const previousWindow = windowManager.getPreviousActiveWindow()
+  const windowInfo =
+    (param?.type === 'window' && param?.payload) || windowManager.getPreviousActiveWindow()
 
-  if (!previousWindow) {
+  if (!windowInfo) {
     return { success: false, error: '无法获取当前窗口信息' }
+  }
+
+  if (process.platform === 'win32') {
+    const folderPath =
+      windowInfo.app === 'explorer.exe'
+        ? getExplorerFolderPathFromWindow(windowInfo, 'SystemCmd')
+        : null
+    if (!folderPath) {
+      return { success: false, error: '未读取到当前 "文件资源管理器" 窗口目录' }
+    }
+
+    clipboard.writeText(folderPath)
+    console.log('[SystemCmd] 已复制路径:', folderPath)
+    ctx.mainWindow?.hide()
+    return { success: true, path: folderPath }
   }
 
   if (process.platform === 'darwin') {
@@ -414,13 +482,36 @@ async function handleCopyPath(
 
 async function handleOpenTerminal(
   ctx: SystemCommandContext,
-  execAsync: (cmd: string) => Promise<{ stdout: string; stderr: string }>
+  execAsync: (cmd: string) => Promise<{ stdout: string; stderr: string }>,
+  param?: any
 ): Promise<any> {
   console.log('[SystemCmd] 执行在终端打开')
-  const previousWindow = windowManager.getPreviousActiveWindow()
+  const windowInfo =
+    (param?.type === 'window' && param?.payload) || windowManager.getPreviousActiveWindow()
 
-  if (!previousWindow) {
+  if (!windowInfo) {
     return { success: false, error: '无法获取当前窗口信息' }
+  }
+
+  if (process.platform === 'win32') {
+    try {
+      const folderPath =
+        windowInfo.app === 'explorer.exe'
+          ? getExplorerFolderPathFromWindow(windowInfo, 'SystemCmd')
+          : null
+      if (!folderPath) {
+        return { success: false, error: '未读取到当前 "文件资源管理器" 窗口目录' }
+      }
+
+      await openWindowsCmd(folderPath)
+      console.log('[SystemCmd] 已在终端打开:', folderPath)
+      ctx.mainWindow?.webContents.send('app-launched')
+      ctx.mainWindow?.hide()
+      return { success: true, path: folderPath }
+    } catch (error) {
+      console.error('[SystemCmd] 在终端打开失败:', error)
+      return { success: false, error: String(error) }
+    }
   }
 
   if (process.platform === 'darwin') {

--- a/src/main/core/detachedWindowManager.ts
+++ b/src/main/core/detachedWindowManager.ts
@@ -184,7 +184,9 @@ class DetachedWindowManager {
           }
         }
       }
+
       const win = new BrowserWindow(windowConfig)
+
       // Windows 11 应用窗口材质（与主窗口保持一致）
       if (isWindows) {
         this.applyWindowMaterial(win)

--- a/src/main/core/superPanelManager.ts
+++ b/src/main/core/superPanelManager.ts
@@ -14,7 +14,7 @@ import translationManager from './translationManager.js'
 const SUPER_PANEL_WIDTH = 250
 const SUPER_PANEL_HEIGHT = 400
 
-// 模拟复制后等待剪贴板监听更新的时间窗口
+// 模拟复制后等待剪贴板更新的时间窗口
 const CLIPBOARD_WAIT_MS = 180
 
 // 剪贴板内容类型
@@ -185,6 +185,8 @@ class SuperPanelManager {
     width?: number
     height?: number
     appPath?: string
+    className?: string
+    hwnd?: number
   } | null = null
 
   /**

--- a/src/main/managers/windowManager.ts
+++ b/src/main/managers/windowManager.ts
@@ -70,6 +70,8 @@ class WindowManager {
     width?: number
     height?: number
     appPath?: string
+    className?: string
+    hwnd?: number
   } | null = null // 打开应用前激活的窗口
   // private _shouldRestoreFocus = true // TODO: 是否在隐藏窗口时恢复焦点（待实现）
   private windowPositionsByDisplay: Record<number, { x: number; y: number }> = {}
@@ -546,6 +548,8 @@ class WindowManager {
       width?: number
       height?: number
       appPath?: string
+      className?: string
+      hwnd?: number
     } | null
   ): void {
     this.previousActiveWindow = windowInfo
@@ -800,6 +804,8 @@ class WindowManager {
     width?: number
     height?: number
     appPath?: string
+    className?: string
+    hwnd?: number
   } | null {
     return this.previousActiveWindow
   }

--- a/src/main/utils/common.ts
+++ b/src/main/utils/common.ts
@@ -1,3 +1,7 @@
+import { app } from 'electron'
+import { fileURLToPath } from 'url'
+import { WindowManager } from '../core/native/index.js'
+
 /**
  * 睡眠指定毫秒数
  * @param ms 毫秒数
@@ -43,4 +47,59 @@ export function extractAcronym(name: string): string {
 
   // 无法提取首字母缩写
   return ''
+}
+
+interface ExplorerFolderWindowInfo {
+  className?: string
+  hwnd?: number | null
+}
+
+export function decodeFileUrlToPath(fileUrl: string): string {
+  try {
+    return fileURLToPath(fileUrl)
+  } catch {
+    const fallbackPath = fileUrl.replace(/^file:\/\/\//, '').replace(/\//g, '\\')
+    try {
+      return decodeURIComponent(fallbackPath)
+    } catch {
+      return fallbackPath
+    }
+  }
+}
+
+/**
+ * 根据窗口类名与 hwnd 读取 Explorer 当前目录。
+ * 返回 null 表示当前窗口不是可读取目录的 Explorer/桌面窗口。
+ */
+export function getExplorerFolderPathFromWindow(
+  windowInfo: ExplorerFolderWindowInfo,
+  logPrefix: string
+): string | null {
+  if (windowInfo.className === 'Progman' || windowInfo.className === 'WorkerW') {
+    return app.getPath('desktop')
+  }
+
+  if (windowInfo.className !== 'CabinetWClass' && windowInfo.className !== 'ExploreWClass') {
+    return null
+  }
+
+  if (typeof windowInfo.hwnd !== 'number') {
+    console.error(`[${logPrefix}] Explorer 窗口缺少 hwnd，无法读取目录`)
+    return null
+  }
+
+  let folderUrl: string | null = null
+  try {
+    folderUrl = WindowManager.getExplorerFolderPath(windowInfo.hwnd)
+  } catch (error) {
+    console.error(`[${logPrefix}] Explorer 目录读取异常 (hwnd=${windowInfo.hwnd}):`, error)
+    return null
+  }
+
+  if (!folderUrl) {
+    console.error(`[${logPrefix}] Explorer 目录读取失败 (hwnd=${windowInfo.hwnd})`)
+    return null
+  }
+
+  return decodeFileUrlToPath(folderUrl)
 }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -6,6 +6,9 @@ export interface Command {
   icon?: string
   type?: string
   subType?: string
+  cmdType?: string
+  originalName?: string
+  persistedName?: string
 }
 
 const api = {
@@ -14,7 +17,7 @@ const api = {
   isWindows: () => ipcRenderer.invoke('is-windows'),
   launch: (options: {
     path: string
-    type?: 'direct' | 'plugin' | 'builtin'
+    type?: 'direct' | 'plugin' | 'builtin' | 'file'
     featureCode?: string
     param?: any
     name?: string
@@ -116,6 +119,8 @@ const api = {
         width?: number
         height?: number
         appPath?: string
+        className?: string
+        hwnd?: number
       } | null
     ) => void
   ) => {
@@ -141,7 +146,15 @@ const api = {
       app: string
       bundleId?: string
       pid?: number
-      timestamp: number
+      title?: string
+      x?: number
+      y?: number
+      width?: number
+      height?: number
+      appPath?: string
+      timestamp?: number
+      className?: string
+      hwnd?: number
     }) => void
   ) => {
     ipcRenderer.on('window-info-changed', (_event, windowInfo) => callback(windowInfo))
@@ -243,9 +256,11 @@ const api = {
   onIpcLaunch: (
     callback: (options: {
       path: string
-      type?: 'direct' | 'plugin'
+      type?: 'app' | 'direct' | 'plugin' | 'builtin' | 'file'
       featureCode?: string
       param?: any
+      name?: string
+      cmdType?: string
     }) => void
   ) => {
     ipcRenderer.on('ipc-launch', (_event, options) => callback(options))
@@ -445,7 +460,7 @@ declare global {
       isWindows: () => Promise<boolean>
       launch: (options: {
         path: string
-        type?: 'direct' | 'plugin' | 'builtin'
+        type?: 'direct' | 'plugin' | 'builtin' | 'file'
         featureCode?: string
         param?: any
         name?: string
@@ -544,7 +559,15 @@ declare global {
             app: string
             bundleId?: string
             pid?: number
+            title?: string
+            x?: number
+            y?: number
+            width?: number
+            height?: number
+            appPath?: string
             timestamp?: number
+            className?: string
+            hwnd?: number
           } | null
         ) => void
       ) => void
@@ -558,7 +581,15 @@ declare global {
           app: string
           bundleId?: string
           pid?: number
-          timestamp: number
+          title?: string
+          x?: number
+          y?: number
+          width?: number
+          height?: number
+          appPath?: string
+          timestamp?: number
+          className?: string
+          hwnd?: number
         }) => void
       ) => void
       onPluginsChanged: (callback: () => void) => void
@@ -574,7 +605,7 @@ declare global {
       onIpcLaunch: (
         callback: (options: {
           path: string
-          type?: 'direct' | 'plugin'
+          type?: 'app' | 'direct' | 'plugin' | 'builtin' | 'file'
           featureCode?: string
           param?: any
           name?: string

--- a/src/renderer/src/components/search/SearchResults.vue
+++ b/src/renderer/src/components/search/SearchResults.vue
@@ -490,11 +490,17 @@ async function handleAppContextMenu(
 
   // 只在历史记录中显示"从使用记录删除"
   if (!fromSearch && !fromPinned) {
+    const historyMatchName =
+      app.type === 'plugin'
+        ? app.pluginName || app.name
+        : app.type === 'direct' && app.subType === 'app'
+          ? app.persistedName || app.name
+          : app.name
     menuItems.push({
       id: `remove-from-history:${JSON.stringify({
         path: app.path,
         featureCode: app.featureCode,
-        name: app.pluginName || app.name
+        name: historyMatchName
       })}`,
       label: '从使用记录删除'
     })
@@ -520,19 +526,26 @@ async function handleAppContextMenu(
   }
 
   // 根据是否已固定显示不同选项
-  if (isPinned(app.path, app.featureCode, app.pluginName || app.name)) {
+  const pinMatchName =
+    app.type === 'plugin'
+      ? app.pluginName || app.name
+      : app.type === 'direct' && app.subType === 'app'
+        ? app.persistedName || app.name
+        : app.name
+  if (isPinned(app.path, app.featureCode, pinMatchName)) {
     menuItems.push({
       id: `unpin-app:${JSON.stringify({
         path: app.path,
         featureCode: app.featureCode,
-        name: app.pluginName || app.name
+        name: pinMatchName
       })}`,
       label: '从搜索框取消固定'
     })
   } else {
     menuItems.push({
       id: `pin-app:${JSON.stringify({
-        name: app.name,
+        name:
+          app.type === 'direct' && app.subType === 'app' ? app.persistedName || app.name : app.name,
         path: app.path,
         icon: app.icon,
         pinyin: app.pinyin,
@@ -540,7 +553,11 @@ async function handleAppContextMenu(
         type: app.type,
         featureCode: app.featureCode,
         pluginName: app.pluginName,
-        pluginExplain: app.pluginExplain
+        pluginExplain: app.pluginExplain,
+        subType: app.subType,
+        cmdType: app.cmdType,
+        originalName: app.originalName,
+        persistedName: app.persistedName
       })}`,
       label: '固定到搜索框'
     })
@@ -666,6 +683,10 @@ async function handleSelectApp(app: any): Promise<void> {
         path: file.path
       })) as MatchFile[]
     } else if (app.cmdType === 'window') {
+      if (!commandDataStore.matchesWindowCommand(app, windowStore.currentWindow)) {
+        console.warn('window 指令与当前窗口不匹配，已阻止启动:', app.name)
+        return
+      }
       payload = JSON.parse(JSON.stringify(windowStore.currentWindow))
     }
 

--- a/src/renderer/src/composables/useSearchResults.ts
+++ b/src/renderer/src/composables/useSearchResults.ts
@@ -55,8 +55,14 @@ export function useSearchResults(props: {
 } {
   const commandDataStore = useCommandDataStore()
   const windowStore = useWindowStore()
-  const { search, searchInCommands, searchImageCommands, searchTextCommands, searchFileCommands } =
-    commandDataStore
+  const {
+    search,
+    searchInCommands,
+    searchImageCommands,
+    searchTextCommands,
+    searchFileCommands,
+    matchesWindowCommand
+  } = commandDataStore
 
   // 使用统计缓存（key: "path:featureCode", value: useCount）
   const usageStatsMap = ref<Map<string, number>>(new Map())
@@ -84,6 +90,15 @@ export function useSearchResults(props: {
     },
     { immediate: true }
   )
+
+  function filterUnavailableWindowCommands<
+    T extends { cmdType?: string; matchCmd?: { type?: string } }
+  >(results: T[]): T[] {
+    return results.filter((cmd) => {
+      const cmdType = cmd.cmdType || cmd.matchCmd?.type
+      return cmdType !== 'window' || matchesWindowCommand(cmd as any, windowStore.currentWindow)
+    })
+  }
 
   // 统一的搜索结果（只执行一次搜索）
   const unifiedSearchResult = computed(() => {
@@ -134,7 +149,7 @@ export function useSearchResults(props: {
       return []
     }
 
-    return unifiedSearchResult.value.bestMatches
+    return filterUnavailableWindowCommands(unifiedSearchResult.value.bestMatches)
   })
 
   // 最佳匹配（匹配指令：regex/img/files 类型）

--- a/src/renderer/src/env.d.ts
+++ b/src/renderer/src/env.d.ts
@@ -25,7 +25,7 @@ declare global {
       isWindows: () => Promise<boolean>
       launch: (options: {
         path: string
-        type?: 'direct' | 'plugin' | 'file'
+        type?: 'direct' | 'plugin' | 'builtin' | 'file'
         featureCode?: string
         param?: any
         name?: string
@@ -157,6 +157,8 @@ declare global {
             width?: number
             height?: number
             appPath?: string
+            className?: string
+            hwnd?: number
           } | null
         ) => void
       ) => void
@@ -187,7 +189,7 @@ declare global {
       onIpcLaunch: (
         callback: (options: {
           path: string
-          type?: 'app' | 'plugin'
+          type?: 'app' | 'direct' | 'plugin' | 'builtin' | 'file'
           featureCode?: string
           param?: any
           name?: string
@@ -247,7 +249,20 @@ declare global {
       // 窗口相关
       windowPaste: () => Promise<{ success: boolean; error?: string }>
       onWindowInfoChanged: (
-        callback: (windowInfo: { appName: string; bundleId: string; timestamp: number }) => void
+        callback: (windowInfo: {
+          app: string
+          bundleId?: string
+          pid?: number
+          title?: string
+          x?: number
+          y?: number
+          width?: number
+          height?: number
+          appPath?: string
+          timestamp?: number
+          className?: string
+          hwnd?: number
+        }) => void
       ) => void
       getLastCopiedContent: (timeLimit?: number) => Promise<{
         type: 'text' | 'image' | 'file'

--- a/src/renderer/src/stores/commandDataStore.ts
+++ b/src/renderer/src/stores/commandDataStore.ts
@@ -11,6 +11,7 @@ import {
 } from './commandUtils'
 import {
   COMMAND_ALIASES_KEY,
+  getLegacyDirectAppCommandId,
   normalizeCommandAliases,
   type CommandAliasStore
 } from '@shared/commandShared'
@@ -88,8 +89,8 @@ export interface Command {
   pluginName?: string // 插件名称（仅插件类型有效）
   pluginTitle?: string // 插件标题（仅插件类型有效）
   pluginExplain?: string // 插件功能说明
-  matchCmd?: MatchCmd // 匹配指令配置（regex 或 over 或 img 或 files）
-  cmdType?: 'text' | 'regex' | 'over' | 'img' | 'files' // cmd类型
+  matchCmd?: MatchCmd // 匹配指令配置（regex 或 over 或 img 或 files 或 window）
+  cmdType?: 'text' | 'regex' | 'over' | 'img' | 'files' | 'window' // cmd类型
   mainPush?: boolean // 是否为 mainPush 功能（搜索时动态查询插件获取结果）
   matches?: MatchInfo[] // 搜索匹配信息（用于高亮显示）
   matchType?: 'acronym' | 'name' | 'pinyin' | 'pinyinAbbr' // 匹配类型（用于高亮算法选择）
@@ -97,6 +98,8 @@ export interface Command {
   settingUri?: string // ms-settings URI
   category?: string // 分类（用于分组显示）
   confirmDialog?: any // 确认对话框配置
+  originalName?: string // 原始名称（用于 direct/app 旧版禁用键兼容）
+  persistedName?: string // 持久化记录里的名称（用于历史/固定在 alias 删除后的删除与取消固定）
 }
 
 interface SearchResultScoreMeta {
@@ -175,8 +178,13 @@ export const useCommandDataStore = defineStore('commandData', () => {
   const commands = ref<Command[]>([]) // 用于 Fuse 模糊搜索的指令列表
   const regexCommands = ref<Command[]>([]) // 只用正则匹配的指令列表
   const mainPushFeatures = ref<MainPushFeature[]>([]) // mainPush 功能列表
+  const rawAppsCache = ref<any[]>([])
+  const enabledPluginsCache = ref<any[]>([])
+  const systemSettingCommandsCache = ref<Command[]>([])
+  const localShortcutCommandsCache = ref<Command[]>([])
   const loading = ref(false)
   const fuse = ref<Fuse<Command> | null>(null)
+  let loadCommandsRequestId = 0
   // 是否已初始化
   const isInitialized = ref(false)
   // 标记是否是本地触发的更新（用于避免重复加载）
@@ -232,8 +240,7 @@ export const useCommandDataStore = defineStore('commandData', () => {
     })
   }
 
-  // 生成指令唯一标识（与设置插件保持一致）
-  // 格式: pluginName:featureCode:cmdName:cmdType
+  // 生成指令唯一标识（与设置插件保持一致，direct/app 使用 path-based 稳定 ID）
   function getCommandId(cmd: Command): string {
     return _getCommandId(cmd)
   }
@@ -241,49 +248,160 @@ export const useCommandDataStore = defineStore('commandData', () => {
   /**
    * 基于当前指令列表，找到与历史记录或固定项对应的最新指令快照。
    *
-   * 对插件指令（有 featureCode）采用两阶段匹配：
-   * 1. 精确匹配（含名称）——使别名指令项被正确识别，历史/固定列表中显示的是别名而非原始名称；
-   * 2. 宽松匹配（忽略名称）——别名已删除或指令被重命名时，降级展示原始指令，避免数据丢失。
-   *
-   * 对非插件指令按「名称 + type + subType + featureCode」精确匹配。
+   * - 插件指令：先按 name 精确匹配，再按插件身份 + featureCode 回退。
+   * - direct/app：先按 path + name 精确匹配，再按 path 回退，使 alias 删除后自动回退原名。
+   * - 其它类型：保持名称级精确匹配。
    */
   function findCurrentCommandMatch(storedCommand: Command): Command | undefined {
-    // 非插件类型：直接按名称 + 类型精确匹配
-    if (storedCommand.type !== 'plugin' || !storedCommand.featureCode) {
-      return commands.value.find(
+    if (storedCommand.type === 'plugin' && storedCommand.featureCode) {
+      const isSamePlugin = (cmd: Command): boolean => {
+        if (cmd.pluginName && storedCommand.pluginName) {
+          return cmd.pluginName === storedCommand.pluginName
+        }
+        return cmd.path === storedCommand.path
+      }
+
+      const isPluginMatch = (cmd: Command): boolean =>
+        cmd.type === 'plugin' && cmd.featureCode === storedCommand.featureCode && isSamePlugin(cmd)
+
+      const nameMatch = commands.value.find(
+        (cmd) => isPluginMatch(cmd) && cmd.name === storedCommand.name
+      )
+      if (nameMatch) return nameMatch
+
+      return commands.value.find(isPluginMatch)
+    }
+
+    const isStoredDirectApp =
+      (storedCommand.type as string) === 'app' ||
+      (storedCommand.type === 'direct' && storedCommand.subType === 'app')
+
+    if (isStoredDirectApp) {
+      const exactMatch = commands.value.find(
         (cmd) =>
-          cmd.name === storedCommand.name &&
-          cmd.type === storedCommand.type &&
-          cmd.subType === storedCommand.subType &&
-          cmd.featureCode === storedCommand.featureCode
+          cmd.type === 'direct' &&
+          cmd.subType === 'app' &&
+          cmd.path === storedCommand.path &&
+          cmd.name === storedCommand.name
+      )
+      if (exactMatch) return exactMatch
+
+      return commands.value.find(
+        (cmd) => cmd.type === 'direct' && cmd.subType === 'app' && cmd.path === storedCommand.path
       )
     }
 
-    // 插件类型：pluginName 已是全局唯一标识（开发版含 __dev 后缀）
-    const isSamePlugin = (cmd: Command): boolean => {
-      if (cmd.pluginName && storedCommand.pluginName) {
-        return cmd.pluginName === storedCommand.pluginName
-      }
-      return cmd.path === storedCommand.path
+    return commands.value.find(
+      (cmd) =>
+        cmd.name === storedCommand.name &&
+        cmd.type === storedCommand.type &&
+        cmd.subType === storedCommand.subType &&
+        cmd.featureCode === storedCommand.featureCode
+    )
+  }
+
+  /**
+   * direct/app 历史与固定支持两种旧数据形态：旧版可能写成 type: 'app'，新版为 type: 'direct' + subType: 'app'。
+   */
+  function isDirectAppRecord(command: Pick<Command, 'type' | 'subType'>): boolean {
+    return (
+      (command.type as string) === 'app' || (command.type === 'direct' && command.subType === 'app')
+    )
+  }
+
+  /**
+   * direct/app 历史与固定在回退到原名后，仍保留持久化时的旧名称，便于删除历史或取消固定时命中原记录。
+   * persistedName 既兼容旧记录直接写在 name 上，也兼容拖拽排序后单独落盘的 persistedName 字段。
+   */
+  function attachPersistedName(
+    currentCommand: Command | undefined,
+    storedCommand: Command
+  ): Command | undefined {
+    if (!currentCommand) {
+      return undefined
     }
 
-    const isPluginMatch = (cmd: Command): boolean =>
-      cmd.type === 'plugin' && cmd.featureCode === storedCommand.featureCode && isSamePlugin(cmd)
+    const persistedName = storedCommand.persistedName || storedCommand.name
+    if (
+      isDirectAppRecord(storedCommand) &&
+      persistedName &&
+      persistedName !== currentCommand.name
+    ) {
+      return {
+        ...currentCommand,
+        persistedName
+      }
+    }
 
-    // 阶段 1：精确匹配（含名称），使别名指令项被正确识别
-    const nameMatch = commands.value.find(
-      (cmd) => isPluginMatch(cmd) && cmd.name === storedCommand.name
-    )
-    if (nameMatch) return nameMatch
+    return currentCommand
+  }
 
-    // 阶段 2：宽松匹配（忽略名称），别名已删除或指令重命名时降级展示原始指令
-    return commands.value.find(isPluginMatch)
+  /**
+   * 基于 alias 文本构造一个可搜索的衍生指令。
+   */
+  function buildAliasSearchCommand(command: Command, alias: string, icon?: string): Command {
+    return {
+      ...command,
+      name: alias,
+      icon: icon || command.icon,
+      originalName:
+        command.type === 'direct' && command.subType === 'app'
+          ? command.originalName || command.name
+          : command.originalName,
+      pinyin: pinyin(alias, { toneType: 'none', type: 'string' }).replace(/\s+/g, '').toLowerCase(),
+      pinyinAbbr: pinyin(alias, { pattern: 'first', toneType: 'none', type: 'string' })
+        .replace(/\s+/g, '')
+        .toLowerCase()
+    }
+  }
+
+  function getLaunchableAliasEntries(command: Command, aliasesMap: CommandAliasStore): Command[] {
+    const cmdType = command.cmdType || 'text'
+    const isPluginLaunchable = command.type === 'plugin' && ['text', 'window'].includes(cmdType)
+    const isDirectAppLaunchable =
+      command.type === 'direct' && command.subType === 'app' && cmdType === 'text'
+
+    if (!isPluginLaunchable && !isDirectAppLaunchable) {
+      return []
+    }
+
+    const aliasEntries = aliasesMap[getCommandId(command)]
+    if (!aliasEntries?.length) {
+      return []
+    }
+
+    return aliasEntries.map((entry) => buildAliasSearchCommand(command, entry.alias, entry.icon))
+  }
+
+  function expandDirectAppAliases(baseApp: Command, aliasesMap: CommandAliasStore): Command[] {
+    const aliasCommands = getLaunchableAliasEntries(baseApp, aliasesMap)
+    if (!aliasCommands.length) {
+      return []
+    }
+
+    const seenNames = new Set<string>([
+      baseApp.name.toLowerCase(),
+      ...((baseApp as any).aliases || [])
+        .filter((alias: unknown): alias is string => typeof alias === 'string')
+        .map((alias) => alias.toLowerCase())
+    ])
+
+    const results: Command[] = []
+    for (const aliasCommand of aliasCommands) {
+      const normalizedAlias = aliasCommand.name.toLowerCase()
+      if (seenNames.has(normalizedAlias)) {
+        continue
+      }
+      seenNames.add(normalizedAlias)
+      results.push(aliasCommand)
+    }
+
+    return results
   }
 
   async function loadCommandAliases(): Promise<CommandAliasStore> {
     try {
       const data = await window.ztools.dbGet(COMMAND_ALIASES_KEY)
-      // 统一在渲染层入口做一次归一化，兼容旧数据结构，避免后续搜索逻辑分散处理兼容分支
       return normalizeCommandAliases(data)
     } catch (error) {
       console.error('加载指令别名失败:', error)
@@ -291,43 +409,25 @@ export const useCommandDataStore = defineStore('commandData', () => {
     }
   }
 
-  function expandPluginTextCommandAliases(
-    command: Command,
-    aliasesMap: CommandAliasStore
-  ): Command[] {
-    // alias 只作用于插件的文本指令；匹配指令和直接启动项保持原始行为
-    if (command.type !== 'plugin' || command.cmdType !== 'text') {
-      return [command]
-    }
-
-    const aliasEntries = aliasesMap[getCommandId(command)]
-    if (!aliasEntries?.length) {
-      return [command]
-    }
-
-    // 为每个别名生成一个独立的指令（与应用本地化别名处理方式一致）
-    const aliasCommands: Command[] = aliasEntries.map((entry) => ({
-      ...command,
-      name: entry.alias,
-      icon: entry.icon || command.icon,
-      pinyin: pinyin(entry.alias, { toneType: 'none', type: 'string' })
-        .replace(/\s+/g, '')
-        .toLowerCase(),
-      pinyinAbbr: pinyin(entry.alias, { pattern: 'first', toneType: 'none', type: 'string' })
-        .replace(/\s+/g, '')
-        .toLowerCase()
-    }))
-
-    return [command, ...aliasCommands]
-  }
-
-  // 检查指令是否被禁用
+  /**
+   * 检查指令是否被禁用。
+   * direct/app 额外兼容旧版 name-based 禁用键。
+   */
   function isCommandDisabled(cmd: Command): boolean {
     const id = getCommandId(cmd)
-    return disabledCommands.value.includes(id)
+    if (disabledCommands.value.includes(id)) {
+      return true
+    }
+
+    if (cmd.type === 'direct' && cmd.subType === 'app') {
+      return disabledCommands.value.includes(
+        getLegacyDirectAppCommandId(cmd.originalName || cmd.name)
+      )
+    }
+
+    return false
   }
 
-  // 加载禁用指令列表
   async function loadDisabledCommands(): Promise<void> {
     try {
       const data = await window.ztools.dbGet(DISABLED_COMMANDS_KEY)
@@ -349,7 +449,6 @@ export const useCommandDataStore = defineStore('commandData', () => {
     }
   }
 
-  // 加载搜索偏好记录
   async function loadSearchPreference(): Promise<void> {
     try {
       const data = await window.ztools.dbGet('search-preference')
@@ -406,7 +505,7 @@ export const useCommandDataStore = defineStore('commandData', () => {
         loadHistoryData()
       })
 
-      // 监听指令列表变化事件（应用文件夹变化、插件变化或 alias 保存后触发）
+      // 监听指令列表变化事件（应用文件夹变化、插件变化时触发）
       window.ztools.onAppsChanged(() => {
         loadCommands()
       })
@@ -436,7 +535,7 @@ export const useCommandDataStore = defineStore('commandData', () => {
         loadDisabledCommands()
       })
 
-      // 监听指令别名变化事件（仅重建别名展开，不重新获取系统应用）
+      // 监听指令别名变化事件，仅基于当前缓存重建 alias 展开，避免重复扫描系统应用。
       window.ztools.onCommandAliasesChanged(() => {
         reloadCommandAliases()
       })
@@ -559,27 +658,23 @@ export const useCommandDataStore = defineStore('commandData', () => {
       ])
       setDisabledPluginPaths(disabledPlugins)
       const enabledPluginPaths = getEnabledPluginPaths(plugins)
-      const enabledPlugins = plugins.filter((plugin: any) => enabledPluginPaths.has(plugin.path))
-
-      const { pluginItems, regexItems, mainPushItems } = buildPluginCommandItems(
-        enabledPlugins,
-        commandAliases
+      enabledPluginsCache.value = plugins.filter((plugin: any) =>
+        enabledPluginPaths.has(plugin.path)
       )
 
-      // 替换 commands 中的插件指令部分，保留非插件指令（系统应用、系统设置、本地启动项）
-      const nonPluginCommands = commands.value.filter((c) => c.type !== 'plugin')
-      commands.value = [...nonPluginCommands, ...pluginItems]
-      regexCommands.value = regexItems
-      mainPushFeatures.value = mainPushItems
-
-      // 重建 Fuse.js 搜索索引
-      rebuildFuseIndex()
-
-      console.log(
-        `[PluginCommands] 插件指令已更新: ${pluginItems.length} 个普通指令, ${regexItems.length} 个匹配指令`
-      )
+      rebuildCommandCollections(commandAliases)
     } catch (error) {
       console.error('[PluginCommands] 重载插件指令失败:', error)
+    }
+  }
+
+  async function reloadCommandAliases(): Promise<void> {
+    try {
+      const commandAliases = await loadCommandAliases()
+      rebuildCommandCollections(commandAliases)
+      console.log('[CommandAliases] 指令别名已更新')
+    } catch (error) {
+      console.error('[CommandAliases] 重载指令别名失败:', error)
     }
   }
 
@@ -688,7 +783,7 @@ export const useCommandDataStore = defineStore('commandData', () => {
           const cmdName = isMatchCmd ? cmd.label : cmd
 
           if (isMatchCmd) {
-            regexItems.push({
+            const matchCommand: Command = {
               name: cmdName,
               path: plugin.path,
               icon: featureIcon,
@@ -710,35 +805,38 @@ export const useCommandDataStore = defineStore('commandData', () => {
               })
                 .replace(/\s+/g, '')
                 .toLowerCase()
-            })
+            }
+
+            regexItems.push(matchCommand)
+
+            if (cmd.type === 'window') {
+              pluginItems.push(...getLaunchableAliasEntries(matchCommand, commandAliases))
+            }
           } else {
-            pluginItems.push(
-              ...expandPluginTextCommandAliases(
-                {
-                  name: cmdName,
-                  path: plugin.path,
-                  icon: featureIcon,
-                  type: 'plugin',
-                  featureCode: feature.code,
-                  pluginName: plugin.name,
-                  pluginTitle: plugin.title,
-                  pluginExplain: feature.explain,
-                  cmdType: 'text',
-                  mainPush: isMainPush,
-                  pinyin: pinyin(cmdName, { toneType: 'none', type: 'string' })
-                    .replace(/\s+/g, '')
-                    .toLowerCase(),
-                  pinyinAbbr: pinyin(cmdName, {
-                    pattern: 'first',
-                    toneType: 'none',
-                    type: 'string'
-                  })
-                    .replace(/\s+/g, '')
-                    .toLowerCase()
-                },
-                commandAliases
-              )
-            )
+            const textCommand: Command = {
+              name: cmdName,
+              path: plugin.path,
+              icon: featureIcon,
+              type: 'plugin',
+              featureCode: feature.code,
+              pluginName: plugin.name,
+              pluginTitle: plugin.title,
+              pluginExplain: feature.explain,
+              cmdType: 'text',
+              mainPush: isMainPush,
+              pinyin: pinyin(cmdName, { toneType: 'none', type: 'string' })
+                .replace(/\s+/g, '')
+                .toLowerCase(),
+              pinyinAbbr: pinyin(cmdName, {
+                pattern: 'first',
+                toneType: 'none',
+                type: 'string'
+              })
+                .replace(/\s+/g, '')
+                .toLowerCase()
+            }
+
+            pluginItems.push(textCommand, ...getLaunchableAliasEntries(textCommand, commandAliases))
           }
         }
       }
@@ -747,65 +845,81 @@ export const useCommandDataStore = defineStore('commandData', () => {
     return { pluginItems, regexItems, mainPushItems }
   }
 
+  function buildAppCommandItems(rawApps: any[], commandAliases: CommandAliasStore): Command[] {
+    return rawApps.flatMap((app) => {
+      const extendedApp = app as any
+      const baseApp: Command = {
+        ...app,
+        type: extendedApp.type || ('direct' as const),
+        subType: extendedApp.subType || ('app' as const),
+        cmdType: 'text',
+        originalName: app.name,
+        pinyin: pinyin(app.name, { toneType: 'none', type: 'string' })
+          .replace(/\s+/g, '')
+          .toLowerCase(),
+        pinyinAbbr: pinyin(app.name, { pattern: 'first', toneType: 'none', type: 'string' })
+          .replace(/\s+/g, '')
+          .toLowerCase()
+      }
+      const result: Command[] = [baseApp]
+      if (extendedApp.aliases && Array.isArray(extendedApp.aliases)) {
+        for (const alias of extendedApp.aliases) {
+          if (alias && alias !== extendedApp.name) {
+            result.push({
+              ...baseApp,
+              name: alias,
+              pinyin: pinyin(alias, { toneType: 'none', type: 'string' })
+                .replace(/\s+/g, '')
+                .toLowerCase(),
+              pinyinAbbr: pinyin(alias, { pattern: 'first', toneType: 'none', type: 'string' })
+                .replace(/\s+/g, '')
+                .toLowerCase()
+            })
+          }
+        }
+      }
+
+      result.push(...expandDirectAppAliases(baseApp, commandAliases))
+
+      return result
+    })
+  }
+
+  function rebuildCommandCollections(commandAliases: CommandAliasStore): void {
+    const appItems = buildAppCommandItems(rawAppsCache.value, commandAliases)
+    const { pluginItems, regexItems, mainPushItems } = buildPluginCommandItems(
+      enabledPluginsCache.value,
+      commandAliases
+    )
+
+    commands.value = [
+      ...appItems,
+      ...pluginItems,
+      ...systemSettingCommandsCache.value,
+      ...localShortcutCommandsCache.value
+    ]
+    regexCommands.value = regexItems
+    mainPushFeatures.value = mainPushItems
+
+    rebuildFuseIndex()
+
+    console.log(
+      `加载了 ${appItems.length} 个应用指令, ${pluginItems.length} 个插件指令, ${systemSettingCommandsCache.value.length} 个系统设置指令, ${localShortcutCommandsCache.value.length} 个本地启动项, ${regexItems.length} 个匹配指令`
+    )
+  }
+
   // 加载指令列表
   async function loadCommands(): Promise<void> {
+    const requestId = ++loadCommandsRequestId
     loading.value = true
     try {
       const [rawApps, plugins, disabledPlugins, commandAliases] = await Promise.all([
         window.ztools.getApps(),
-        window.ztools.getAllPlugins(), // 使用 getAllPlugins 获取所有插件（包括 system）
+        window.ztools.getAllPlugins(),
         window.ztools.getDisabledPlugins(),
         loadCommandAliases()
       ])
-      setDisabledPluginPaths(disabledPlugins)
-      const enabledPluginPaths = getEnabledPluginPaths(plugins)
-      const enabledPlugins = plugins.filter((plugin: any) => enabledPluginPaths.has(plugin.path))
 
-      // 处理本地应用指令
-      const appItems = rawApps.flatMap((app) => {
-        // 类型断言：后端可能返回扩展字段（type, subType）
-        const extendedApp = app as any
-        const baseApp = {
-          ...app,
-          // 保留已有的 type 和 subType（用于内置指令），否则使用默认值
-          type: extendedApp.type || ('direct' as const),
-          subType: extendedApp.subType || ('app' as const),
-          pinyin: pinyin(app.name, { toneType: 'none', type: 'string' })
-            .replace(/\s+/g, '')
-            .toLowerCase(),
-          pinyinAbbr: pinyin(app.name, { pattern: 'first', toneType: 'none', type: 'string' })
-            .replace(/\s+/g, '')
-            .toLowerCase()
-        }
-        const result = [baseApp]
-        // 如果有别名（如本地化名称），为每个别名生成一个独立的指令
-        if (extendedApp.aliases && Array.isArray(extendedApp.aliases)) {
-          for (const alias of extendedApp.aliases) {
-            if (alias && alias !== extendedApp.name) {
-              result.push({
-                ...baseApp,
-                name: alias,
-                pinyin: pinyin(alias, { toneType: 'none', type: 'string' })
-                  .replace(/\s+/g, '')
-                  .toLowerCase(),
-                pinyinAbbr: pinyin(alias, { pattern: 'first', toneType: 'none', type: 'string' })
-                  .replace(/\s+/g, '')
-                  .toLowerCase()
-              })
-            }
-          }
-        }
-
-        return result
-      })
-
-      // 处理插件：每个 cmd 转换为一个独立指令，插件文本指令的别名会展开为额外的独立指令
-      const { pluginItems, regexItems, mainPushItems } = buildPluginCommandItems(
-        enabledPlugins,
-        commandAliases
-      )
-
-      // 3. 加载系统设置（仅 Windows 平台）
       let settingCommands: Command[] = []
       try {
         const isWindows = window.ztools.getPlatform() === 'win32'
@@ -814,12 +928,12 @@ export const useCommandDataStore = defineStore('commandData', () => {
           settingCommands = settings.map((s: any) => ({
             name: s.name,
             path: s.uri,
-            icon: settingsFillIcon, // 使用前端统一图标
+            icon: settingsFillIcon,
             type: 'direct' as const,
             subType: 'system-setting' as const,
             settingUri: s.uri,
             category: s.category,
-            confirmDialog: s.confirmDialog, // 传递确认对话框配置
+            confirmDialog: s.confirmDialog,
             pinyin: pinyin(s.name, { toneType: 'none', type: 'string' })
               .replace(/\s+/g, '')
               .toLowerCase(),
@@ -832,7 +946,6 @@ export const useCommandDataStore = defineStore('commandData', () => {
         console.error('加载系统设置失败:', error)
       }
 
-      // 4. 加载本地启动项
       let localShortcuts: Command[] = []
       try {
         const shortcuts = await window.ztools.localShortcuts.getAll()
@@ -850,20 +963,26 @@ export const useCommandDataStore = defineStore('commandData', () => {
         console.error('加载本地启动项失败:', error)
       }
 
-      // 合并所有指令
-      commands.value = [...appItems, ...pluginItems, ...settingCommands, ...localShortcuts]
-      regexCommands.value = regexItems
-      mainPushFeatures.value = mainPushItems
+      if (requestId !== loadCommandsRequestId) {
+        return
+      }
 
-      console.log(
-        `加载了 ${appItems.length} 个应用指令, ${pluginItems.length} 个插件指令, ${settingCommands.length} 个系统设置指令, ${localShortcuts.length} 个本地启动项, ${regexItems.length} 个匹配指令`
+      setDisabledPluginPaths(disabledPlugins)
+      rawAppsCache.value = rawApps
+      const enabledPluginPaths = getEnabledPluginPaths(plugins)
+      enabledPluginsCache.value = plugins.filter((plugin: any) =>
+        enabledPluginPaths.has(plugin.path)
       )
+      systemSettingCommandsCache.value = settingCommands
+      localShortcutCommandsCache.value = localShortcuts
 
-      rebuildFuseIndex()
+      rebuildCommandCollections(commandAliases)
     } catch (error) {
       console.error('加载指令失败:', error)
     } finally {
-      loading.value = false
+      if (requestId === loadCommandsRequestId) {
+        loading.value = false
+      }
     }
   }
 
@@ -873,7 +992,7 @@ export const useCommandDataStore = defineStore('commandData', () => {
   async function reloadLocalShortcuts(): Promise<void> {
     try {
       const shortcuts = await window.ztools.localShortcuts.getAll()
-      const newLocalShortcuts: Command[] = shortcuts.map((s: any) => ({
+      localShortcutCommandsCache.value = shortcuts.map((s: any) => ({
         name: s.alias || s.name,
         path: s.path,
         icon: s.icon,
@@ -884,48 +1003,13 @@ export const useCommandDataStore = defineStore('commandData', () => {
         cmdType: 'text' as const
       }))
 
-      // 替换 commands 中的本地启动项部分
-      const nonLocalCommands = commands.value.filter((c) => c.subType !== 'local-shortcut')
-      commands.value = [...nonLocalCommands, ...newLocalShortcuts]
+      rebuildCommandCollections(await loadCommandAliases())
 
-      rebuildFuseIndex()
-
-      console.log(`[LocalShortcuts] 本地启动项已更新: ${newLocalShortcuts.length} 个`)
+      console.log(
+        `[LocalShortcuts] 本地启动项已更新: ${localShortcutCommandsCache.value.length} 个`
+      )
     } catch (error) {
       console.error('[LocalShortcuts] 重载本地启动项失败:', error)
-    }
-  }
-
-  /**
-   * 仅重新加载指令别名并重建插件文本指令的别名展开，不重新获取系统应用。
-   */
-  async function reloadCommandAliases(): Promise<void> {
-    try {
-      const [plugins, disabledPlugins, commandAliases] = await Promise.all([
-        window.ztools.getAllPlugins(),
-        window.ztools.getDisabledPlugins(),
-        loadCommandAliases()
-      ])
-      setDisabledPluginPaths(disabledPlugins)
-      const enabledPluginPaths = getEnabledPluginPaths(plugins)
-      const enabledPlugins = plugins.filter((plugin: any) => enabledPluginPaths.has(plugin.path))
-
-      const { pluginItems, regexItems, mainPushItems } = buildPluginCommandItems(
-        enabledPlugins,
-        commandAliases
-      )
-
-      // 替换 commands 中的插件指令部分，保留非插件指令
-      const nonPluginCommands = commands.value.filter((c) => c.type !== 'plugin')
-      commands.value = [...nonPluginCommands, ...pluginItems]
-      regexCommands.value = regexItems
-      mainPushFeatures.value = mainPushItems
-
-      rebuildFuseIndex()
-
-      console.log(`[CommandAliases] 指令别名已更新，插件指令: ${pluginItems.length} 个`)
-    } catch (error) {
-      console.error('[CommandAliases] 重载指令别名失败:', error)
     }
   }
 
@@ -1245,6 +1329,61 @@ export const useCommandDataStore = defineStore('commandData', () => {
     return result.filter((cmd) => !isCommandDisabled(cmd)).map((cmd) => applySpecialConfig(cmd))
   }
 
+  const windowTitleRegexCache = new Map<string, RegExp | null>()
+
+  function getCachedWindowTitleRegex(pattern: string): RegExp | null {
+    if (windowTitleRegexCache.has(pattern)) {
+      return windowTitleRegexCache.get(pattern) || null
+    }
+
+    try {
+      const titleRegexStr = pattern.replace(/^\/|\/[gimuy]*$/g, '')
+      const regex = new RegExp(titleRegexStr)
+      windowTitleRegexCache.set(pattern, regex)
+      return regex
+    } catch (error) {
+      console.error(`窗口标题正则表达式 ${pattern} 解析失败:`, error)
+      windowTitleRegexCache.set(pattern, null)
+      return null
+    }
+  }
+
+  function matchesWindowCommand(
+    command: Command,
+    windowInfo?: { app?: string; title?: string } | null
+  ): boolean {
+    if (
+      !windowInfo ||
+      (!windowInfo.app && !windowInfo.title) ||
+      command.matchCmd?.type !== 'window'
+    ) {
+      return false
+    }
+
+    const windowCmd = command.matchCmd as WindowCmd
+
+    // 检查 app 匹配
+    if (windowCmd.match.app && windowInfo.app) {
+      const appMatches = windowCmd.match.app.some((appPattern) => {
+        // 直接字符串匹配
+        return windowInfo.app === appPattern
+      })
+      if (appMatches) {
+        return true
+      }
+    }
+
+    // 检查 title 匹配（正则表达式）
+    if (windowCmd.match.title && windowInfo.title) {
+      const titleRegex = getCachedWindowTitleRegex(windowCmd.match.title)
+      if (titleRegex?.test(windowInfo.title)) {
+        return true
+      }
+    }
+
+    return false
+  }
+
   // 搜索支持窗口的指令（根据当前激活窗口进行匹配）
   function searchWindowCommands(windowInfo?: { app?: string; title?: string }): SearchResult[] {
     if (!windowInfo || (!windowInfo.app && !windowInfo.title)) {
@@ -1252,36 +1391,7 @@ export const useCommandDataStore = defineStore('commandData', () => {
     }
 
     const windowCommandsList = regexCommands.value.filter((c) => c.matchCmd?.type === 'window')
-
-    const result = windowCommandsList.filter((cmd) => {
-      const windowCmd = cmd.matchCmd as WindowCmd
-
-      // 检查 app 匹配
-      if (windowCmd.match.app && windowInfo.app) {
-        const appMatches = windowCmd.match.app.some((appPattern) => {
-          // 直接字符串匹配
-          return windowInfo.app === appPattern
-        })
-        if (appMatches) {
-          return true
-        }
-      }
-
-      // 检查 title 匹配（正则表达式）
-      if (windowCmd.match.title && windowInfo.title) {
-        try {
-          const titleRegexStr = windowCmd.match.title.replace(/^\/|\/[gimuy]*$/g, '')
-          const titleRegex = new RegExp(titleRegexStr)
-          if (titleRegex.test(windowInfo.title)) {
-            return true
-          }
-        } catch (error) {
-          console.error(`窗口标题正则表达式 ${windowCmd.match.title} 解析失败:`, error)
-        }
-      }
-
-      return false
-    })
+    const result = windowCommandsList.filter((cmd) => matchesWindowCommand(cmd, windowInfo))
 
     // 应用特殊指令配置，过滤禁用指令
     return result.filter((cmd) => !isCommandDisabled(cmd)).map((cmd) => applySpecialConfig(cmd))
@@ -1308,7 +1418,8 @@ export const useCommandDataStore = defineStore('commandData', () => {
       const currentCommand = findCurrentCommandMatch(historyItem)
 
       // 如果找到了最新数据，使用最新的；否则使用历史记录
-      const command = currentCommand || historyItem
+      const command =
+        attachPersistedName(currentCommand, historyItem) || currentCommand || historyItem
 
       // 应用特殊指令配置（统一处理）
       return applySpecialConfig(command)
@@ -1358,7 +1469,6 @@ export const useCommandDataStore = defineStore('commandData', () => {
    */
   function isPinned(commandPath: string, featureCode?: string, name?: string): boolean {
     return pinnedCommands.value.some((cmd) => {
-      // 对于插件，需要同时匹配 path 和 featureCode
       if (cmd.type === 'plugin' && featureCode !== undefined) {
         if (cmd.featureCode !== featureCode) {
           return false
@@ -1367,7 +1477,14 @@ export const useCommandDataStore = defineStore('commandData', () => {
         const matchesPluginName = Boolean(name && cmd.pluginName === name)
         return matchesPath || matchesPluginName
       }
-      // 非插件类型：同时匹配 name 和 path
+
+      if (cmd.type === 'direct' && cmd.subType === 'app') {
+        if (name) {
+          return cmd.path === commandPath && cmd.name === name
+        }
+        return cmd.path === commandPath
+      }
+
       if (name) {
         return cmd.path === commandPath && cmd.name === name
       }
@@ -1407,7 +1524,7 @@ export const useCommandDataStore = defineStore('commandData', () => {
           return null
         }
 
-        return currentCommand || pinnedItem
+        return attachPersistedName(currentCommand, pinnedItem) || currentCommand || pinnedItem
       })
       .filter((item): item is Command => item !== null)
   }
@@ -1543,6 +1660,7 @@ export const useCommandDataStore = defineStore('commandData', () => {
     searchTextCommands,
     searchFileCommands,
     searchWindowCommands,
+    matchesWindowCommand,
     reloadUserData,
     applySpecialConfig, // 导出特殊配置应用函数
 

--- a/src/renderer/src/stores/windowStore.ts
+++ b/src/renderer/src/stores/windowStore.ts
@@ -12,6 +12,8 @@ interface WindowInfo {
   y?: number
   width?: number
   height?: number
+  className?: string
+  hwnd?: number
   timestamp?: number
 }
 

--- a/src/shared/commandShared.ts
+++ b/src/shared/commandShared.ts
@@ -6,6 +6,9 @@ export interface CommandIdLike {
   pluginName?: string
   featureCode?: string
   cmdType?: string
+  type?: string
+  subType?: string
+  path?: string
 }
 
 /**
@@ -28,15 +31,38 @@ export type CommandAliasStore = Record<string, CommandAliasEntry[]>
  * 设置插件和主窗口渲染进程都会通过该 key 读取同一份映射
  */
 export const COMMAND_ALIASES_KEY = 'command-aliases'
+export const DIRECT_APP_ALIAS_GROUP_KEY = '__direct_app__'
+export const DIRECT_APP_ALIAS_GROUP_TITLE = '系统应用'
+
+function normalizeDirectAppPath(path?: string): string {
+  return (path || '').replace(/\\/g, '/')
+}
 
 /**
  * 生成指令唯一标识
- * 格式: pluginName:featureCode:name:cmdType
- * cmdType 默认回退为 text，保证功能指令、别名映射和设置页目标选择使用同一主键规则
+ * - 插件指令保持现有规则：pluginName:featureCode:name:cmdType
+ * - direct/app 改为基于 path 的稳定 ID，避免同名应用冲突
+ * - 其它类型继续沿用旧规则
  */
 export function getCommandId(cmd: CommandIdLike): string {
   const cmdType = cmd.cmdType || 'text'
+
+  if (cmd.type === 'direct' && cmd.subType === 'app') {
+    const normalizedPath = normalizeDirectAppPath(cmd.path)
+    if (normalizedPath) {
+      return `direct:app:${normalizedPath}`
+    }
+  }
+
   return `${cmd.pluginName || ''}:${cmd.featureCode || ''}:${cmd.name}:${cmdType}`
+}
+
+/**
+ * direct/app 兼容旧版 name-based 禁用键。
+ * 旧版本按应用名称持久化禁用状态，因此 alias 生效后仍需回退到原名命中旧记录。
+ */
+export function getLegacyDirectAppCommandId(name: string, cmdType = 'text'): string {
+  return getCommandId({ name, cmdType })
 }
 
 /**

--- a/tests/main/commandMatchers.test.ts
+++ b/tests/main/commandMatchers.test.ts
@@ -8,11 +8,11 @@ import {
 // ========== findCommandIndex ==========
 
 describe('findCommandIndex', () => {
-  // dev 插件的 pluginName 含 __dev 后缀，直接作为唯一标识
   const list = [
-    { name: '原神', path: 'C:\\launcher.exe', type: 'app' },
-    { name: '米哈游启动器', path: 'C:\\launcher.exe', type: 'app' },
-    { name: 'Chrome', path: 'C:\\chrome.exe', type: 'app' },
+    { name: '原神', path: 'C:\\launcher.exe', type: 'direct', subType: 'app' },
+    { name: '米哈游启动器', path: 'C:\\launcher.exe', type: 'direct', subType: 'app' },
+    { name: 'Chrome', path: 'C:\\chrome.exe', type: 'direct', subType: 'app' },
+    { name: '旧版记事本', path: 'C:\\notepad.exe', type: 'app' },
     {
       name: '翻译',
       path: '/plugins/translate',
@@ -36,7 +36,7 @@ describe('findCommandIndex', () => {
     }
   ]
 
-  describe('非插件类型', () => {
+  describe('direct/app 类型', () => {
     it('应同时匹配 name 和 path', () => {
       const idx = findCommandIndex(list, 'C:\\launcher.exe', 'app', undefined, '原神')
       expect(idx).toBe(0)
@@ -52,22 +52,26 @@ describe('findCommandIndex', () => {
       expect(idx).toBe(-1)
     })
 
-    it('名称匹配但路径不匹配时应返回 -1', () => {
-      const idx = findCommandIndex(list, 'C:\\other.exe', 'app', undefined, '原神')
-      expect(idx).toBe(-1)
+    it('未传 name 时应降级为仅匹配 path', () => {
+      const idx = findCommandIndex(list, 'C:\\launcher.exe', 'app')
+      expect(idx).toBe(0)
+    })
+
+    it('应兼容旧版 type: app 的 direct/app 记录', () => {
+      const idx = findCommandIndex(list, 'C:\\notepad.exe', 'app', undefined, '旧版记事本')
+      expect(idx).toBe(3)
     })
   })
 
   describe('插件类型', () => {
     it('应匹配 path + featureCode', () => {
-      // 通过 path 匹配（无 pluginName 情况）
       const idx = findCommandIndex(list, '/plugins/translate', 'plugin', 'translate')
-      expect(idx).toBe(3)
+      expect(idx).toBe(4)
     })
 
     it('应区分同路径不同 featureCode 的插件', () => {
       const idx = findCommandIndex(list, '/plugins/translate', 'plugin', 'dict')
-      expect(idx).toBe(4)
+      expect(idx).toBe(5)
     })
 
     it('featureCode 不匹配时应返回 -1', () => {
@@ -76,21 +80,8 @@ describe('findCommandIndex', () => {
     })
 
     it('应按 pluginName（含__dev后缀）区分安装版与开发版', () => {
-      // 通过 pluginName 匹配开发版
       const idx = findCommandIndex(list, '/anywhere', 'plugin', 'translate', 'translate__dev')
-      expect(idx).toBe(5)
-    })
-  })
-
-  describe('旧数据兼容（name 缺失）', () => {
-    it('未传 name 时应降级为仅匹配 path', () => {
-      const idx = findCommandIndex(list, 'C:\\launcher.exe', 'app')
-      expect(idx).toBe(0) // 匹配到第一个同路径的
-    })
-
-    it('未传 name 时对不存在的 path 应返回 -1', () => {
-      const idx = findCommandIndex(list, 'C:\\nonexistent.exe', 'app')
-      expect(idx).toBe(-1)
+      expect(idx).toBe(6)
     })
   })
 
@@ -102,35 +93,36 @@ describe('findCommandIndex', () => {
 // ========== filterOutCommand ==========
 
 describe('filterOutCommand', () => {
-  describe('非插件类型', () => {
+  describe('direct/app 类型', () => {
     it('应只过滤匹配 name + path 的项', () => {
       const list = [
-        { name: '原神', path: 'C:\\launcher.exe', type: 'app' },
-        { name: '米哈游启动器', path: 'C:\\launcher.exe', type: 'app' },
-        { name: 'Chrome', path: 'C:\\chrome.exe', type: 'app' }
+        { name: '原神', path: 'C:\\launcher.exe', type: 'direct', subType: 'app' },
+        { name: '米哈游启动器', path: 'C:\\launcher.exe', type: 'direct', subType: 'app' },
+        { name: 'Chrome', path: 'C:\\chrome.exe', type: 'direct', subType: 'app' }
       ]
       const result = filterOutCommand(list, 'C:\\launcher.exe', undefined, '原神')
       expect(result).toHaveLength(2)
       expect(result.map((i) => i.name)).toEqual(['米哈游启动器', 'Chrome'])
     })
 
-    it('不应误删同路径不同名的应用', () => {
+    it('没有 name 参数时应按纯路径匹配', () => {
       const list = [
-        { name: '原神', path: 'C:\\launcher.exe', type: 'app' },
-        { name: '米哈游启动器', path: 'C:\\launcher.exe', type: 'app' }
-      ]
-      const result = filterOutCommand(list, 'C:\\launcher.exe', undefined, '原神')
-      expect(result).toHaveLength(1)
-      expect(result[0].name).toBe('米哈游启动器')
-    })
-
-    it('没有 name 参数时应按纯路径匹配（兼容旧逻辑）', () => {
-      const list = [
-        { name: '原神', path: 'C:\\launcher.exe', type: 'app' },
-        { name: '米哈游启动器', path: 'C:\\launcher.exe', type: 'app' }
+        { name: '原神', path: 'C:\\launcher.exe', type: 'direct', subType: 'app' },
+        { name: '米哈游启动器', path: 'C:\\launcher.exe', type: 'direct', subType: 'app' }
       ]
       const result = filterOutCommand(list, 'C:\\launcher.exe')
       expect(result).toHaveLength(0)
+    })
+
+    it('应兼容删除旧版 type: app 的 direct/app 记录', () => {
+      const list = [
+        { name: '旧版记事本', path: 'C:\\notepad.exe', type: 'app' },
+        { name: '新版记事本', path: 'C:\\notepad.exe', type: 'direct', subType: 'app' }
+      ]
+      const result = filterOutCommand(list, 'C:\\notepad.exe', undefined, '旧版记事本')
+      expect(result).toEqual([
+        { name: '新版记事本', path: 'C:\\notepad.exe', type: 'direct', subType: 'app' }
+      ])
     })
   })
 
@@ -174,7 +166,6 @@ describe('filterOutCommand', () => {
           pluginName: 'excellent-todo__dev'
         }
       ]
-      // 通过 pluginName 删除开发版
       const result = filterOutCommand(list, '/anywhere', 'open', 'excellent-todo__dev')
       expect(result).toHaveLength(1)
       expect(result[0].pluginName).toBe('excellent-todo')
@@ -186,8 +177,8 @@ describe('filterOutCommand', () => {
 
 describe('hasCommand', () => {
   const list = [
-    { name: '原神', path: 'C:\\launcher.exe', type: 'app' },
-    { name: '米哈游启动器', path: 'C:\\launcher.exe', type: 'app' },
+    { name: '原神', path: 'C:\\launcher.exe', type: 'direct', subType: 'app' },
+    { name: '米哈游启动器', path: 'C:\\launcher.exe', type: 'direct', subType: 'app' },
     {
       name: '翻译',
       path: '/plugins/translate',
@@ -204,7 +195,7 @@ describe('hasCommand', () => {
     }
   ]
 
-  it('应找到匹配 name + path 的非插件项', () => {
+  it('应找到匹配 name + path 的 direct/app 项', () => {
     expect(hasCommand(list, 'C:\\launcher.exe', undefined, '原神')).toBe(true)
   })
 
@@ -219,22 +210,25 @@ describe('hasCommand', () => {
   })
 
   it('应按 pluginName(__dev 后缀) 区分安装版与开发版', () => {
-    // 开发版通过 pluginName 匹配
     expect(hasCommand(list, '/anywhere', 'translate', 'translate__dev')).toBe(true)
-    // 安装版 pluginName 不含 __dev
     expect(hasCommand(list, '/anywhere', 'translate', 'translate')).toBe(true)
-    // 不存在的变体
     expect(hasCommand(list, '/anywhere', 'translate', 'nonexistent__dev')).toBe(false)
   })
 
-  describe('旧数据兼容（name 缺失）', () => {
-    it('未传 name 时应降级为仅匹配 path', () => {
-      expect(hasCommand(list, 'C:\\launcher.exe')).toBe(true)
-    })
+  it('未传 name 时 direct/app 应降级为仅匹配 path', () => {
+    expect(hasCommand(list, 'C:\\launcher.exe')).toBe(true)
+    expect(hasCommand(list, 'C:\\nonexistent.exe')).toBe(false)
+  })
 
-    it('未传 name 时对不存在的 path 应返回 false', () => {
-      expect(hasCommand(list, 'C:\\nonexistent.exe')).toBe(false)
-    })
+  it('应兼容旧版 type: app 的 direct/app 记录', () => {
+    expect(
+      hasCommand(
+        [{ name: '旧版记事本', path: 'C:\\notepad.exe', type: 'app' }],
+        'C:\\notepad.exe',
+        undefined,
+        '旧版记事本'
+      )
+    ).toBe(true)
   })
 
   it('列表为空时应返回 false', () => {
@@ -261,7 +255,6 @@ describe('plugin variant matching', () => {
   ]
 
   it('matches plugin commands by pluginName(_dev suffix)', () => {
-    // 通过 pluginName 匹配开发版
     const index = findCommandIndex(list, '/anywhere', 'plugin', 'open', 'excellent-todo__dev')
     expect(index).toBe(1)
   })

--- a/tests/renderer/commandUtils.test.ts
+++ b/tests/renderer/commandUtils.test.ts
@@ -8,7 +8,7 @@ import {
 // ========== getCommandId ==========
 
 describe('getCommandId', () => {
-  it('应生成完整格式的 ID', () => {
+  it('应生成完整格式的插件 ID', () => {
     const cmd = {
       name: '翻译',
       path: '/plugins/translate',
@@ -19,12 +19,17 @@ describe('getCommandId', () => {
     expect(getCommandId(cmd)).toBe('translate-plugin:translate:翻译:regex')
   })
 
-  it('缺省字段应使用空字符串和默认 cmdType', () => {
-    const cmd = { name: 'App', path: 'C:\\app.exe' }
-    expect(getCommandId(cmd)).toBe('::App:text')
+  it('direct/app 应使用基于 path 的稳定 ID', () => {
+    const cmd = {
+      name: 'App',
+      path: 'C:\\app.exe',
+      type: 'direct' as const,
+      subType: 'app' as const
+    }
+    expect(getCommandId(cmd)).toBe('direct:app:C:/app.exe')
   })
 
-  it('cmdType 为 undefined 时应默认为 text', () => {
+  it('cmdType 为 undefined 时插件应默认为 text', () => {
     const cmd = {
       name: '功能',
       path: '/plugin',
@@ -61,6 +66,40 @@ describe('getCommandId', () => {
 
     expect(installed).not.toBe(development)
   })
+
+  it('应将 Windows 反斜杠路径规范化为稳定 ID', () => {
+    const winPath = getCommandId({
+      name: '记事本',
+      path: 'C:\\Windows\\System32\\notepad.exe',
+      type: 'direct' as const,
+      subType: 'app' as const
+    })
+    const normalizedPath = getCommandId({
+      name: '记事本',
+      path: 'C:/Windows/System32/notepad.exe',
+      type: 'direct' as const,
+      subType: 'app' as const
+    })
+
+    expect(winPath).toBe(normalizedPath)
+  })
+
+  it('应区分同名但不同路径的系统应用', () => {
+    const first = getCommandId({
+      name: '微信',
+      path: 'C:\\Program Files\\Tencent\\WeChat.exe',
+      type: 'direct' as const,
+      subType: 'app' as const
+    })
+    const second = getCommandId({
+      name: '微信',
+      path: 'D:\\Portable\\WeChat.exe',
+      type: 'direct' as const,
+      subType: 'app' as const
+    })
+
+    expect(first).not.toBe(second)
+  })
 })
 
 // ========== applySpecialConfig ==========
@@ -83,14 +122,14 @@ describe('applySpecialConfig', () => {
     expect(result.name).toBe('上次匹配')
     expect(result.icon).toBe('arrow-icon')
     expect(result.type).toBe('builtin')
-    expect(result.path).toBe('special:last-match') // path 不变
+    expect(result.path).toBe('special:last-match')
   })
 
   it('应通过 subType 匹配并合并配置', () => {
     const cmd = { name: '蓝牙设置', path: 'ms-settings:bluetooth', subType: 'system-setting' }
     const result = applySpecialConfig(cmd, specialCommands as any)
     expect(result.icon).toBe('settings-icon')
-    expect(result.name).toBe('蓝牙设置') // name 不变
+    expect(result.name).toBe('蓝牙设置')
   })
 
   it('path 匹配应优先于 subType 匹配', () => {
@@ -100,7 +139,6 @@ describe('applySpecialConfig', () => {
       subType: 'system-setting'
     }
     const result = applySpecialConfig(cmd, specialCommands as any)
-    // 应使用 path 匹配的结果，不是 subType
     expect(result.name).toBe('上次匹配')
     expect(result.icon).toBe('arrow-icon')
   })
@@ -164,7 +202,6 @@ describe('calculateMatchScore', () => {
   it('匹配长度占比越高分数越高', () => {
     const scoreShort = calculateMatchScore('a very long application name', 'a', makeMatch([[0, 0]]))
     const scoreLong = calculateMatchScore('chrome', 'chrom', makeMatch([[0, 4]]))
-    // chrom/chrome = 83% 比 a/a very long... = ~3.5% 匹配比例高
     expect(scoreLong).toBeGreaterThan(scoreShort)
   })
 })


### PR DESCRIPTION
支持为系统应用和 window 指令配置别名，并为 direct/app 引入基于 path 的稳定命令 ID 以兼容旧版禁用、历史和固定数据。 同时补充 Windows Explorer 路径能力，并恢复超级面板基于 sequence 的剪贴板识别与分离窗口元数据行为。