### PR TITLE
feat(setting): 网页快开支持普通网站

### DIFF
--- a/internal-plugins/setting/src/env.d.ts
+++ b/internal-plugins/setting/src/env.d.ts
@@ -16,6 +16,18 @@ interface Services {
   writeImageFile: (base64Url: string) => string | undefined
 }
 
+type WebSearchEngineType = 'search' | 'webpage'
+
+interface WebSearchEngine {
+  id: string
+  name: string
+  url: string
+  icon: string
+  enabled: boolean
+  type: WebSearchEngineType
+  keyword?: string
+}
+
 declare global {
   interface Window {
     services: Services
@@ -406,35 +418,11 @@ declare global {
         webSearch: {
           getAll: () => Promise<{
             success: boolean
-            data?: Array<{
-              id: string
-              name: string
-              url: string
-              icon: string
-              enabled: boolean
-              type: 'search' | 'webpage'
-              keyword?: string
-            }>
+            data?: WebSearchEngine[]
             error?: string
           }>
-          add: (engine: {
-            id: string
-            name: string
-            url: string
-            icon: string
-            enabled: boolean
-            type: 'search' | 'webpage'
-            keyword?: string
-          }) => Promise<{ success: boolean; error?: string }>
-          update: (engine: {
-            id: string
-            name: string
-            url: string
-            icon: string
-            enabled: boolean
-            type: 'search' | 'webpage'
-            keyword?: string
-          }) => Promise<{ success: boolean; error?: string }>
+          add: (engine: WebSearchEngine) => Promise<{ success: boolean; error?: string }>
+          update: (engine: WebSearchEngine) => Promise<{ success: boolean; error?: string }>
           delete: (id: string) => Promise<{ success: boolean; error?: string }>
           fetchFavicon: (
             url: string

--- a/internal-plugins/setting/src/env.d.ts
+++ b/internal-plugins/setting/src/env.d.ts
@@ -404,9 +404,37 @@ declare global {
 
         // 网页快开
         webSearch: {
-          getAll: () => Promise<{ success: boolean; data?: any[]; error?: string }>
-          add: (engine: any) => Promise<{ success: boolean; error?: string }>
-          update: (engine: any) => Promise<{ success: boolean; error?: string }>
+          getAll: () => Promise<{
+            success: boolean
+            data?: Array<{
+              id: string
+              name: string
+              url: string
+              icon: string
+              enabled: boolean
+              type: 'search' | 'webpage'
+              keyword?: string
+            }>
+            error?: string
+          }>
+          add: (engine: {
+            id: string
+            name: string
+            url: string
+            icon: string
+            enabled: boolean
+            type: 'search' | 'webpage'
+            keyword?: string
+          }) => Promise<{ success: boolean; error?: string }>
+          update: (engine: {
+            id: string
+            name: string
+            url: string
+            icon: string
+            enabled: boolean
+            type: 'search' | 'webpage'
+            keyword?: string
+          }) => Promise<{ success: boolean; error?: string }>
           delete: (id: string) => Promise<{ success: boolean; error?: string }>
           fetchFavicon: (
             url: string

--- a/internal-plugins/setting/src/views/WebSearchSetting/WebSearchSetting.vue
+++ b/internal-plugins/setting/src/views/WebSearchSetting/WebSearchSetting.vue
@@ -196,9 +196,12 @@ onMounted(() => {
             </div>
 
             <div class="engine-actions">
-              <span class="engine-type-badge">{{
-                engine.type === 'webpage' ? '网页' : '搜索引擎'
-              }}</span>
+              <span
+                class="engine-type-badge"
+                :class="{ 'engine-type-badge-webpage': engine.type === 'webpage' }"
+              >
+                {{ engine.type === 'webpage' ? '网页' : '搜索引擎' }}
+              </span>
               <label class="toggle toggle-sm">
                 <input
                   type="checkbox"
@@ -399,10 +402,28 @@ onMounted(() => {
 }
 
 .toggle-sm {
-  transform: scale(0.8);
-  transform-origin: center;
   display: flex;
   align-items: center;
+  width: 36px;
+  height: 20px;
+  margin: 0 7px;
+}
+
+.toggle-sm .toggle-slider {
+  border-radius: 20px;
+}
+
+.toggle-sm .toggle-slider::before {
+  width: 12px;
+  height: 12px;
+}
+
+.toggle-sm input:checked + .toggle-slider::before {
+  transform: translateX(16px);
+}
+
+.toggle-sm input:checked + .toggle-slider:hover::before {
+  transform: translateX(16px) scale(1.15);
 }
 
 .engine-url {
@@ -419,11 +440,22 @@ onMounted(() => {
   flex-shrink: 0;
   height: 22px;
   padding: 0 6px;
+  margin-right: 8px;
   border-radius: 4px;
   font-size: 11px;
   line-height: 1;
   color: var(--primary-color);
   background: var(--primary-light-bg);
+}
+
+.engine-type-badge-webpage {
+  color: #d97706;
+  background: rgba(245, 158, 11, 0.14);
+}
+
+:global([data-theme='dark']) .engine-type-badge-webpage {
+  color: #fbbf24;
+  background: rgba(251, 191, 36, 0.16);
 }
 
 .engine-keyword {
@@ -435,7 +467,8 @@ onMounted(() => {
 .engine-actions {
   display: flex;
   align-items: center;
-  gap: 8px;
+  justify-content: flex-end;
+  gap: 6px;
   margin-left: 16px;
   flex-shrink: 0;
 }
@@ -444,6 +477,9 @@ onMounted(() => {
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  width: 28px;
+  height: 28px;
+  padding: 0;
 }
 
 /* 图标按钮颜色样式 */

--- a/internal-plugins/setting/src/views/WebSearchSetting/WebSearchSetting.vue
+++ b/internal-plugins/setting/src/views/WebSearchSetting/WebSearchSetting.vue
@@ -16,6 +16,8 @@ interface WebSearchEngine {
   url: string
   icon: string
   enabled: boolean
+  type: 'search' | 'webpage'
+  keyword?: string
 }
 
 // 搜索引擎列表
@@ -89,6 +91,10 @@ async function handleSave(engine: WebSearchEngine): Promise<void> {
     error('请填写名称和 URL')
     return
   }
+  if (engine.type === 'webpage' && !engine.keyword?.trim()) {
+    error('请填写匹配关键字')
+    return
+  }
 
   try {
     const engineData = {
@@ -96,7 +102,9 @@ async function handleSave(engine: WebSearchEngine): Promise<void> {
       name: engine.name,
       url: engine.url,
       icon: engine.icon || '',
-      enabled: engine.enabled !== undefined ? engine.enabled : true
+      enabled: engine.enabled !== undefined ? engine.enabled : true,
+      type: engine.type || 'search',
+      keyword: engine.keyword || ''
     }
 
     if (editingEngine.value) {
@@ -161,7 +169,7 @@ onMounted(() => {
       <div v-show="!showEditor" class="scrollable-content">
         <!-- 顶部添加按钮 -->
         <div class="panel-header">
-          <button class="btn" @click="showAddEditor">添加搜索引擎</button>
+          <button class="btn" @click="showAddEditor">添加网页快开</button>
         </div>
 
         <!-- 搜索引擎列表 -->
@@ -182,9 +190,15 @@ onMounted(() => {
                 <h3 class="engine-name">{{ engine.name }}</h3>
               </div>
               <div class="engine-url">{{ engine.url }}</div>
+              <div v-if="engine.type === 'webpage' && engine.keyword" class="engine-keyword">
+                匹配关键字：{{ engine.keyword }}
+              </div>
             </div>
 
             <div class="engine-actions">
+              <span class="engine-type-badge">{{
+                engine.type === 'webpage' ? '网页' : '搜索引擎'
+              }}</span>
               <label class="toggle toggle-sm">
                 <input
                   type="checkbox"
@@ -246,7 +260,7 @@ onMounted(() => {
           <div v-if="!loading && engines.length === 0" class="empty-state">
             <div class="i-z-search empty-icon font-size-64px"></div>
             <div class="empty-text">暂无搜索引擎</div>
-            <div class="empty-hint">点击"添加搜索引擎"来配置你的第一个网页快开</div>
+            <div class="empty-hint">点击"添加网页快开"来配置你的第一个网页快开</div>
           </div>
         </div>
       </div>
@@ -387,6 +401,8 @@ onMounted(() => {
 .toggle-sm {
   transform: scale(0.8);
   transform-origin: center;
+  display: flex;
+  align-items: center;
 }
 
 .engine-url {
@@ -396,11 +412,38 @@ onMounted(() => {
   line-height: 1.4;
 }
 
+.engine-type-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  height: 22px;
+  padding: 0 6px;
+  border-radius: 4px;
+  font-size: 11px;
+  line-height: 1;
+  color: var(--primary-color);
+  background: var(--primary-light-bg);
+}
+
+.engine-keyword {
+  margin-top: 4px;
+  font-size: 12px;
+  color: var(--text-secondary);
+}
+
 .engine-actions {
   display: flex;
+  align-items: center;
   gap: 8px;
   margin-left: 16px;
   flex-shrink: 0;
+}
+
+.engine-actions .icon-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
 }
 
 /* 图标按钮颜色样式 */

--- a/internal-plugins/setting/src/views/WebSearchSetting/components/WebSearchEditor/WebSearchEditor.vue
+++ b/internal-plugins/setting/src/views/WebSearchSetting/components/WebSearchEditor/WebSearchEditor.vue
@@ -36,6 +36,7 @@ const urlHint = computed(() =>
     : '使用 {q} 作为搜索关键词的占位符；未填写协议时会自动补充 https://'
 )
 const isFetchingIcon = ref(false)
+const iconFileInputRef = ref<HTMLInputElement | null>(null)
 
 const formData = ref<WebSearchEngine>({
   id: '',
@@ -93,6 +94,35 @@ async function handleFetchFavicon(): Promise<void> {
   } finally {
     isFetchingIcon.value = false
   }
+}
+
+function handleSelectIconFile(): void {
+  iconFileInputRef.value?.click()
+}
+
+function handleIconFileChange(event: Event): void {
+  const input = event.target as HTMLInputElement
+  const file = input.files?.[0]
+  input.value = ''
+
+  if (!file) return
+  if (!file.type.startsWith('image/')) {
+    error('请选择图片文件')
+    return
+  }
+
+  const reader = new FileReader()
+  reader.onload = () => {
+    if (typeof reader.result === 'string') {
+      formData.value.icon = reader.result
+    } else {
+      error('读取图标失败')
+    }
+  }
+  reader.onerror = () => {
+    error('读取图标失败')
+  }
+  reader.readAsDataURL(file)
 }
 
 function handleSave(): void {
@@ -216,14 +246,23 @@ function isHttpUrl(url: string): boolean {
               <div v-else class="i-z-search font-size-24px"></div>
             </div>
             <button
+              type="button"
               class="btn btn-sm"
               :disabled="isFetchingIcon || !formData.url"
               @click="handleFetchFavicon"
             >
               {{ isFetchingIcon ? '获取中...' : '自动获取' }}
             </button>
+            <button type="button" class="btn btn-sm" @click="handleSelectIconFile">上传图标</button>
+            <input
+              ref="iconFileInputRef"
+              class="icon-file-input"
+              type="file"
+              accept="image/*"
+              @change="handleIconFileChange"
+            />
           </div>
-          <p class="form-hint">根据 URL 自动获取网站图标</p>
+          <p class="form-hint">根据 URL 自动获取网站图标，或上传本地图片</p>
         </div>
       </div>
 
@@ -303,6 +342,7 @@ function isHttpUrl(url: string): boolean {
   display: flex;
   align-items: center;
   gap: 12px;
+  flex-wrap: wrap;
 }
 
 .icon-preview {
@@ -326,6 +366,10 @@ function isHttpUrl(url: string): boolean {
 .preview-placeholder {
   color: var(--text-secondary);
   opacity: 0.5;
+}
+
+.icon-file-input {
+  display: none;
 }
 
 .editor-footer {

--- a/internal-plugins/setting/src/views/WebSearchSetting/components/WebSearchEditor/WebSearchEditor.vue
+++ b/internal-plugins/setting/src/views/WebSearchSetting/components/WebSearchEditor/WebSearchEditor.vue
@@ -8,6 +8,8 @@ interface WebSearchEngine {
   url: string
   icon: string
   enabled: boolean
+  type: 'search' | 'webpage'
+  keyword?: string
 }
 
 interface Props {
@@ -23,6 +25,16 @@ const emit = defineEmits<{
 const { error } = useToast()
 
 const isEditing = computed(() => props.editingEngine !== null)
+const isWebpage = computed(() => formData.value.type === 'webpage')
+const urlLabel = computed(() => (isWebpage.value ? '网页 URL *' : 'URL 模板 *'))
+const urlPlaceholder = computed(() =>
+  isWebpage.value ? '例如：https://www.example.com' : '例如：https://www.google.com/search?q={q}'
+)
+const urlHint = computed(() =>
+  isWebpage.value
+    ? '支持 http/https，未填写协议时会自动补充 https://'
+    : '使用 {q} 作为搜索关键词的占位符；未填写协议时会自动补充 https://'
+)
 const isFetchingIcon = ref(false)
 
 const formData = ref<WebSearchEngine>({
@@ -30,7 +42,9 @@ const formData = ref<WebSearchEngine>({
   name: '',
   url: '',
   icon: '',
-  enabled: true
+  enabled: true,
+  type: 'webpage',
+  keyword: ''
 })
 
 // 监听 editingEngine 变化
@@ -38,14 +52,20 @@ watch(
   () => props.editingEngine,
   (newEngine) => {
     if (newEngine) {
-      formData.value = { ...newEngine }
+      formData.value = {
+        ...newEngine,
+        type: newEngine.type || 'search',
+        keyword: newEngine.keyword || ''
+      }
     } else {
       formData.value = {
         id: '',
         name: '',
         url: '',
         icon: '',
-        enabled: true
+        enabled: true,
+        type: 'webpage',
+        keyword: ''
       }
     }
   },
@@ -77,39 +97,109 @@ async function handleFetchFavicon(): Promise<void> {
 
 function handleSave(): void {
   if (!formData.value.name || !formData.value.url) {
-    error('请填写名称和 URL 模板')
+    error('请填写名称和 URL')
     return
   }
-  if (!formData.value.url.includes('{q}')) {
-    error('URL 模板必须包含 {q} 占位符')
-    return
+
+  const nextData = {
+    ...formData.value,
+    name: formData.value.name.trim(),
+    url: formData.value.url.trim(),
+    keyword: formData.value.keyword?.trim() || ''
   }
-  emit('save', { ...formData.value })
+
+  if (nextData.type === 'webpage') {
+    if (!nextData.keyword) {
+      error('请填写匹配关键字')
+      return
+    }
+    if (nextData.url.includes('{q}')) {
+      error('网页 URL 不能包含 {q} 占位符')
+      return
+    }
+    nextData.url = ensureUrlProtocol(nextData.url)
+    if (!isHttpUrl(nextData.url)) {
+      error('网页 URL 必须是有效的 http/https 地址')
+      return
+    }
+  } else {
+    if (!nextData.url.includes('{q}')) {
+      error('URL 模板必须包含 {q} 占位符')
+      return
+    }
+    nextData.url = ensureUrlProtocol(nextData.url)
+    if (!isHttpUrl(nextData.url.replace('{q}', 'test'))) {
+      error('URL 模板必须是有效的 http/https 地址')
+      return
+    }
+    nextData.keyword = ''
+  }
+
+  emit('save', nextData)
+}
+
+function ensureUrlProtocol(url: string): string {
+  if (/^https?:\/\//i.test(url)) {
+    return url
+  }
+  return `https://${url}`
+}
+
+function isHttpUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url)
+    return parsed.protocol === 'http:' || parsed.protocol === 'https:'
+  } catch {
+    return false
+  }
 }
 </script>
 <template>
-  <DetailPanel :title="isEditing ? '编辑搜索引擎' : '添加搜索引擎'" @back="$emit('back')">
+  <DetailPanel :title="isEditing ? '编辑网页快开' : '添加网页快开'" @back="$emit('back')">
     <div class="editor-wrapper">
       <div class="editor-content">
+        <div class="form-group">
+          <label class="form-label">类型 *</label>
+          <div class="type-segment">
+            <button
+              type="button"
+              class="type-option"
+              :class="{ active: formData.type === 'webpage' }"
+              @click="formData.type = 'webpage'"
+            >
+              网页
+            </button>
+            <button
+              type="button"
+              class="type-option"
+              :class="{ active: formData.type === 'search' }"
+              @click="formData.type = 'search'"
+            >
+              搜索引擎
+            </button>
+          </div>
+        </div>
+
         <div class="form-group">
           <label class="form-label">名称 *</label>
           <input
             v-model="formData.name"
             type="text"
             class="input"
-            placeholder="例如：Google 搜索"
+            :placeholder="isWebpage ? '例如：ZTools 官网' : '例如：Google 搜索'"
           />
         </div>
 
+        <div v-if="isWebpage" class="form-group">
+          <label class="form-label">匹配关键字 *</label>
+          <input v-model="formData.keyword" type="text" class="input" placeholder="例如：官网" />
+          <p class="form-hint">在主搜索框输入该关键字时打开这个网页</p>
+        </div>
+
         <div class="form-group">
-          <label class="form-label">URL 模板 *</label>
-          <input
-            v-model="formData.url"
-            type="text"
-            class="input"
-            placeholder="例如：https://www.google.com/search?q={q}"
-          />
-          <p class="form-hint">使用 {q} 作为搜索关键词的占位符</p>
+          <label class="form-label">{{ urlLabel }}</label>
+          <input v-model="formData.url" type="text" class="input" :placeholder="urlPlaceholder" />
+          <p class="form-hint">{{ urlHint }}</p>
         </div>
 
         <div class="form-group">
@@ -123,7 +213,7 @@ function handleSave(): void {
                 alt=""
                 @error="($event.target as HTMLImageElement).style.display = 'none'"
               />
-              <div class="i-z-search font-size-24px"></div>
+              <div v-else class="i-z-search font-size-24px"></div>
             </div>
             <button
               class="btn btn-sm"
@@ -179,6 +269,34 @@ function handleSave(): void {
   color: var(--text-secondary);
   margin-top: 4px;
   margin-bottom: 0;
+}
+
+.type-segment {
+  display: inline-flex;
+  padding: 2px;
+  border: 1px solid var(--control-border);
+  border-radius: 6px;
+  background: var(--control-bg);
+}
+
+.type-option {
+  min-width: 88px;
+  height: 28px;
+  border: none;
+  border-radius: 4px;
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: 13px;
+  cursor: pointer;
+}
+
+.type-option:hover {
+  color: var(--text-color);
+}
+
+.type-option.active {
+  color: var(--primary-color);
+  background: var(--primary-light-bg);
 }
 
 .icon-row {

--- a/src/main/api/index.ts
+++ b/src/main/api/index.ts
@@ -256,12 +256,14 @@ class APIManager {
   /**
    * 在指定插件中查找匹配的命令
    */
-  private findCommandInPlugin(
+  private async findCommandInPlugin(
     plugin: any,
     cmdName: string
-  ): { feature: any; cmdLabel: string; cmdType: string } | null {
+  ): Promise<{ feature: any; cmdLabel: string; cmdType: string } | null> {
     const dynamicFeatures = pluginFeatureAPI.loadDynamicFeatures(plugin.name)
-    const allFeatures = [...(plugin.features || []), ...dynamicFeatures]
+    const webSearchFeatures =
+      plugin.name === 'system' ? await webSearchAPI.getSearchEngineFeatures() : []
+    const allFeatures = [...(plugin.features || []), ...dynamicFeatures, ...webSearchFeatures]
 
     for (const feature of allFeatures) {
       if (feature.cmds && Array.isArray(feature.cmds)) {
@@ -368,7 +370,7 @@ class APIManager {
           return
         }
 
-        const result = this.findCommandInPlugin(plugin, cmdName)
+        const result = await this.findCommandInPlugin(plugin, cmdName)
         if (!result) {
           const msg = `[API] 未找到命令: ${pluginDescription}/${cmdName}`
           console.error(msg)
@@ -391,7 +393,7 @@ class APIManager {
         const pluginMatches: { plugin: any; feature: any; cmdLabel: string; cmdType: string }[] = []
 
         for (const plugin of pluginList) {
-          const result = this.findCommandInPlugin(plugin, cmdName)
+          const result = await this.findCommandInPlugin(plugin, cmdName)
           if (result) {
             pluginMatches.push({
               plugin,

--- a/src/main/api/renderer/systemCommands.ts
+++ b/src/main/api/renderer/systemCommands.ts
@@ -282,7 +282,25 @@ async function handleDynamicWebSearch(
   if (!engine) {
     return { success: false, error: '未找到搜索引擎配置' }
   }
+  if (engine.type === 'webpage') {
+    return handleOpenWebpage(ctx, engine.url, engine.name)
+  }
   return handleWebSearch(ctx, param, engine.url, engine.name)
+}
+
+async function handleOpenWebpage(
+  ctx: SystemCommandContext,
+  url: string,
+  label: string
+): Promise<any> {
+  console.log(`[SystemCmd] 打开网页 ${label}:`, url)
+  if (!url) {
+    return { success: false, error: '缺少网页地址' }
+  }
+  await shell.openExternal(url)
+  ctx.mainWindow?.webContents.send('app-launched')
+  ctx.mainWindow?.hide()
+  return { success: true }
 }
 
 async function handleScreenshot(ctx: SystemCommandContext): Promise<any> {

--- a/src/main/api/renderer/webSearch.ts
+++ b/src/main/api/renderer/webSearch.ts
@@ -4,6 +4,8 @@ import windowManager from '../../managers/windowManager'
 import databaseAPI from '../shared/database'
 import commandsAPI from './commands'
 
+export type WebSearchEngineType = 'search' | 'webpage'
+
 /**
  * 网页快开搜索引擎数据结构
  */
@@ -13,6 +15,8 @@ export interface WebSearchEngine {
   url: string // URL 模板，{q} 为关键词占位符
   icon: string // favicon (base64 或 URL)
   enabled: boolean // 是否启用
+  type: WebSearchEngineType // search: 模板搜索, webpage: 直接打开网页
+  keyword?: string // 网页类型的匹配关键字
 }
 
 /**
@@ -96,7 +100,7 @@ class WebSearchAPI {
     try {
       const data = databaseAPI.dbGet(this.DB_KEY)
       if (data && Array.isArray(data)) {
-        return data
+        return data.map((engine) => this.normalizeEngine(engine))
       }
       return []
     } catch {
@@ -108,31 +112,25 @@ class WebSearchAPI {
    * 添加搜索引擎
    */
   public async addEngine(engine: WebSearchEngine): Promise<{ success: boolean; error?: string }> {
-    if (!engine.name || !engine.url) {
-      return { success: false, error: '名称和 URL 不能为空' }
+    const validated = this.validateAndNormalizeEngine(engine, false)
+    if (!validated.success) {
+      return { success: false, error: validated.error }
     }
-    if (!engine.url.includes('{q}')) {
-      return { success: false, error: 'URL 必须包含 {q} 占位符' }
-    }
+    const normalizedEngine = validated.engine!
 
     const engines = this.getAllEngines()
 
     // 自动生成 ID
-    if (!engine.id) {
-      engine.id = randomUUID()
+    if (!normalizedEngine.id) {
+      normalizedEngine.id = randomUUID()
     }
 
     // 检查重复 ID
-    if (engines.some((e) => e.id === engine.id)) {
+    if (engines.some((e) => e.id === normalizedEngine.id)) {
       return { success: false, error: '该搜索引擎 ID 已存在' }
     }
 
-    // 默认启用
-    if (engine.enabled === undefined) {
-      engine.enabled = true
-    }
-
-    engines.push(engine)
+    engines.push(normalizedEngine)
     databaseAPI.dbPut(this.DB_KEY, engines)
 
     this.notifyCommandsChanged()
@@ -146,20 +144,19 @@ class WebSearchAPI {
   public async updateEngine(
     engine: WebSearchEngine
   ): Promise<{ success: boolean; error?: string }> {
-    if (!engine.id || !engine.name || !engine.url) {
-      return { success: false, error: '名称和 URL 不能为空' }
+    const validated = this.validateAndNormalizeEngine(engine, true)
+    if (!validated.success) {
+      return { success: false, error: validated.error }
     }
-    if (!engine.url.includes('{q}')) {
-      return { success: false, error: 'URL 必须包含 {q} 占位符' }
-    }
+    const normalizedEngine = validated.engine!
 
     const engines = this.getAllEngines()
-    const index = engines.findIndex((e) => e.id === engine.id)
+    const index = engines.findIndex((e) => e.id === normalizedEngine.id)
     if (index === -1) {
       return { success: false, error: '未找到该搜索引擎' }
     }
 
-    engines[index] = engine
+    engines[index] = normalizedEngine
     databaseAPI.dbPut(this.DB_KEY, engines)
 
     this.notifyCommandsChanged()
@@ -192,18 +189,37 @@ class WebSearchAPI {
     const engines = this.getAllEngines()
     return engines
       .filter((e) => e.enabled)
-      .map((e) => ({
-        code: `web-search-${e.id}`,
-        explain: e.name,
-        icon: e.icon || '',
-        cmds: [
+      .flatMap((e): any[] => {
+        const baseFeature = {
+          code: `web-search-${e.id}`,
+          explain: e.name,
+          icon: e.icon || ''
+        }
+
+        if (e.type === 'webpage') {
+          const keyword = e.keyword?.trim()
+          if (!keyword) return []
+          return [
+            {
+              ...baseFeature,
+              cmds: [keyword]
+            }
+          ]
+        }
+
+        return [
           {
-            type: 'over',
-            label: e.name,
-            minLength: 1
+            ...baseFeature,
+            cmds: [
+              {
+                type: 'over',
+                label: e.name,
+                minLength: 1
+              }
+            ]
           }
         ]
-      }))
+      })
   }
 
   /**
@@ -226,16 +242,22 @@ class WebSearchAPI {
    */
   public async fetchFavicon(url: string): Promise<string> {
     try {
-      const urlObj = new URL(url.replace('{q}', 'test'))
+      const candidateUrl = this.ensureUrlProtocol(url.replace('{q}', 'test').trim())
+      const urlObj = new URL(candidateUrl)
       const origin = urlObj.origin
 
-      // 先尝试请求网页获取 favicon link
-      const html = await this.httpGet(`${origin}/`)
-      const faviconUrl = this.parseFaviconFromHtml(html, origin)
+      // 先尝试请求网页获取 favicon link。部分站点的压缩响应会导致 Electron net
+      // 解码失败，这里只跳过 HTML 解析，仍继续回退到 /favicon.ico。
+      try {
+        const html = await this.httpGet(`${origin}/`)
+        const faviconUrl = this.parseFaviconFromHtml(html, origin)
 
-      if (faviconUrl) {
-        const base64 = await this.downloadAsBase64(faviconUrl)
-        if (base64) return base64
+        if (faviconUrl) {
+          const base64 = await this.downloadAsBase64(faviconUrl)
+          if (base64) return base64
+        }
+      } catch (error) {
+        console.warn('[WebSearch] 获取页面 HTML 失败，回退到 /favicon.ico:', error)
       }
 
       // 回退到 /favicon.ico
@@ -247,6 +269,79 @@ class WebSearchAPI {
       console.error('[WebSearch] fetchFavicon error:', error)
       return ''
     }
+  }
+
+  private normalizeEngine(engine: any): WebSearchEngine {
+    const type: WebSearchEngineType = engine?.type === 'webpage' ? 'webpage' : 'search'
+    return {
+      id: typeof engine?.id === 'string' ? engine.id : '',
+      name: typeof engine?.name === 'string' ? engine.name.trim() : '',
+      url: typeof engine?.url === 'string' ? engine.url.trim() : '',
+      icon: typeof engine?.icon === 'string' ? engine.icon : '',
+      enabled: typeof engine?.enabled === 'boolean' ? engine.enabled : true,
+      type,
+      keyword: typeof engine?.keyword === 'string' ? engine.keyword.trim() : ''
+    }
+  }
+
+  private validateAndNormalizeEngine(
+    engine: WebSearchEngine,
+    requireId: boolean
+  ): { success: boolean; engine?: WebSearchEngine; error?: string } {
+    const normalized = this.normalizeEngine(engine)
+
+    if (requireId && !normalized.id) {
+      return { success: false, error: 'ID 不能为空' }
+    }
+    if (!normalized.name || !normalized.url) {
+      return { success: false, error: '名称和 URL 不能为空' }
+    }
+
+    if (normalized.type === 'webpage') {
+      if (!normalized.keyword) {
+        return { success: false, error: '匹配关键字不能为空' }
+      }
+      if (normalized.url.includes('{q}')) {
+        return { success: false, error: '网页 URL 不能包含 {q} 占位符' }
+      }
+      const urlResult = this.normalizeHttpUrl(normalized.url)
+      if (!urlResult.success) {
+        return { success: false, error: '网页 URL 必须是有效的 http/https 地址' }
+      }
+      normalized.url = urlResult.url!
+      return { success: true, engine: normalized }
+    }
+
+    if (!normalized.url.includes('{q}')) {
+      return { success: false, error: '搜索引擎 URL 必须包含 {q} 占位符' }
+    }
+    normalized.url = this.ensureUrlProtocol(normalized.url)
+    const urlResult = this.normalizeHttpUrl(normalized.url.replace('{q}', 'test'))
+    if (!urlResult.success) {
+      return { success: false, error: '搜索引擎 URL 必须是有效的 http/https 地址' }
+    }
+    normalized.keyword = ''
+    return { success: true, engine: normalized }
+  }
+
+  private normalizeHttpUrl(rawUrl: string): { success: boolean; url?: string } {
+    const candidate = this.ensureUrlProtocol(rawUrl.trim())
+    try {
+      const parsed = new URL(candidate)
+      if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+        return { success: false }
+      }
+      return { success: true, url: parsed.toString() }
+    } catch {
+      return { success: false }
+    }
+  }
+
+  private ensureUrlProtocol(url: string): string {
+    if (/^https?:\/\//i.test(url)) {
+      return url
+    }
+    return `https://${url}`
   }
 
   /**
@@ -283,6 +378,20 @@ class WebSearchAPI {
       const request = net.request(url)
       let data = ''
       let resolved = false
+      const fail = (error: Error): void => {
+        clearTimeout(timeout)
+        if (!resolved) {
+          resolved = true
+          reject(error)
+        }
+      }
+      const done = (value: string): void => {
+        clearTimeout(timeout)
+        if (!resolved) {
+          resolved = true
+          resolve(value)
+        }
+      }
 
       const timeout = setTimeout(() => {
         if (!resolved) {
@@ -293,6 +402,8 @@ class WebSearchAPI {
       }, 10000)
 
       request.on('response', (response) => {
+        response.on('error', fail)
+
         // 处理重定向
         if (
           response.statusCode &&
@@ -313,38 +424,18 @@ class WebSearchAPI {
           data += chunk.toString()
           // 只读取前 100KB，足够解析 head 中的 favicon
           if (data.length > 100 * 1024) {
-            clearTimeout(timeout)
-            if (!resolved) {
-              resolved = true
-              request.abort()
-              resolve(data)
-            }
+            request.abort()
+            done(data)
           }
         })
         response.on('end', () => {
-          clearTimeout(timeout)
-          if (!resolved) {
-            resolved = true
-            resolve(data)
-          }
-        })
-        response.on('error', (error) => {
-          clearTimeout(timeout)
-          if (!resolved) {
-            resolved = true
-            reject(error)
-          }
+          done(data)
         })
       })
 
-      request.on('error', (error) => {
-        clearTimeout(timeout)
-        if (!resolved) {
-          resolved = true
-          reject(error)
-        }
-      })
+      request.on('error', fail)
 
+      request.setHeader('Accept-Encoding', 'identity')
       request.end()
     })
   }
@@ -357,6 +448,13 @@ class WebSearchAPI {
       const request = net.request(url)
       const chunks: Buffer[] = []
       let resolved = false
+      const done = (value: string): void => {
+        clearTimeout(timeout)
+        if (!resolved) {
+          resolved = true
+          resolve(value)
+        }
+      }
 
       const timeout = setTimeout(() => {
         if (!resolved) {
@@ -367,6 +465,10 @@ class WebSearchAPI {
       }, 10000)
 
       request.on('response', (response) => {
+        response.on('error', () => {
+          done('')
+        })
+
         // 处理重定向
         if (
           response.statusCode &&
@@ -384,11 +486,7 @@ class WebSearchAPI {
         }
 
         if (response.statusCode !== 200) {
-          clearTimeout(timeout)
-          if (!resolved) {
-            resolved = true
-            resolve('')
-          }
+          done('')
           return
         }
 
@@ -401,35 +499,21 @@ class WebSearchAPI {
           chunks.push(Buffer.from(chunk))
         })
         response.on('end', () => {
-          clearTimeout(timeout)
-          if (!resolved) {
-            resolved = true
-            const buffer = Buffer.concat(chunks)
-            if (buffer.length > 0) {
-              const mimeType = contentType.split(';')[0].trim()
-              resolve(`data:${mimeType};base64,${buffer.toString('base64')}`)
-            } else {
-              resolve('')
-            }
-          }
-        })
-        response.on('error', () => {
-          clearTimeout(timeout)
-          if (!resolved) {
-            resolved = true
-            resolve('')
+          const buffer = Buffer.concat(chunks)
+          if (buffer.length > 0) {
+            const mimeType = contentType.split(';')[0].trim()
+            done(`data:${mimeType};base64,${buffer.toString('base64')}`)
+          } else {
+            done('')
           }
         })
       })
 
       request.on('error', () => {
-        clearTimeout(timeout)
-        if (!resolved) {
-          resolved = true
-          resolve('')
-        }
+        done('')
       })
 
+      request.setHeader('Accept-Encoding', 'identity')
       request.end()
     })
   }

--- a/src/main/api/renderer/webSearch.ts
+++ b/src/main/api/renderer/webSearch.ts
@@ -3,6 +3,7 @@ import { randomUUID } from 'crypto'
 import windowManager from '../../managers/windowManager'
 import databaseAPI from '../shared/database'
 import commandsAPI from './commands'
+import { filterSuperPanelPinnedCommands } from '../../core/superPanelPinnedCommands'
 
 export type WebSearchEngineType = 'search' | 'webpage'
 
@@ -174,12 +175,56 @@ class WebSearchAPI {
       return { success: false, error: '未找到该搜索引擎' }
     }
 
+    const featureCode = `web-search-${engines[index].id}`
+
     engines.splice(index, 1)
     databaseAPI.dbPut(this.DB_KEY, engines)
 
+    this.cleanupDeletedFeatureReferences(featureCode)
     this.notifyCommandsChanged()
 
     return { success: true }
+  }
+
+  private cleanupDeletedFeatureReferences(featureCode: string): void {
+    const cleanupTargets = [
+      { key: 'command-history', channel: 'history-changed' },
+      { key: 'pinned-commands', channel: 'pinned-changed' },
+      { key: 'command-usage-stats' },
+      { key: 'super-panel-pinned', channel: 'super-panel-pinned-changed' }
+    ]
+
+    for (const target of cleanupTargets) {
+      try {
+        const data = databaseAPI.dbGet(target.key)
+        if (!Array.isArray(data)) continue
+
+        const result =
+          target.key === 'super-panel-pinned'
+            ? filterSuperPanelPinnedCommands(data, { featureCode })
+            : this.filterDeletedFeatureFromList(data, featureCode)
+
+        if (!result.changed) continue
+
+        databaseAPI.dbPut(target.key, result.items)
+        if (target.channel) {
+          windowManager.getMainWindow()?.webContents.send(target.channel)
+        }
+      } catch (error) {
+        console.error(`[WebSearch] 清理已删除网页快开引用失败: ${target.key}`, error)
+      }
+    }
+  }
+
+  private filterDeletedFeatureFromList(
+    items: any[],
+    featureCode: string
+  ): { items: any[]; changed: boolean } {
+    const nextItems = items.filter((item) => item?.featureCode !== featureCode)
+    return {
+      items: nextItems,
+      changed: nextItems.length !== items.length
+    }
   }
 
   /**

--- a/src/main/core/startupDataMigrations.ts
+++ b/src/main/core/startupDataMigrations.ts
@@ -57,6 +57,7 @@ function migrateLegacyMacAppIcons(items: any[]): boolean {
 export function runStartupDataMigrations(): void {
   migrateDevPluginNames()
   migrateVariantRefLists()
+  migrateWebSearchEngineTypes()
 
   if (process.platform !== 'darwin') return
 
@@ -80,6 +81,49 @@ export function runStartupDataMigrations(): void {
     } catch (error) {
       console.error(`[StartupMigration] 迁移失败: ${key}`, error)
     }
+  }
+}
+
+/**
+ * 将旧版网页快开配置补齐为带 type 的新格式。
+ *
+ * 旧格式没有 type，等价于搜索引擎；网页类型额外使用 keyword 作为普通命令匹配词。
+ */
+export function migrateWebSearchEngineTypes(): void {
+  try {
+    const data: any[] = databaseAPI.dbGet('web-search-engines') || []
+    if (!Array.isArray(data)) return
+
+    let changed = false
+    const migrated = data.map((item) => {
+      if (!item || typeof item !== 'object') {
+        changed = true
+        return item
+      }
+
+      const next = { ...item }
+      if (next.type !== 'search' && next.type !== 'webpage') {
+        next.type = 'search'
+        changed = true
+      }
+      if (typeof next.enabled !== 'boolean') {
+        next.enabled = true
+        changed = true
+      }
+      if (typeof next.keyword !== 'string') {
+        next.keyword = ''
+        changed = true
+      }
+
+      return next
+    })
+
+    if (changed) {
+      databaseAPI.dbPut('web-search-engines', migrated)
+      console.log('[StartupMigration] 已迁移网页快开配置类型')
+    }
+  } catch (error) {
+    console.error('[StartupMigration] 迁移网页快开配置类型失败:', error)
   }
 }
 

--- a/src/main/core/superPanelManager.ts
+++ b/src/main/core/superPanelManager.ts
@@ -9,6 +9,7 @@ import windowManager from '../managers/windowManager.js'
 import clipboardManager, { type LastCopiedContent } from '../managers/clipboardManager.js'
 import { applyWindowMaterial, getDefaultWindowMaterial } from '../utils/windowUtils.js'
 import translationManager from './translationManager.js'
+import { filterSuperPanelPinnedCommands } from './superPanelPinnedCommands.js'
 
 // 超级面板窗口尺寸
 const SUPER_PANEL_WIDTH = 250
@@ -671,37 +672,10 @@ class SuperPanelManager {
         }
 
         // 递归处理文件夹内部的指令
-        pinnedCommands = pinnedCommands
-          .map((cmd: any) => {
-            if (cmd.isFolder) {
-              cmd.items = cmd.items.filter((item: any) => {
-                if (featureCode) {
-                  return !(item.path === path && item.featureCode === featureCode)
-                }
-                return item.path !== path
-              })
-              return cmd
-            }
-            return cmd
-          })
-          .filter((cmd: any) => {
-            if (cmd.isFolder) {
-              // 文件夹为空则移除，只剩1个则展开
-              return cmd.items.length > 0
-            }
-            if (featureCode) {
-              return !(cmd.path === path && cmd.featureCode === featureCode)
-            }
-            return cmd.path !== path
-          })
-
-        // 文件夹只剩1个指令时自动解散
-        pinnedCommands = pinnedCommands.flatMap((cmd: any) => {
-          if (cmd.isFolder && cmd.items.length === 1) {
-            return cmd.items
-          }
-          return [cmd]
-        })
+        pinnedCommands = filterSuperPanelPinnedCommands(pinnedCommands, {
+          path,
+          featureCode
+        }).items
 
         console.log('[SuperPanel] 更新后的固定列表:', pinnedCommands.length, '项')
         databaseAPI.dbPut('super-panel-pinned', pinnedCommands)

--- a/src/main/core/superPanelPinnedCommands.ts
+++ b/src/main/core/superPanelPinnedCommands.ts
@@ -1,0 +1,53 @@
+interface SuperPanelPinnedCommandMatch {
+  path?: string
+  featureCode?: string
+}
+
+function matchesPinnedCommand(item: any, match: SuperPanelPinnedCommandMatch): boolean {
+  if (match.featureCode !== undefined && item?.featureCode !== match.featureCode) {
+    return false
+  }
+  if (match.path !== undefined && item?.path !== match.path) {
+    return false
+  }
+  return match.featureCode !== undefined || match.path !== undefined
+}
+
+export function filterSuperPanelPinnedCommands(
+  items: any[],
+  match: SuperPanelPinnedCommandMatch
+): { items: any[]; changed: boolean } {
+  let changed = false
+  const nextItems: any[] = []
+
+  for (const item of items) {
+    if (matchesPinnedCommand(item, match)) {
+      changed = true
+      continue
+    }
+
+    // 递归处理文件夹内部的指令；文件夹为空则移除，只剩 1 个指令时自动解散。
+    if (item?.isFolder && Array.isArray(item.items)) {
+      const filtered = filterSuperPanelPinnedCommands(item.items, match)
+      if (filtered.changed) changed = true
+
+      if (filtered.items.length === 0) {
+        changed = true
+        continue
+      }
+
+      if (filtered.items.length === 1) {
+        changed = true
+        nextItems.push(filtered.items[0])
+        continue
+      }
+
+      nextItems.push(filtered.changed ? { ...item, items: filtered.items } : item)
+      continue
+    }
+
+    nextItems.push(item)
+  }
+
+  return { items: nextItems, changed }
+}

--- a/tests/main/startupDataMigrations.test.ts
+++ b/tests/main/startupDataMigrations.test.ts
@@ -1,0 +1,89 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mockDbGet = vi.hoisted(() => vi.fn())
+const mockDbPut = vi.hoisted(() => vi.fn())
+
+vi.mock('../../src/main/api/shared/database.js', () => ({
+  default: {
+    dbGet: mockDbGet,
+    dbPut: mockDbPut
+  }
+}))
+
+vi.mock('../../src/shared/pluginRuntimeNamespace.js', () => ({
+  isDevelopmentPluginName: vi.fn((name: string) => name.endsWith('__dev')),
+  toDevPluginName: vi.fn((name: string) => `${name}__dev`)
+}))
+
+vi.mock('../../src/main/core/internalPlugins.js', () => ({
+  isBundledInternalPlugin: vi.fn(() => false)
+}))
+
+import { migrateWebSearchEngineTypes } from '../../src/main/core/startupDataMigrations'
+
+describe('startupDataMigrations', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('migrates legacy web search engines to typed search entries', () => {
+    mockDbGet.mockReturnValue([
+      {
+        id: 'legacy',
+        name: 'Legacy',
+        url: 'https://example.com?q={q}',
+        icon: ''
+      },
+      {
+        id: 'webpage',
+        name: 'Webpage',
+        url: 'https://example.com/',
+        icon: '',
+        enabled: false,
+        type: 'webpage',
+        keyword: 'example'
+      }
+    ])
+
+    migrateWebSearchEngineTypes()
+
+    expect(mockDbPut).toHaveBeenCalledWith('web-search-engines', [
+      {
+        id: 'legacy',
+        name: 'Legacy',
+        url: 'https://example.com?q={q}',
+        icon: '',
+        type: 'search',
+        enabled: true,
+        keyword: ''
+      },
+      {
+        id: 'webpage',
+        name: 'Webpage',
+        url: 'https://example.com/',
+        icon: '',
+        enabled: false,
+        type: 'webpage',
+        keyword: 'example'
+      }
+    ])
+  })
+
+  it('does not rewrite already migrated web search data', () => {
+    mockDbGet.mockReturnValue([
+      {
+        id: 'search',
+        name: 'Search',
+        url: 'https://example.com?q={q}',
+        icon: '',
+        enabled: true,
+        type: 'search',
+        keyword: ''
+      }
+    ])
+
+    migrateWebSearchEngineTypes()
+
+    expect(mockDbPut).not.toHaveBeenCalled()
+  })
+})

--- a/tests/main/systemCommandsWebSearch.test.ts
+++ b/tests/main/systemCommandsWebSearch.test.ts
@@ -1,0 +1,125 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mockOpenExternal = vi.hoisted(() => vi.fn())
+const mockGetEngineByFeatureCode = vi.hoisted(() => vi.fn())
+
+vi.mock('electron', () => ({
+  BrowserWindow: vi.fn(),
+  clipboard: {},
+  nativeImage: {
+    createFromDataURL: vi.fn()
+  },
+  Notification: vi.fn(),
+  shell: {
+    openExternal: mockOpenExternal,
+    openPath: vi.fn(),
+    showItemInFolder: vi.fn()
+  }
+}))
+
+vi.mock('../../src/main/api/renderer/webSearch', () => ({
+  default: {
+    getEngineByFeatureCode: mockGetEngineByFeatureCode
+  }
+}))
+
+vi.mock('../../src/main/managers/windowManager', () => ({
+  default: {
+    getPreviousActiveWindow: vi.fn(),
+    getMainWindow: vi.fn()
+  }
+}))
+
+vi.mock('../../src/main/api/shared/database', () => ({
+  default: {
+    dbGet: vi.fn(),
+    dbPut: vi.fn()
+  }
+}))
+
+vi.mock('../../src/main/core/globalStyles', () => ({
+  GLOBAL_SCROLLBAR_CSS: ''
+}))
+
+vi.mock('../../src/main/core/screenCapture', () => ({
+  screenCapture: vi.fn()
+}))
+
+vi.mock('../../src/main/core/native/index.js', () => ({
+  ColorPicker: {
+    start: vi.fn()
+  }
+}))
+
+vi.mock('../../src/main/utils/common', () => ({
+  getExplorerFolderPathFromWindow: vi.fn()
+}))
+
+import { executeSystemCommand } from '../../src/main/api/renderer/systemCommands'
+
+describe('systemCommands web search execution', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockOpenExternal.mockResolvedValue(undefined)
+  })
+
+  it('executes search engines by encoding the query into the template', async () => {
+    mockGetEngineByFeatureCode.mockResolvedValue({
+      id: 'search-1',
+      name: 'Search',
+      url: 'https://example.com/search?q={q}',
+      icon: '',
+      enabled: true,
+      type: 'search',
+      keyword: ''
+    })
+    const mainWindow = {
+      webContents: { send: vi.fn() },
+      hide: vi.fn()
+    }
+
+    await expect(
+      executeSystemCommand(
+        'web-search-search-1',
+        { mainWindow: mainWindow as any, pluginManager: null },
+        {
+          payload: 'hello world'
+        }
+      )
+    ).resolves.toEqual({ success: true })
+
+    expect(mockOpenExternal).toHaveBeenCalledWith('https://example.com/search?q=hello%20world')
+    expect(mainWindow.webContents.send).toHaveBeenCalledWith('app-launched')
+    expect(mainWindow.hide).toHaveBeenCalled()
+  })
+
+  it('executes webpage entries by opening the fixed URL', async () => {
+    mockGetEngineByFeatureCode.mockResolvedValue({
+      id: 'webpage-1',
+      name: 'Example',
+      url: 'https://example.com/',
+      icon: '',
+      enabled: true,
+      type: 'webpage',
+      keyword: 'example'
+    })
+    const mainWindow = {
+      webContents: { send: vi.fn() },
+      hide: vi.fn()
+    }
+
+    await expect(
+      executeSystemCommand(
+        'web-search-webpage-1',
+        { mainWindow: mainWindow as any, pluginManager: null },
+        {
+          payload: 'ignored query'
+        }
+      )
+    ).resolves.toEqual({ success: true })
+
+    expect(mockOpenExternal).toHaveBeenCalledWith('https://example.com/')
+    expect(mainWindow.webContents.send).toHaveBeenCalledWith('app-launched')
+    expect(mainWindow.hide).toHaveBeenCalled()
+  })
+})

--- a/tests/main/webSearch.test.ts
+++ b/tests/main/webSearch.test.ts
@@ -1,0 +1,219 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { EventEmitter } from 'events'
+
+const mockDbGet = vi.hoisted(() => vi.fn())
+const mockDbPut = vi.hoisted(() => vi.fn())
+const mockGetMainWindow = vi.hoisted(() => vi.fn())
+const mockNetRequest = vi.hoisted(() => vi.fn())
+
+vi.mock('electron', () => ({
+  ipcMain: {
+    handle: vi.fn()
+  },
+  net: {
+    request: mockNetRequest
+  }
+}))
+
+vi.mock('../../src/main/api/shared/database', () => ({
+  default: {
+    dbGet: mockDbGet,
+    dbPut: mockDbPut
+  }
+}))
+
+vi.mock('../../src/main/managers/windowManager', () => ({
+  default: {
+    getMainWindow: mockGetMainWindow
+  }
+}))
+
+vi.mock('../../src/main/api/renderer/commands', () => ({
+  default: {}
+}))
+
+import webSearchAPI from '../../src/main/api/renderer/webSearch'
+
+describe('webSearchAPI', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockDbGet.mockReturnValue([])
+    mockGetMainWindow.mockReturnValue(null)
+  })
+
+  it('rejects search engines without a query placeholder', async () => {
+    const result = await webSearchAPI.addEngine({
+      id: '',
+      name: 'Google',
+      url: 'https://www.google.com/search',
+      icon: '',
+      enabled: true,
+      type: 'search'
+    })
+
+    expect(result.success).toBe(false)
+    expect(result.error).toContain('{q}')
+    expect(mockDbPut).not.toHaveBeenCalled()
+  })
+
+  it('validates and normalizes webpage entries', async () => {
+    const result = await webSearchAPI.addEngine({
+      id: 'webpage-1',
+      name: 'Example',
+      url: 'example.com',
+      icon: '',
+      enabled: true,
+      type: 'webpage',
+      keyword: 'example'
+    })
+
+    expect(result).toEqual({ success: true })
+    expect(mockDbPut).toHaveBeenCalledWith('web-search-engines', [
+      {
+        id: 'webpage-1',
+        name: 'Example',
+        url: 'https://example.com/',
+        icon: '',
+        enabled: true,
+        type: 'webpage',
+        keyword: 'example'
+      }
+    ])
+  })
+
+  it('normalizes search engine templates with missing protocols', async () => {
+    const result = await webSearchAPI.addEngine({
+      id: 'search-1',
+      name: 'Search',
+      url: 'example.com/search?q={q}',
+      icon: '',
+      enabled: true,
+      type: 'search'
+    })
+
+    expect(result).toEqual({ success: true })
+    expect(mockDbPut).toHaveBeenCalledWith('web-search-engines', [
+      {
+        id: 'search-1',
+        name: 'Search',
+        url: 'https://example.com/search?q={q}',
+        icon: '',
+        enabled: true,
+        type: 'search',
+        keyword: ''
+      }
+    ])
+  })
+
+  it('rejects webpage entries with query placeholders or missing keywords', async () => {
+    const withPlaceholder = await webSearchAPI.addEngine({
+      id: '',
+      name: 'Bad webpage',
+      url: 'https://example.com?q={q}',
+      icon: '',
+      enabled: true,
+      type: 'webpage',
+      keyword: 'bad'
+    })
+    const withoutKeyword = await webSearchAPI.addEngine({
+      id: '',
+      name: 'No keyword',
+      url: 'https://example.com',
+      icon: '',
+      enabled: true,
+      type: 'webpage',
+      keyword: ''
+    })
+
+    expect(withPlaceholder.success).toBe(false)
+    expect(withoutKeyword.success).toBe(false)
+    expect(mockDbPut).not.toHaveBeenCalled()
+  })
+
+  it('generates match features for search engines and text features for webpages', async () => {
+    mockDbGet.mockReturnValue([
+      {
+        id: 'search-1',
+        name: 'Google',
+        url: 'https://www.google.com/search?q={q}',
+        icon: 'google-icon',
+        enabled: true,
+        type: 'search'
+      },
+      {
+        id: 'webpage-1',
+        name: 'Example',
+        url: 'https://example.com/',
+        icon: 'example-icon',
+        enabled: true,
+        type: 'webpage',
+        keyword: 'example'
+      },
+      {
+        id: 'disabled-1',
+        name: 'Disabled',
+        url: 'https://disabled.example.com/',
+        icon: '',
+        enabled: false,
+        type: 'webpage',
+        keyword: 'disabled'
+      }
+    ])
+
+    await expect(webSearchAPI.getSearchEngineFeatures()).resolves.toEqual([
+      {
+        code: 'web-search-search-1',
+        explain: 'Google',
+        icon: 'google-icon',
+        cmds: [{ type: 'over', label: 'Google', minLength: 1 }]
+      },
+      {
+        code: 'web-search-webpage-1',
+        explain: 'Example',
+        icon: 'example-icon',
+        cmds: ['example']
+      }
+    ])
+  })
+
+  it('falls back to favicon.ico when the page html response fails to decode', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    mockNetRequest.mockImplementation((url: string) => {
+      const request = new EventEmitter() as EventEmitter & {
+        setHeader: ReturnType<typeof vi.fn>
+        abort: ReturnType<typeof vi.fn>
+        end: () => void
+      }
+      request.setHeader = vi.fn()
+      request.abort = vi.fn()
+      request.end = () => {
+        queueMicrotask(() => {
+          const response = new EventEmitter() as EventEmitter & {
+            statusCode: number
+            headers: Record<string, string>
+          }
+          response.statusCode = 200
+          response.headers = url.endsWith('/favicon.ico') ? { 'content-type': 'image/x-icon' } : {}
+          request.emit('response', response)
+
+          queueMicrotask(() => {
+            if (url.endsWith('/favicon.ico')) {
+              response.emit('data', Buffer.from([1, 2, 3]))
+              response.emit('end')
+            } else {
+              response.emit('error', new Error('net::ERR_CONTENT_DECODING_FAILED'))
+            }
+          })
+        })
+      }
+      return request
+    })
+
+    await expect(webSearchAPI.fetchFavicon('https://pan.baidu.com')).resolves.toBe(
+      'data:image/x-icon;base64,AQID'
+    )
+    expect(mockNetRequest).toHaveBeenCalledWith('https://pan.baidu.com/')
+    expect(mockNetRequest).toHaveBeenCalledWith('https://pan.baidu.com/favicon.ico')
+    warnSpy.mockRestore()
+  })
+})

--- a/tests/main/webSearch.test.ts
+++ b/tests/main/webSearch.test.ts
@@ -176,6 +176,96 @@ describe('webSearchAPI', () => {
     ])
   })
 
+  it('removes deleted webpage commands from history, pins, stats, and super panel pins', async () => {
+    const send = vi.fn()
+    mockGetMainWindow.mockReturnValue({ webContents: { send } })
+    mockDbGet.mockImplementation((key: string) => {
+      if (key === 'web-search-engines') {
+        return [
+          {
+            id: 'webpage-1',
+            name: 'Example',
+            url: 'https://example.com/',
+            icon: '',
+            enabled: true,
+            type: 'webpage',
+            keyword: 'example'
+          },
+          {
+            id: 'webpage-2',
+            name: 'Keep',
+            url: 'https://keep.example.com/',
+            icon: '',
+            enabled: true,
+            type: 'webpage',
+            keyword: 'keep'
+          }
+        ]
+      }
+      if (key === 'command-history') {
+        return [
+          { path: '/system', type: 'plugin', featureCode: 'web-search-webpage-1' },
+          { path: '/system', type: 'plugin', featureCode: 'web-search-webpage-2' }
+        ]
+      }
+      if (key === 'pinned-commands') {
+        return [
+          { path: '/system', type: 'plugin', featureCode: 'web-search-webpage-1' },
+          { path: '/system', type: 'plugin', featureCode: 'web-search-webpage-2' }
+        ]
+      }
+      if (key === 'command-usage-stats') {
+        return [
+          { path: '/system', type: 'plugin', featureCode: 'web-search-webpage-1' },
+          { path: '/system', type: 'plugin', featureCode: 'web-search-webpage-2' }
+        ]
+      }
+      if (key === 'super-panel-pinned') {
+        return [
+          {
+            isFolder: true,
+            name: 'Folder',
+            items: [
+              { path: '/system', type: 'plugin', featureCode: 'web-search-webpage-1' },
+              { path: '/system', type: 'plugin', featureCode: 'web-search-webpage-2' }
+            ]
+          }
+        ]
+      }
+      return []
+    })
+
+    await expect(webSearchAPI.deleteEngine('webpage-1')).resolves.toEqual({ success: true })
+
+    expect(mockDbPut).toHaveBeenCalledWith('web-search-engines', [
+      {
+        id: 'webpage-2',
+        name: 'Keep',
+        url: 'https://keep.example.com/',
+        icon: '',
+        enabled: true,
+        type: 'webpage',
+        keyword: 'keep'
+      }
+    ])
+    expect(mockDbPut).toHaveBeenCalledWith('command-history', [
+      { path: '/system', type: 'plugin', featureCode: 'web-search-webpage-2' }
+    ])
+    expect(mockDbPut).toHaveBeenCalledWith('pinned-commands', [
+      { path: '/system', type: 'plugin', featureCode: 'web-search-webpage-2' }
+    ])
+    expect(mockDbPut).toHaveBeenCalledWith('command-usage-stats', [
+      { path: '/system', type: 'plugin', featureCode: 'web-search-webpage-2' }
+    ])
+    expect(mockDbPut).toHaveBeenCalledWith('super-panel-pinned', [
+      { path: '/system', type: 'plugin', featureCode: 'web-search-webpage-2' }
+    ])
+    expect(send).toHaveBeenCalledWith('history-changed')
+    expect(send).toHaveBeenCalledWith('pinned-changed')
+    expect(send).toHaveBeenCalledWith('super-panel-pinned-changed')
+    expect(send).toHaveBeenCalledWith('plugins-changed')
+  })
+
   it('falls back to favicon.ico when the page html response fails to decode', async () => {
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
     mockNetRequest.mockImplementation((url: string) => {


### PR DESCRIPTION
# 变更内容
+ 网页快开支持了普通网站（非搜索引擎）
+ 支持手动上传图标
+ 删除快开时同时删除历史记录、pin、超级面板项
+ 支持设置全局快捷键触发快开

# 动机
支持普通网站的快速打开

# 截图

<img width="975" height="733" alt="image" src="https://github.com/user-attachments/assets/59817915-1d24-4457-b5c0-a165e6fdbd07" />

<img width="1102" height="821" alt="image" src="https://github.com/user-attachments/assets/0c617c10-2220-4f6f-9264-23d030b75f5b" />

# 相关 Issue
+ Closes #350
+ Close #417
+ #292