### PR TITLE
feat(plugin): 支持卸载插件时保留用户数据

### DIFF
--- a/internal-plugins/setting/src/App.vue
+++ b/internal-plugins/setting/src/App.vue
@@ -18,11 +18,13 @@ const { toastState, confirmState, handleConfirm, handleCancel } = useToast()
   <!-- 全局确认对话框 -->
   <ConfirmDialog
     v-model:visible="confirmState.visible"
+    v-model:extra-values="confirmState.extraValues"
     :title="confirmState.title"
     :message="confirmState.message"
     :type="confirmState.type"
     :confirm-text="confirmState.confirmText"
     :cancel-text="confirmState.cancelText"
+    :extra="confirmState.extra"
     @confirm="handleConfirm"
     @cancel="handleCancel"
   />

--- a/internal-plugins/setting/src/components/common/ConfirmDialog/ConfirmDialog.vue
+++ b/internal-plugins/setting/src/components/common/ConfirmDialog/ConfirmDialog.vue
@@ -56,12 +56,7 @@
 
 <script setup lang="ts">
 import { computed } from 'vue'
-
-interface ConfirmExtraItem {
-  id: string
-  message: string
-  defaultChecked?: boolean
-}
+import type { ConfirmExtraItem } from '../Toast'
 
 interface Props {
   visible: boolean

--- a/internal-plugins/setting/src/components/common/ConfirmDialog/ConfirmDialog.vue
+++ b/internal-plugins/setting/src/components/common/ConfirmDialog/ConfirmDialog.vue
@@ -31,6 +31,16 @@
 
         <div class="dialog-content">
           <p class="dialog-message">{{ message }}</p>
+          <div v-if="extraItems.length > 0" class="dialog-extra">
+            <label v-for="item in extraItems" :key="item.id" class="dialog-extra-item">
+              <input
+                type="checkbox"
+                :checked="currentExtraValues[item.id] ?? false"
+                @change="handleExtraChange(item.id, $event)"
+              />
+              <span>{{ item.message }}</span>
+            </label>
+          </div>
         </div>
 
         <div class="dialog-footer">
@@ -47,6 +57,12 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 
+interface ConfirmExtraItem {
+  id: string
+  message: string
+  defaultChecked?: boolean
+}
+
 interface Props {
   visible: boolean
   title?: string
@@ -54,6 +70,8 @@ interface Props {
   type?: 'info' | 'warning' | 'danger'
   confirmText?: string
   cancelText?: string
+  extra?: ConfirmExtraItem[]
+  extraValues?: Record<string, boolean>
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -65,9 +83,13 @@ const props = withDefaults(defineProps<Props>(), {
 
 const emit = defineEmits<{
   (e: 'update:visible', value: boolean): void
+  (e: 'update:extraValues', value: Record<string, boolean>): void
   (e: 'confirm'): void
   (e: 'cancel'): void
 }>()
+
+const extraItems = computed(() => props.extra ?? [])
+const currentExtraValues = computed(() => props.extraValues ?? {})
 
 const confirmButtonClass = computed(() => {
   if (props.type === 'danger') return 'btn-danger'
@@ -83,6 +105,15 @@ const handleConfirm = (): void => {
 const handleCancel = (): void => {
   emit('cancel')
   emit('update:visible', false)
+}
+
+const handleExtraChange = (id: string, event: Event): void => {
+  const target = event.target
+  if (!(target instanceof HTMLInputElement)) return
+  emit('update:extraValues', {
+    ...currentExtraValues.value,
+    [id]: target.checked
+  })
 }
 
 const handleOverlayClick = (): void => {
@@ -168,6 +199,30 @@ const handleOverlayClick = (): void => {
   color: var(--text-secondary);
   margin: 0;
   white-space: pre-wrap;
+}
+
+.dialog-extra {
+  margin-top: 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.dialog-extra-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  line-height: 1.4;
+  color: var(--text-color);
+  cursor: pointer;
+}
+
+.dialog-extra-item input {
+  width: 15px;
+  height: 15px;
+  margin: 0;
+  accent-color: var(--primary-color);
 }
 
 .dialog-footer {

--- a/internal-plugins/setting/src/components/common/PluginDetail/PluginDetail.vue
+++ b/internal-plugins/setting/src/components/common/PluginDetail/PluginDetail.vue
@@ -4,7 +4,7 @@ import { DetailPanel } from '@/components'
 import PluginDetailHeader from './PluginDetailHeader.vue'
 import PluginDetailTabs from './PluginDetailTabs.vue'
 import PluginDetailToolbar from './PluginDetailToolbar.vue'
-import type { PluginDownloadState, PluginItem, TabId } from './types'
+import type { PluginDownloadState, PluginItem, PluginUninstallOptions, TabId } from './types'
 import { usePluginDetail } from './usePluginDetail'
 
 const props = defineProps<{
@@ -27,7 +27,7 @@ const emit = defineEmits<{
   (e: 'open'): void
   (e: 'download'): void
   (e: 'upgrade'): void
-  (e: 'uninstall'): void
+  (e: 'uninstall', options: PluginUninstallOptions): void
   (e: 'kill'): void
   (e: 'open-folder'): void
   (e: 'toggle-pin'): void
@@ -105,7 +105,7 @@ function onSwitchTab(tabId: TabId): void {
         @open="emit('open')"
         @kill="emit('kill')"
         @open-folder="emit('open-folder')"
-        @uninstall="handleUninstall(() => emit('uninstall'))"
+        @uninstall="handleUninstall((options) => emit('uninstall', options))"
         @toggle-pin="emit('toggle-pin')"
         @toggle-disabled="emit('toggle-disabled', $event)"
         @toggle-settings-dropdown="toggleSettingsDropdown"

--- a/internal-plugins/setting/src/components/common/PluginDetail/index.ts
+++ b/internal-plugins/setting/src/components/common/PluginDetail/index.ts
@@ -1,2 +1,9 @@
 export { default as PluginDetail } from './PluginDetail.vue'
-export type { PluginItem, PluginFeature, DocItem, TabId, TabItem } from './types'
+export type {
+  PluginItem,
+  PluginFeature,
+  PluginUninstallOptions,
+  DocItem,
+  TabId,
+  TabItem
+} from './types'

--- a/internal-plugins/setting/src/components/common/PluginDetail/types.ts
+++ b/internal-plugins/setting/src/components/common/PluginDetail/types.ts
@@ -42,3 +42,7 @@ export interface PluginDownloadState {
   totalBytes?: number
   error?: string
 }
+
+export interface PluginUninstallOptions {
+  deleteData: boolean
+}

--- a/internal-plugins/setting/src/components/common/PluginDetail/usePluginDetail.ts
+++ b/internal-plugins/setting/src/components/common/PluginDetail/usePluginDetail.ts
@@ -322,14 +322,14 @@ export function usePluginDetail(options: UsePluginDetailOptions) {
         {
           id: 'deleteData',
           message: '同时删除插件数据',
-          defaultChecked: true
+          defaultChecked: false
         }
       ],
       confirmText: '删除',
       cancelText: '取消'
     })
     if (result.confirmed) {
-      emitFn({ deleteData: result.extra.deleteData ?? true })
+      emitFn({ deleteData: result.extra.deleteData === true })
     }
   }
 

--- a/internal-plugins/setting/src/components/common/PluginDetail/usePluginDetail.ts
+++ b/internal-plugins/setting/src/components/common/PluginDetail/usePluginDetail.ts
@@ -1,7 +1,7 @@
 import { marked } from 'marked'
 import { computed, onMounted, onUnmounted, ref, watch, type Ref } from 'vue'
 import { useToast } from '@/components'
-import type { DocItem, PluginItem, TabId, TabItem } from './types'
+import type { DocItem, PluginItem, PluginUninstallOptions, TabId, TabItem } from './types'
 
 // 配置 marked
 marked.setOptions({
@@ -19,7 +19,7 @@ export interface UsePluginDetailOptions {
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 export function usePluginDetail(options: UsePluginDetailOptions) {
   const { plugin, isRunning, showComments = false } = options
-  const { success, error, confirm } = useToast()
+  const { success, error, confirm, confirmWithExtra } = useToast()
 
   // 插件设置状态
   const showSettingsDropdown = ref(false)
@@ -313,16 +313,23 @@ export function usePluginDetail(options: UsePluginDetailOptions) {
   })
 
   // 处理卸载
-  async function handleUninstall(emitFn: () => void): Promise<void> {
-    const confirmed = await confirm({
+  async function handleUninstall(emitFn: (options: PluginUninstallOptions) => void): Promise<void> {
+    const result = await confirmWithExtra({
       title: '删除插件',
       message: `确定要删除插件"${plugin.value.name}"吗？\n\n此操作将删除插件文件，无法恢复。`,
       type: 'danger',
+      extra: [
+        {
+          id: 'deleteData',
+          message: '同时删除插件数据',
+          defaultChecked: true
+        }
+      ],
       confirmText: '删除',
       cancelText: '取消'
     })
-    if (confirmed) {
-      emitFn()
+    if (result.confirmed) {
+      emitFn({ deleteData: result.extra.deleteData ?? true })
     }
   }
 

--- a/internal-plugins/setting/src/components/common/Toast/Toast.ts
+++ b/internal-plugins/setting/src/components/common/Toast/Toast.ts
@@ -21,7 +21,7 @@ interface ConfirmOptions {
   cancelText?: string
 }
 
-interface ConfirmExtraItem {
+export interface ConfirmExtraItem {
   id: string
   message: string
   defaultChecked?: boolean
@@ -31,7 +31,7 @@ interface ConfirmWithExtraOptions extends ConfirmOptions {
   extra: ConfirmExtraItem[]
 }
 
-interface ConfirmWithExtraResult {
+export interface ConfirmWithExtraResult {
   confirmed: boolean
   extra: Record<string, boolean>
 }
@@ -45,7 +45,7 @@ interface ConfirmState {
   cancelText: string
   extra: ConfirmExtraItem[]
   extraValues: Record<string, boolean>
-  resolve: ((value: any) => void) | null
+  resolve: ((value: ConfirmWithExtraResult) => void) | null
 }
 
 const toastState = ref<ToastState>({
@@ -111,20 +111,12 @@ export function useToast(): {
   }
 
   // 确认对话框
-  const confirm = (options: ConfirmOptions): Promise<boolean> => {
-    return new Promise((resolve) => {
-      confirmState.value = {
-        visible: true,
-        title: options.title || '确认操作',
-        message: options.message,
-        type: options.type || 'info',
-        confirmText: options.confirmText || '确定',
-        cancelText: options.cancelText || '取消',
-        extra: [],
-        extraValues: {},
-        resolve
-      }
+  const confirm = async (options: ConfirmOptions): Promise<boolean> => {
+    const result = await confirmWithExtra({
+      ...options,
+      extra: []
     })
+    return result.confirmed
   }
 
   /**
@@ -150,30 +142,18 @@ export function useToast(): {
   }
 
   const handleConfirm = (): void => {
-    if (confirmState.value.resolve) {
-      if (confirmState.value.extra.length > 0) {
-        confirmState.value.resolve({
-          confirmed: true,
-          extra: { ...confirmState.value.extraValues }
-        })
-      } else {
-        confirmState.value.resolve(true)
-      }
-    }
+    confirmState.value.resolve?.({
+      confirmed: true,
+      extra: { ...confirmState.value.extraValues }
+    })
     confirmState.value.visible = false
   }
 
   const handleCancel = (): void => {
-    if (confirmState.value.resolve) {
-      if (confirmState.value.extra.length > 0) {
-        confirmState.value.resolve({
-          confirmed: false,
-          extra: { ...confirmState.value.extraValues }
-        })
-      } else {
-        confirmState.value.resolve(false)
-      }
-    }
+    confirmState.value.resolve?.({
+      confirmed: false,
+      extra: { ...confirmState.value.extraValues }
+    })
     confirmState.value.visible = false
   }
 

--- a/internal-plugins/setting/src/components/common/Toast/Toast.ts
+++ b/internal-plugins/setting/src/components/common/Toast/Toast.ts
@@ -21,6 +21,21 @@ interface ConfirmOptions {
   cancelText?: string
 }
 
+interface ConfirmExtraItem {
+  id: string
+  message: string
+  defaultChecked?: boolean
+}
+
+interface ConfirmWithExtraOptions extends ConfirmOptions {
+  extra: ConfirmExtraItem[]
+}
+
+interface ConfirmWithExtraResult {
+  confirmed: boolean
+  extra: Record<string, boolean>
+}
+
 interface ConfirmState {
   visible: boolean
   title: string
@@ -28,7 +43,9 @@ interface ConfirmState {
   type: 'info' | 'warning' | 'danger'
   confirmText: string
   cancelText: string
-  resolve: ((value: boolean) => void) | null
+  extra: ConfirmExtraItem[]
+  extraValues: Record<string, boolean>
+  resolve: ((value: any) => void) | null
 }
 
 const toastState = ref<ToastState>({
@@ -45,6 +62,8 @@ const confirmState = ref<ConfirmState>({
   type: 'info',
   confirmText: '确定',
   cancelText: '取消',
+  extra: [],
+  extraValues: {},
   resolve: null
 })
 
@@ -58,6 +77,7 @@ export function useToast(): {
   info: (message: string, duration?: number) => void
   hide: () => void
   confirm: (options: ConfirmOptions) => Promise<boolean>
+  confirmWithExtra: (options: ConfirmWithExtraOptions) => Promise<ConfirmWithExtraResult>
   handleConfirm: () => void
   handleCancel: () => void
 } {
@@ -100,6 +120,30 @@ export function useToast(): {
         type: options.type || 'info',
         confirmText: options.confirmText || '确定',
         cancelText: options.cancelText || '取消',
+        extra: [],
+        extraValues: {},
+        resolve
+      }
+    })
+  }
+
+  /**
+   * 加勾选框来额外获取一些信息
+   */
+  const confirmWithExtra = (options: ConfirmWithExtraOptions): Promise<ConfirmWithExtraResult> => {
+    return new Promise((resolve) => {
+      const extraValues = Object.fromEntries(
+        options.extra.map((item) => [item.id, item.defaultChecked ?? false])
+      )
+      confirmState.value = {
+        visible: true,
+        title: options.title || '确认操作',
+        message: options.message,
+        type: options.type || 'info',
+        confirmText: options.confirmText || '确定',
+        cancelText: options.cancelText || '取消',
+        extra: options.extra,
+        extraValues,
         resolve
       }
     })
@@ -107,14 +151,28 @@ export function useToast(): {
 
   const handleConfirm = (): void => {
     if (confirmState.value.resolve) {
-      confirmState.value.resolve(true)
+      if (confirmState.value.extra.length > 0) {
+        confirmState.value.resolve({
+          confirmed: true,
+          extra: { ...confirmState.value.extraValues }
+        })
+      } else {
+        confirmState.value.resolve(true)
+      }
     }
     confirmState.value.visible = false
   }
 
   const handleCancel = (): void => {
     if (confirmState.value.resolve) {
-      confirmState.value.resolve(false)
+      if (confirmState.value.extra.length > 0) {
+        confirmState.value.resolve({
+          confirmed: false,
+          extra: { ...confirmState.value.extraValues }
+        })
+      } else {
+        confirmState.value.resolve(false)
+      }
     }
     confirmState.value.visible = false
   }
@@ -129,6 +187,7 @@ export function useToast(): {
     info,
     hide,
     confirm,
+    confirmWithExtra,
     handleConfirm,
     handleCancel
   }

--- a/internal-plugins/setting/src/env.d.ts
+++ b/internal-plugins/setting/src/env.d.ts
@@ -101,7 +101,10 @@ declare global {
         ) => Promise<{ success: boolean; error?: string }>
         // 打包指定开发项目
         packageDevProject: (pluginName: string) => Promise<{ success: boolean; error?: string }>
-        deletePlugin: (pluginPath: string) => Promise<{ success: boolean; error?: string }>
+        deletePlugin: (
+          pluginPath: string,
+          options?: { deleteData?: boolean }
+        ) => Promise<{ success: boolean; error?: string }>
         killPlugin: (pluginPath: string) => Promise<{ success: boolean; error?: string }>
         revealInFinder: (filePath: string) => Promise<void>
         launch: (options: {

--- a/internal-plugins/setting/src/views/PluginMarketSetting/PluginMarketSetting.vue
+++ b/internal-plugins/setting/src/views/PluginMarketSetting/PluginMarketSetting.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed, onMounted, onUnmounted, ref } from 'vue'
 import { useToast } from '@/components'
+import type { PluginUninstallOptions } from '@/components'
 import {
   compareVersions,
   shuffleArray,
@@ -392,20 +393,23 @@ async function downloadPlugin(plugin: Plugin): Promise<void> {
   }
 }
 
-async function handleUninstallPlugin(plugin: Plugin): Promise<void> {
+async function handleUninstallPlugin(
+  plugin: Plugin,
+  options: PluginUninstallOptions
+): Promise<void> {
   if (!plugin.path) {
     error('无法卸载：找不到插件路径')
     return
   }
 
   try {
-    const deleteResult = await window.ztools.internal.deletePlugin(plugin.path)
+    const deleteResult = await window.ztools.internal.deletePlugin(plugin.path, options)
     if (!deleteResult.success) {
       error(`卸载失败: ${deleteResult.error}`)
       return
     }
 
-    success('插件卸载成功')
+    success(options.deleteData ? '插件已卸载，插件数据已删除' : '插件已卸载，插件数据已保留')
 
     plugin.installed = false
     plugin.localVersion = undefined
@@ -666,7 +670,7 @@ onUnmounted(() => {
         @open="handleOpenPlugin(selectedPlugin)"
         @download="downloadPlugin(selectedPlugin)"
         @upgrade="handleUpgradePlugin(selectedPlugin)"
-        @uninstall="handleUninstallPlugin(selectedPlugin)"
+        @uninstall="handleUninstallPlugin(selectedPlugin, $event)"
       />
     </Transition>
   </div>

--- a/internal-plugins/setting/src/views/PluginMarketSetting/components/PluginDetail/PluginDetail.vue
+++ b/internal-plugins/setting/src/views/PluginMarketSetting/components/PluginDetail/PluginDetail.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { nextTick, ref } from 'vue'
 import { PluginDetail as SharedPluginDetail } from '@/components'
-import type { TabId } from '@/components'
+import type { PluginUninstallOptions, TabId } from '@/components'
 import type { PluginDownloadState } from '../types'
 
 const props = defineProps<{
@@ -16,7 +16,7 @@ defineEmits<{
   (e: 'open'): void
   (e: 'download'): void
   (e: 'upgrade'): void
-  (e: 'uninstall'): void
+  (e: 'uninstall', options: PluginUninstallOptions): void
   (e: 'kill'): void
   (e: 'open-folder'): void
   (e: 'package'): void
@@ -73,7 +73,7 @@ function handleTabSwitch(tabId: TabId): void {
     @open="$emit('open')"
     @download="$emit('download')"
     @upgrade="$emit('upgrade')"
-    @uninstall="$emit('uninstall')"
+    @uninstall="$emit('uninstall', $event)"
     @kill="$emit('kill')"
     @open-folder="$emit('open-folder')"
     @package="$emit('package')"

--- a/internal-plugins/setting/src/views/PluginsSetting/PluginsSetting.vue
+++ b/internal-plugins/setting/src/views/PluginsSetting/PluginsSetting.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
 import { useToast, AdaptiveIcon } from '@/components'
+import type { PluginUninstallOptions } from '@/components'
 import { PluginDetail, NpmInstallPanel } from './components'
 import { compareVersions, upgradeInstalledPluginFromMarket, weightedSearch } from '@/utils'
 import { useJumpFunction, useZtoolsSubInput } from '@/composables'
@@ -319,14 +320,17 @@ async function importPlugin(): Promise<void> {
 }
 
 // 从详情页面卸载插件（确认弹窗在 PluginDetail 中已展示，此处直接执行删除）
-async function handleUninstallFromDetail(plugin: any): Promise<void> {
+async function handleUninstallFromDetail(
+  plugin: any,
+  options: PluginUninstallOptions
+): Promise<void> {
   if (isDeleting.value) return
 
   isDeleting.value = true
   try {
-    const result = await window.ztools.internal.deletePlugin(plugin.path)
+    const result = await window.ztools.internal.deletePlugin(plugin.path, options)
     if (result.success) {
-      success('插件卸载成功')
+      success(options.deleteData ? '插件已卸载，插件数据已删除' : '插件已卸载，插件数据已保留')
       // 关闭详情面板
       closePluginDetail()
       // 重新加载插件列表
@@ -945,7 +949,7 @@ async function handleInstallFromNpm(data: {
         :is-disabled="isPluginDisabled(selectedPlugin.path)"
         @back="closePluginDetail"
         @open="handleOpenPlugin(selectedPlugin)"
-        @uninstall="handleUninstallFromDetail(selectedPlugin)"
+        @uninstall="handleUninstallFromDetail(selectedPlugin, $event)"
         @kill="handleKillPlugin(selectedPlugin)"
         @open-folder="handleOpenFolder(selectedPlugin)"
         @toggle-pin="togglePin(selectedPlugin)"

--- a/internal-plugins/setting/src/views/PluginsSetting/components/PluginDetail/PluginDetail.vue
+++ b/internal-plugins/setting/src/views/PluginsSetting/components/PluginDetail/PluginDetail.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { PluginDetail as SharedPluginDetail } from '@/components'
+import type { PluginUninstallOptions } from '@/components'
 
 defineProps<{
   plugin: any
@@ -14,7 +15,7 @@ defineEmits<{
   (e: 'open'): void
   (e: 'download'): void
   (e: 'upgrade'): void
-  (e: 'uninstall'): void
+  (e: 'uninstall', options: PluginUninstallOptions): void
   (e: 'kill'): void
   (e: 'open-folder'): void
 
@@ -37,7 +38,7 @@ defineEmits<{
     @open="$emit('open')"
     @download="$emit('download')"
     @upgrade="$emit('upgrade')"
-    @uninstall="$emit('uninstall')"
+    @uninstall="$emit('uninstall', $event)"
     @kill="$emit('kill')"
     @open-folder="$emit('open-folder')"
     @toggle-pin="$emit('toggle-pin')"

--- a/resources/preload.js
+++ b/resources/preload.js
@@ -875,8 +875,8 @@ window.ztools = {
         packagePath,
         version
       ),
-    deletePlugin: async (pluginPath) =>
-      await electron.ipcRenderer.invoke('internal:delete-plugin', pluginPath),
+    deletePlugin: async (pluginPath, options) =>
+      await electron.ipcRenderer.invoke('internal:delete-plugin', pluginPath, options),
     getRunningPlugins: async () =>
       await electron.ipcRenderer.invoke('internal:get-running-plugins'),
     killPlugin: async (pluginPath) =>

--- a/src/main/api/plugin/internal.ts
+++ b/src/main/api/plugin/internal.ts
@@ -12,6 +12,7 @@ import translationManager from '../../core/translationManager.js'
 import aiModelsAPI from '../renderer/aiModels.js'
 import commandsAPI from '../renderer/commands.js'
 import pluginsAPI from '../renderer/plugins.js'
+import type { DeletePluginOptions } from '../renderer/plugins'
 import settingsAPI from '../renderer/settings.js'
 import systemAPI from '../renderer/system.js'
 import webSearchAPI from '../renderer/webSearch.js'
@@ -354,12 +355,15 @@ export class InternalPluginAPI {
       }
     )
 
-    ipcMain.handle('internal:delete-plugin', async (event, pluginPath: string) => {
-      if (!requireInternalPlugin(this.pluginManager, event)) {
-        throw new PermissionDeniedError('internal:delete-plugin')
+    ipcMain.handle(
+      'internal:delete-plugin',
+      async (event, pluginPath: string, options?: DeletePluginOptions) => {
+        if (!requireInternalPlugin(this.pluginManager, event)) {
+          throw new PermissionDeniedError('internal:delete-plugin')
+        }
+        return await pluginsAPI.deletePlugin(pluginPath, options)
       }
-      return await pluginsAPI.deletePlugin(pluginPath)
-    })
+    )
 
     ipcMain.handle('internal:get-running-plugins', async (event) => {
       if (!requireInternalPlugin(this.pluginManager, event)) {

--- a/src/main/api/renderer/plugins.ts
+++ b/src/main/api/renderer/plugins.ts
@@ -438,7 +438,11 @@ export class PluginsAPI {
     return pathToFileURL(path.join(pluginPath, logo)).href
   }
 
-  // 删除插件
+  /**
+   * 删除插件
+   * @param pluginPath 插件路径
+   * @param options 删除选项 当 options.deleteData 显式设置为 false 时，保留插件数据
+   */
   public async deletePlugin(pluginPath: string, options: DeletePluginOptions = {}): Promise<any> {
     try {
       const plugins: any = databaseAPI.dbGet('plugins')

--- a/src/main/api/renderer/plugins.ts
+++ b/src/main/api/renderer/plugins.ts
@@ -22,6 +22,10 @@ import {
 // 插件目录
 const DISABLED_PLUGINS_KEY = 'disabled-plugins'
 
+export interface DeletePluginOptions {
+  deleteData?: boolean
+}
+
 /**
  * 插件管理API - 主程序专用
  */
@@ -108,7 +112,9 @@ export class PluginsAPI {
       (_event, pluginName: string, packagePath?: string, version?: string) =>
         this.devProjects.packageDevProject(pluginName, packagePath, version)
     )
-    ipcMain.handle('delete-plugin', (_event, pluginPath: string) => this.deletePlugin(pluginPath))
+    ipcMain.handle('delete-plugin', (_event, pluginPath: string, options?: DeletePluginOptions) =>
+      this.deletePlugin(pluginPath, options)
+    )
     ipcMain.handle('get-running-plugins', () => this.getRunningPlugins())
     ipcMain.handle('kill-plugin', (_event, pluginPath: string) => this.killPlugin(pluginPath))
     ipcMain.handle('kill-plugin-and-return', (_event, pluginPath: string) =>
@@ -433,7 +439,7 @@ export class PluginsAPI {
   }
 
   // 删除插件
-  public async deletePlugin(pluginPath: string): Promise<any> {
+  public async deletePlugin(pluginPath: string, options: DeletePluginOptions = {}): Promise<any> {
     try {
       const plugins: any = databaseAPI.dbGet('plugins')
       if (!plugins || !Array.isArray(plugins)) {
@@ -462,7 +468,9 @@ export class PluginsAPI {
 
       this.devProjects.removePluginUsageData(pluginInfo.name)
 
-      await databaseAPI.clearPluginData(pluginInfo.name)
+      if (options.deleteData !== false) {
+        await databaseAPI.clearPluginData(pluginInfo.name)
+      }
 
       // 删除禁用插件标识
       const disabledPlugins = this.getDisabledPluginSet()

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -82,7 +82,8 @@ const api = {
     packageName: string
     useChinaMirror?: boolean
   }): Promise<any> => ipcRenderer.invoke('install-plugin-from-npm', options),
-  deletePlugin: (pluginPath: string) => ipcRenderer.invoke('delete-plugin', pluginPath),
+  deletePlugin: (pluginPath: string, options?: { deleteData?: boolean }) =>
+    ipcRenderer.invoke('delete-plugin', pluginPath, options),
   exportAllPlugins: () => ipcRenderer.invoke('export-all-plugins'),
   getRunningPlugins: () => ipcRenderer.invoke('get-running-plugins'),
   killPlugin: (pluginPath: string) => ipcRenderer.invoke('kill-plugin', pluginPath),
@@ -524,7 +525,10 @@ declare global {
         pluginNameOrTaskId: string
       ) => Promise<{ success: boolean; error?: string }>
       onPluginMarketDownloadProgress: (callback: (payload: any) => void) => () => void
-      deletePlugin: (pluginPath: string) => Promise<{ success: boolean; error?: string }>
+      deletePlugin: (
+        pluginPath: string,
+        options?: { deleteData?: boolean }
+      ) => Promise<{ success: boolean; error?: string }>
       exportAllPlugins: () => Promise<{
         success: boolean
         exportPath?: string

--- a/tests/main/pluginRemovalCleanup.test.ts
+++ b/tests/main/pluginRemovalCleanup.test.ts
@@ -223,4 +223,31 @@ describe('plugin removal cleanup', () => {
     expect(mockDbPut).toHaveBeenCalledWith('plugins', [])
     expect(mockFsRm).toHaveBeenCalledWith('D:\\plugins\\demo', { recursive: true, force: true })
   })
+
+  it('can uninstall a plugin while preserving plugin data', async () => {
+    mockDbGet.mockImplementation((key: string) => {
+      if (key === 'plugins') {
+        return [{ name: 'demo', path: 'D:\\plugins\\demo', isDevelopment: false }]
+      }
+      return []
+    })
+
+    const api = new PluginsAPI()
+    const killPlugin = vi.fn()
+    const removePluginUsageData = vi.fn()
+
+    ;(api as any).pluginManager = { killPlugin }
+    ;(api as any).devProjects = { removePluginUsageData }
+    ;(api as any).mainWindow = { webContents: { send: vi.fn() } }
+    ;(api as any).disabledPluginPathSet = new Set<string>()
+
+    const result = await api.deletePlugin('D:\\plugins\\demo', { deleteData: false })
+
+    expect(result).toEqual({ success: true })
+    expect(killPlugin).toHaveBeenCalledWith('D:\\plugins\\demo')
+    expect(removePluginUsageData).toHaveBeenCalledWith('demo')
+    expect(mockClearPluginData).not.toHaveBeenCalled()
+    expect(mockDbPut).toHaveBeenCalledWith('plugins', [])
+    expect(mockFsRm).toHaveBeenCalledWith('D:\\plugins\\demo', { recursive: true, force: true })
+  })
 })


### PR DESCRIPTION
# 变更内容
为确认对话框增加了额外的勾选框，使用新的 comfirmWithExtra 函数，不影响之前使用 comfirm 函数的代码

# 动机
应该允许删除插件而保留数据，避免因为误操作而导致积累的用户数据全部丢失

# 效果截图
<img width="1000" height="749" alt="image" src="https://github.com/user-attachments/assets/e14f4a20-a91e-4085-bef7-8f8da7b96b78" />


# 相关 issue
+ #490 