### PR TITLE
fix(main-push): 支持 mainPushCallback 返回的异步结果和对象结果

### DIFF
--- a/resources/preload.js
+++ b/resources/preload.js
@@ -115,12 +115,20 @@ const lazyPluginDetach = lazyListen('plugin-detach', () => {
 })
 
 // mainPush 查询请求（由 onMainPush 触发注册，搜索时主进程转发）
-const lazyMainPushQuery = lazyListen('main-push-query', (event, { queryData, callId }) => {
+const lazyMainPushQuery = lazyListen('main-push-query', async (event, { queryData, callId }) => {
   try {
     let allResults = []
     if (mainPushCallback) {
       try {
-        const results = mainPushCallback.callback(queryData)
+        let results = mainPushCallback.callback(queryData)
+        // MainPush结果可能是一个 Promise，需要等待结果
+        if (results && typeof results.then === 'function') {
+          results = await results
+        }
+        // MainPush结果可能是一个对象，需要提取 data 字段
+        if (results && Array.isArray(results.data)) {
+          results = results.data
+        }
         if (Array.isArray(results) && results.length > 0) {
           allResults = allResults.concat(results)
         }

--- a/resources/preload.js
+++ b/resources/preload.js
@@ -120,13 +120,9 @@ const lazyMainPushQuery = lazyListen('main-push-query', async (event, { queryDat
     let allResults = []
     if (mainPushCallback) {
       try {
-        let results = mainPushCallback.callback(queryData)
-        // MainPush结果可能是一个 Promise，需要等待结果
-        if (results && typeof results.then === 'function') {
-          results = await results
-        }
+        let results = await mainPushCallback.callback(queryData)
         // MainPush结果可能是一个对象，需要提取 data 字段
-        if (results && Array.isArray(results.data)) {
+        if (results && results.type === 'list' && Array.isArray(results.data)) {
           results = results.data
         }
         if (Array.isArray(results) && results.length > 0) {


### PR DESCRIPTION
# 变更内容
修复了部分插件 main push 无法生效的问题

为 main push 的 callback 增加了处理两种返回值的能力：
+ promise
+ `{type: "list", data: [...]}`

# 动机
有一些插件的main push callback 返回值不是数组，有时候这个 callback 是异步的，有时候返回的是一个对象。之前的处理仅支持同步函数和返回数组，导致很多插件的 main push 代码不起作用

经过这个修改后，很多插件的 main push 都恢复正常了
<img width="1000" height="579" alt="image" src="https://github.com/user-attachments/assets/1855f264-03c4-4cd1-8bc0-912da1eb917d" />

# 相关 issue
+ #442
+ #443