### PR TITLE
fix: 修复独立插件窗口重入未前置

### DIFF
--- a/src/main/core/detachedWindowManager.ts
+++ b/src/main/core/detachedWindowManager.ts
@@ -491,6 +491,9 @@ class DetachedWindowManager {
     for (const windowInfo of this.detachedWindowMap.values()) {
       if (windowInfo.pluginPath === pluginPath && !windowInfo.window.isDestroyed()) {
         if (windowInfo.window.isMinimized()) windowInfo.window.restore()
+        // fix: macOS 上分离窗口即使已经是显示状态，也可能被其他 App/window 完全盖住，
+        // 单独 focus() 不一定能提升窗口层级，所以先 show() 再 focus()，确保重入插件时窗口前置。
+        windowInfo.window.show()
         windowInfo.window.focus()
         return true
       }

--- a/src/main/core/detachedWindowManager.ts
+++ b/src/main/core/detachedWindowManager.ts
@@ -493,7 +493,7 @@ class DetachedWindowManager {
         if (windowInfo.window.isMinimized()) windowInfo.window.restore()
         // fix: macOS 上分离窗口即使已经是显示状态，也可能被其他 App/window 完全盖住，
         // 单独 focus() 不一定能提升窗口层级，所以先 show() 再 focus()，确保重入插件时窗口前置。
-        windowInfo.window.show()
+        if (process.platform === 'darwin') windowInfo.window.show()
         windowInfo.window.focus()
         return true
       }


### PR DESCRIPTION
fix: #503 

## 变更内容

- 复用已存在的独立插件窗口时，显式调用 `show()` 后再执行 `focus()`
- 补充注释说明 macOS 下该处理的原因