### PR TITLE
修正Windows下copy-path和open-terminal两个系统命令对文件资源管理器的判断异常

### DIFF
--- a/internal-plugins/system/public/plugin.json
+++ b/internal-plugins/system/public/plugin.json
@@ -90,7 +90,8 @@
           "type": "window",
           "label": "复制路径",
           "match": {
-            "app": ["Finder.app", "explorer.exe"]
+            "app": ["Finder.app", "explorer.exe"],
+            "className": ["", "CabinetWClass"]
           }
         },
         {
@@ -110,7 +111,8 @@
           "type": "window",
           "label": "在终端打开",
           "match": {
-            "app": ["Finder.app", "explorer.exe"]
+            "app": ["Finder.app", "explorer.exe"],
+            "className": ["", "CabinetWClass"]
           }
         },
         {

--- a/src/main/managers/clipboardManager.ts
+++ b/src/main/managers/clipboardManager.ts
@@ -155,6 +155,10 @@ class ClipboardManager {
     className?: string
     hwnd?: number
   }): void {
+    //Windows下任务栏成为前台窗口时，阻止当前窗口数据的切换
+    if (data.app === 'explorer.exe' && data.className === 'Shell_TrayWnd') {
+      return
+    }
     // 直接使用原生数据，保留所有字段
     this.currentWindow = {
       app: data.app,
@@ -841,7 +845,7 @@ class ClipboardManager {
         resolve(null)
       }, timeoutMs)
 
-      const wrappedResolve = (content: LastCopiedContent) => {
+      const wrappedResolve = (content: LastCopiedContent): void => {
         if (timer) {
           clearTimeout(timer)
           timer = null

--- a/src/renderer/src/components/search/SearchResults.vue
+++ b/src/renderer/src/components/search/SearchResults.vue
@@ -168,7 +168,8 @@ const windowMatchedActions = computed(() => {
   // 使用 commandDataStore 的 searchWindowCommands 进行匹配
   const matched = commandDataStore.searchWindowCommands({
     app: currentWindow.app,
-    title: currentWindow.title
+    title: currentWindow.title,
+    className: currentWindow.className
   })
 
   // 如果有搜索内容，在匹配的窗口指令中进一步搜索

--- a/src/renderer/src/stores/commandDataStore.ts
+++ b/src/renderer/src/stores/commandDataStore.ts
@@ -57,6 +57,7 @@ interface WindowCmd {
   match: {
     app?: string[] // 匹配应用名称列表（如 ["Finder.app"]）
     title?: string // 匹配窗口标题的正则表达式字符串
+    className?: string[]
   }
 }
 
@@ -1350,7 +1351,7 @@ export const useCommandDataStore = defineStore('commandData', () => {
 
   function matchesWindowCommand(
     command: Command,
-    windowInfo?: { app?: string; title?: string } | null
+    windowInfo?: { app?: string; title?: string; className?: string } | null
   ): boolean {
     if (
       !windowInfo ||
@@ -1368,7 +1369,10 @@ export const useCommandDataStore = defineStore('commandData', () => {
         // 直接字符串匹配
         return windowInfo.app === appPattern
       })
-      if (appMatches) {
+      const classNameMatches = windowCmd.match.className?.some(
+        (classNamePattern) => classNamePattern === windowInfo.className
+      )
+      if (appMatches && (!windowCmd.match.className || classNameMatches)) {
         return true
       }
     }
@@ -1385,7 +1389,11 @@ export const useCommandDataStore = defineStore('commandData', () => {
   }
 
   // 搜索支持窗口的指令（根据当前激活窗口进行匹配）
-  function searchWindowCommands(windowInfo?: { app?: string; title?: string }): SearchResult[] {
+  function searchWindowCommands(windowInfo?: {
+    app?: string
+    title?: string
+    className?: string
+  }): SearchResult[] {
     if (!windowInfo || (!windowInfo.app && !windowInfo.title)) {
       return []
     }

--- a/src/renderer/src/stores/commandDataStore.ts
+++ b/src/renderer/src/stores/commandDataStore.ts
@@ -1370,7 +1370,7 @@ export const useCommandDataStore = defineStore('commandData', () => {
         return windowInfo.app === appPattern
       })
       const classNameMatches = windowCmd.match.className?.some(
-        (classNamePattern) => classNamePattern === windowInfo.className
+        (classNamePattern) => classNamePattern === (windowInfo.className || '')
       )
       if (appMatches && (!windowCmd.match.className || classNameMatches)) {
         return true


### PR DESCRIPTION
增加了对windows下文件资源管理器的类名判断，只有在类名为"CabinetWClass"时，才会显示copy-path和open-terminal命令。类似于下图中的界面成为前台窗口时，才显示这两个命令。
<img width="1893" height="1017" alt="image" src="https://github.com/user-attachments/assets/48a5ada4-d3ba-4ad6-a8dc-b55f7e1b12c2" />

目前2.5.0版本，在点击系统托盘后，任务栏会成为前台窗口，此时以无法获取到打开的文件资源管理器中的路径。
同时还阻止了任务栏会成为前台窗口时，不再触发窗口激活事件，以此作为第二重保障