### PR TITLE
feat: 支持关闭插件搜索栏推送

### DIFF
--- a/internal-plugins/setting/src/components/common/PluginDetail/PluginDetail.vue
+++ b/internal-plugins/setting/src/components/common/PluginDetail/PluginDetail.vue
@@ -44,10 +44,13 @@ const {
   isAutoKill,
   isAutoDetach,
   isAutoStart,
+  isMainPushEnabled,
+  pluginHasMainPush,
   toggleSettingsDropdown,
   toggleAutoKill,
   toggleAutoDetach,
   toggleAutoStart,
+  toggleMainPushEnabled,
   // Tab
   activeTab,
   availableTabs,
@@ -102,6 +105,8 @@ function onSwitchTab(tabId: TabId): void {
         :is-auto-kill="isAutoKill"
         :is-auto-detach="isAutoDetach"
         :is-auto-start="isAutoStart"
+        :is-main-push-enabled="isMainPushEnabled"
+        :show-main-push-toggle="pluginHasMainPush"
         @open="emit('open')"
         @kill="emit('kill')"
         @open-folder="emit('open-folder')"
@@ -112,6 +117,7 @@ function onSwitchTab(tabId: TabId): void {
         @toggle-auto-kill="toggleAutoKill"
         @toggle-auto-detach="toggleAutoDetach"
         @toggle-auto-start="toggleAutoStart"
+        @toggle-main-push-enabled="toggleMainPushEnabled"
       />
     </template>
 

--- a/internal-plugins/setting/src/components/common/PluginDetail/PluginDetailToolbar.vue
+++ b/internal-plugins/setting/src/components/common/PluginDetail/PluginDetailToolbar.vue
@@ -14,6 +14,8 @@ defineProps<{
   isAutoKill: boolean
   isAutoDetach: boolean
   isAutoStart: boolean
+  isMainPushEnabled: boolean
+  showMainPushToggle?: boolean
 }>()
 
 const emit = defineEmits<{
@@ -27,6 +29,7 @@ const emit = defineEmits<{
   (e: 'toggle-auto-kill'): void
   (e: 'toggle-auto-detach'): void
   (e: 'toggle-auto-start'): void
+  (e: 'toggle-main-push-enabled'): void
 }>()
 
 function handleDisabledToggle(event: Event): void {
@@ -105,6 +108,20 @@ function handleDisabledToggle(event: Event): void {
             </div>
             <label class="toggle">
               <input type="checkbox" :checked="!isDisabled" @change="handleDisabledToggle" />
+              <span class="toggle-slider"></span>
+            </label>
+          </div>
+          <div v-if="showMainPushToggle" class="settings-dropdown-item">
+            <div class="settings-item-info">
+              <span class="settings-item-label">搜索栏推送</span>
+              <span class="settings-item-desc">关闭后不在搜索栏动态推送内容</span>
+            </div>
+            <label class="toggle">
+              <input
+                type="checkbox"
+                :checked="isMainPushEnabled"
+                @change="emit('toggle-main-push-enabled')"
+              />
               <span class="toggle-slider"></span>
             </label>
           </div>

--- a/internal-plugins/setting/src/components/common/PluginDetail/types.ts
+++ b/internal-plugins/setting/src/components/common/PluginDetail/types.ts
@@ -4,6 +4,7 @@ export interface PluginFeature {
   explain?: string
   icon?: string
   cmds?: any[]
+  mainPush?: boolean
 }
 
 export interface PluginItem {

--- a/internal-plugins/setting/src/components/common/PluginDetail/usePluginDetail.ts
+++ b/internal-plugins/setting/src/components/common/PluginDetail/usePluginDetail.ts
@@ -2,6 +2,11 @@ import { marked } from 'marked'
 import { computed, onMounted, onUnmounted, ref, watch, type Ref } from 'vue'
 import { useToast } from '@/components'
 import type { DocItem, PluginItem, PluginUninstallOptions, TabId, TabItem } from './types'
+import {
+  DISABLED_MAIN_PUSH_PLUGINS_KEY,
+  normalizeConfigList,
+  isMainPushPluginEnabled
+} from '@shared/pluginSettings'
 
 // 配置 marked
 marked.setOptions({
@@ -26,17 +31,17 @@ export function usePluginDetail(options: UsePluginDetailOptions) {
   const isAutoKill = ref(false)
   const isAutoDetach = ref(false)
   const isAutoStart = ref(false)
+  const isMainPushEnabled = ref(true)
 
   // 当前详情页插件的有效名称（已包含 __dev 后缀）
   const currentPluginName = computed(() => plugin.value.name || null)
-
-  /** 解析配置列表，兼容旧式 { pluginName, source } 和新式 string */
-  function normalizeConfigList(data: unknown): string[] {
-    if (!Array.isArray(data)) return []
-    return data
-      .map((item) => (typeof item === 'string' ? item : (item?.pluginName ?? '')))
-      .filter(Boolean)
-  }
+  const pluginHasMainPush = computed(() =>
+    Boolean(
+      plugin.value.features?.some(
+        (feature: any) => feature?.mainPush && Array.isArray(feature.cmds)
+      )
+    )
+  )
 
   /** 切换字符串列表中的某项 */
   function toggleInList(list: string[], name: string): string[] {
@@ -82,6 +87,18 @@ export function usePluginDetail(options: UsePluginDetailOptions) {
       }
     } catch (err) {
       console.debug('未找到 autoStartPlugin 配置', err)
+    }
+
+    try {
+      const mainPushData = await window.ztools.internal.dbGet(DISABLED_MAIN_PUSH_PLUGINS_KEY)
+      if (currentPluginName.value) {
+        isMainPushEnabled.value = isMainPushPluginEnabled(
+          currentPluginName.value,
+          normalizeConfigList(mainPushData)
+        )
+      }
+    } catch (err) {
+      console.debug('未找到 disabledMainPushPlugin 配置', err)
     }
   }
 
@@ -134,6 +151,21 @@ export function usePluginDetail(options: UsePluginDetailOptions) {
     list = toggleInList(list, currentPluginName.value)
     await window.ztools.internal.dbPut('autoStartPlugin', list)
     isAutoStart.value = list.includes(currentPluginName.value)
+  }
+
+  async function toggleMainPushEnabled(): Promise<void> {
+    if (!currentPluginName.value) return
+
+    const nextDisabled = isMainPushEnabled.value
+    const result = await window.ztools.internal.setPluginMainPushDisabled(
+      currentPluginName.value,
+      nextDisabled
+    )
+    if (result.success) {
+      isMainPushEnabled.value = !nextDisabled
+    } else {
+      error(`更新搜索栏推送状态失败: ${result.error || '未知错误'}`)
+    }
   }
 
   // Tab 状态
@@ -493,11 +525,14 @@ export function usePluginDetail(options: UsePluginDetailOptions) {
     isAutoKill,
     isAutoDetach,
     isAutoStart,
+    isMainPushEnabled,
+    pluginHasMainPush,
     currentPluginName,
     toggleSettingsDropdown,
     toggleAutoKill,
     toggleAutoDetach,
     toggleAutoStart,
+    toggleMainPushEnabled,
 
     // Tab 状态
     activeTab,

--- a/internal-plugins/setting/src/env.d.ts
+++ b/internal-plugins/setting/src/env.d.ts
@@ -57,6 +57,10 @@ declare global {
           pluginPath: string,
           disabled: boolean
         ) => Promise<{ success: boolean; error?: string }>
+        setPluginMainPushDisabled: (
+          pluginName: string,
+          disabled: boolean
+        ) => Promise<{ success: boolean; error?: string }>
         getAllPlugins: () => Promise<
           Array<{
             name: string

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,8 @@
+allowBuilds:
+  electron: true
+  electron-winstaller: true
+  esbuild: true
+  lmdb: true
+  msgpackr-extract: true
+  sharp: true
+  uiohook-napi: true

--- a/resources/preload.js
+++ b/resources/preload.js
@@ -834,6 +834,12 @@ window.ztools = {
     setPluginDisabled: async (pluginPath, disabled) =>
       await electron.ipcRenderer.invoke('internal:set-plugin-disabled', pluginPath, disabled),
     getAllPlugins: async () => await electron.ipcRenderer.invoke('internal:get-all-plugins'),
+    setPluginMainPushDisabled: async (pluginName, disabled) =>
+      await electron.ipcRenderer.invoke(
+        'internal:set-plugin-main-push-disabled',
+        pluginName,
+        disabled
+      ),
     selectPluginFile: async () => await electron.ipcRenderer.invoke('internal:select-plugin-file'),
     importPlugin: async () => await electron.ipcRenderer.invoke('internal:import-plugin'),
     getDevProjects: async () => await electron.ipcRenderer.invoke('internal:get-dev-projects'),

--- a/src/main/api/plugin/internal.ts
+++ b/src/main/api/plugin/internal.ts
@@ -213,6 +213,16 @@ export class InternalPluginAPI {
       return await pluginsAPI.getAllPlugins()
     })
 
+    ipcMain.handle(
+      'internal:set-plugin-main-push-disabled',
+      async (event, pluginName: string, disabled: boolean) => {
+        if (!requireInternalPlugin(this.pluginManager, event)) {
+          throw new PermissionDeniedError('internal:set-plugin-main-push-disabled')
+        }
+        return await pluginsAPI.setPluginMainPushDisabled(pluginName, disabled)
+      }
+    )
+
     ipcMain.handle('internal:select-plugin-file', async (event) => {
       if (!requireInternalPlugin(this.pluginManager, event)) {
         throw new PermissionDeniedError('internal:select-plugin-file')

--- a/src/main/api/renderer/plugins.ts
+++ b/src/main/api/renderer/plugins.ts
@@ -18,9 +18,20 @@ import {
   getPluginDataPrefix,
   isDevelopmentPluginName
 } from '../../../shared/pluginRuntimeNamespace'
+import {
+  DISABLED_MAIN_PUSH_PLUGINS_KEY,
+  normalizeConfigList,
+  removePluginNameFromSettingList
+} from '../../../shared/pluginSettings'
 
 // 插件目录
 const DISABLED_PLUGINS_KEY = 'disabled-plugins'
+const PLUGIN_NAME_SETTING_KEYS = [
+  'outKillPlugin',
+  'autoDetachPlugin',
+  'autoStartPlugin',
+  DISABLED_MAIN_PUSH_PLUGINS_KEY
+]
 
 export interface DeletePluginOptions {
   deleteData?: boolean
@@ -474,6 +485,7 @@ export class PluginsAPI {
 
       if (options.deleteData !== false) {
         await databaseAPI.clearPluginData(pluginInfo.name)
+        this.removePluginNameConfigs(PLUGIN_NAME_SETTING_KEYS, pluginInfo.name)
       }
 
       // 删除禁用插件标识
@@ -499,6 +511,45 @@ export class PluginsAPI {
       return { success: true }
     } catch (error: unknown) {
       console.error('[Plugins] 删除插件失败:', error)
+      return { success: false, error: error instanceof Error ? error.message : '未知错误' }
+    }
+  }
+
+  private removePluginNameConfigs(keys: string[], pluginName: string): void {
+    for (const key of keys) {
+      const current = databaseAPI.dbGet(key)
+      const normalized = normalizeConfigList(current)
+      const next = removePluginNameFromSettingList(normalized, pluginName)
+      if (next.length !== normalized.length) {
+        databaseAPI.dbPut(key, next)
+      }
+    }
+  }
+
+  public async setPluginMainPushDisabled(
+    pluginName: string,
+    disabled: boolean
+  ): Promise<{ success: boolean; error?: string }> {
+    try {
+      const disabledPluginNames = new Set(
+        normalizeConfigList(databaseAPI.dbGet(DISABLED_MAIN_PUSH_PLUGINS_KEY))
+      )
+      const isCurrentlyDisabled = disabledPluginNames.has(pluginName)
+      if (isCurrentlyDisabled === disabled) {
+        return { success: true }
+      }
+
+      if (disabled) {
+        disabledPluginNames.add(pluginName)
+      } else {
+        disabledPluginNames.delete(pluginName)
+      }
+
+      databaseAPI.dbPut(DISABLED_MAIN_PUSH_PLUGINS_KEY, [...disabledPluginNames])
+      this.notifyPluginsChanged()
+      return { success: true }
+    } catch (error: unknown) {
+      console.error('[Plugins] 更新插件 mainPush 状态失败:', error)
       return { success: false, error: error instanceof Error ? error.message : '未知错误' }
     }
   }

--- a/src/renderer/src/components/detached/DetachedTitlebar.vue
+++ b/src/renderer/src/components/detached/DetachedTitlebar.vue
@@ -123,6 +123,7 @@
 
 <script setup lang="ts">
 import { onMounted, ref } from 'vue'
+import { normalizeConfigList } from '@shared/pluginSettings'
 import AdaptiveIcon from '../common/AdaptiveIcon.vue'
 
 const platform = ref<'darwin' | 'win32'>('darwin')
@@ -139,13 +140,6 @@ const acrylicDarkOpacity = ref(50) // 亚克力暗黑模式透明度（默认 50
 const aiRequestStatus = ref<'idle' | 'sending' | 'receiving'>('idle') // AI 请求状态
 const primaryColor = ref('blue')
 const customColor = ref('#db2777')
-
-function normalizeConfigList(data: unknown): string[] {
-  if (!Array.isArray(data)) return []
-  return (data as any[])
-    .map((item) => (typeof item === 'string' ? item : (item?.pluginName ?? '')))
-    .filter(Boolean)
-}
 
 function getThemeColor(colorName: string, isDark: boolean): string {
   const colors: Record<string, { light: string; dark: string }> = {

--- a/src/renderer/src/components/search/SearchBox.vue
+++ b/src/renderer/src/components/search/SearchBox.vue
@@ -217,6 +217,7 @@
 
 <script setup lang="ts">
 import { computed, nextTick, onMounted, onUnmounted, ref, watch } from 'vue'
+import { normalizeConfigList } from '@shared/pluginSettings'
 import { DEFAULT_AVATAR, useWindowStore } from '../../stores/windowStore'
 import AdaptiveIcon from '../common/AdaptiveIcon.vue'
 import UpdateIcon from './UpdateIcon.vue'
@@ -274,14 +275,6 @@ const placeholderText = computed(() => {
  */
 function getCurrentPluginName(): string | null {
   return windowStore.currentPlugin?.name ?? null
-}
-
-/** 解析配置列表，兼容旧式对象 */
-function normalizeConfigList(data: unknown): string[] {
-  if (!Array.isArray(data)) return []
-  return data
-    .map((item) => (typeof item === 'string' ? item : (item?.pluginName ?? '')))
-    .filter(Boolean)
 }
 
 /**

--- a/src/renderer/src/stores/commandDataStore.ts
+++ b/src/renderer/src/stores/commandDataStore.ts
@@ -15,6 +15,11 @@ import {
   normalizeCommandAliases,
   type CommandAliasStore
 } from '@shared/commandShared'
+import {
+  DISABLED_MAIN_PUSH_PLUGINS_KEY,
+  isMainPushPluginEnabled,
+  normalizeConfigList
+} from '@shared/pluginSettings'
 
 // 正则匹配指令
 interface RegexCmd {
@@ -193,6 +198,7 @@ export const useCommandDataStore = defineStore('commandData', () => {
   const disabledCommands = ref<string[]>([])
   const DISABLED_COMMANDS_KEY = 'disable-commands'
   const disabledPluginPaths = ref<string[]>([])
+  const disabledMainPushPluginNames = ref<string[]>([])
 
   function setDisabledPluginPaths(paths: unknown): void {
     disabledPluginPaths.value = Array.isArray(paths)
@@ -449,6 +455,16 @@ export const useCommandDataStore = defineStore('commandData', () => {
     }
   }
 
+  async function loadDisabledMainPushPlugins(): Promise<void> {
+    try {
+      const data = await window.ztools.dbGet(DISABLED_MAIN_PUSH_PLUGINS_KEY)
+      disabledMainPushPluginNames.value = normalizeConfigList(data)
+    } catch (error) {
+      console.error('加载禁用 mainPush 插件列表失败:', error)
+      disabledMainPushPluginNames.value = []
+    }
+  }
+
   async function loadSearchPreference(): Promise<void> {
     try {
       const data = await window.ztools.dbGet('search-preference')
@@ -491,7 +507,11 @@ export const useCommandDataStore = defineStore('commandData', () => {
 
     try {
       // 先加载禁用指令列表和指令列表，再加载历史记录和固定列表（历史记录清理需要依赖指令列表）
-      await Promise.all([loadDisabledCommands(), loadDisabledPlugins()])
+      await Promise.all([
+        loadDisabledCommands(),
+        loadDisabledPlugins(),
+        loadDisabledMainPushPlugins()
+      ])
       await loadCommands()
       await Promise.all([
         loadHistoryData(),
@@ -651,12 +671,16 @@ export const useCommandDataStore = defineStore('commandData', () => {
    */
   async function reloadPluginCommands(): Promise<void> {
     try {
-      const [plugins, disabledPlugins, commandAliases] = await Promise.all([
-        window.ztools.getAllPlugins(),
-        window.ztools.getDisabledPlugins(),
-        loadCommandAliases()
-      ])
+      const [plugins, disabledPlugins, disabledMainPushPlugins, commandAliases] = await Promise.all(
+        [
+          window.ztools.getAllPlugins(),
+          window.ztools.getDisabledPlugins(),
+          window.ztools.dbGet(DISABLED_MAIN_PUSH_PLUGINS_KEY),
+          loadCommandAliases()
+        ]
+      )
       setDisabledPluginPaths(disabledPlugins)
+      disabledMainPushPluginNames.value = normalizeConfigList(disabledMainPushPlugins)
       const enabledPluginPaths = getEnabledPluginPaths(plugins)
       enabledPluginsCache.value = plugins.filter((plugin: any) =>
         enabledPluginPaths.has(plugin.path)
@@ -762,7 +786,9 @@ export const useCommandDataStore = defineStore('commandData', () => {
         if (!feature.cmds || !Array.isArray(feature.cmds)) continue
 
         const featureIcon = feature.icon || plugin.logo
-        const isMainPush = !!feature.mainPush
+        const isMainPush =
+          !!feature.mainPush &&
+          isMainPushPluginEnabled(plugin.name, disabledMainPushPluginNames.value)
 
         if (isMainPush) {
           mainPushItems.push({
@@ -913,12 +939,14 @@ export const useCommandDataStore = defineStore('commandData', () => {
     const requestId = ++loadCommandsRequestId
     loading.value = true
     try {
-      const [rawApps, plugins, disabledPlugins, commandAliases] = await Promise.all([
-        window.ztools.getApps(),
-        window.ztools.getAllPlugins(),
-        window.ztools.getDisabledPlugins(),
-        loadCommandAliases()
-      ])
+      const [rawApps, plugins, disabledPlugins, disabledMainPushPlugins, commandAliases] =
+        await Promise.all([
+          window.ztools.getApps(),
+          window.ztools.getAllPlugins(),
+          window.ztools.getDisabledPlugins(),
+          window.ztools.dbGet(DISABLED_MAIN_PUSH_PLUGINS_KEY),
+          loadCommandAliases()
+        ])
 
       let settingCommands: Command[] = []
       try {
@@ -968,6 +996,7 @@ export const useCommandDataStore = defineStore('commandData', () => {
       }
 
       setDisabledPluginPaths(disabledPlugins)
+      disabledMainPushPluginNames.value = normalizeConfigList(disabledMainPushPlugins)
       rawAppsCache.value = rawApps
       const enabledPluginPaths = getEnabledPluginPaths(plugins)
       enabledPluginsCache.value = plugins.filter((plugin: any) =>

--- a/src/shared/pluginSettings.ts
+++ b/src/shared/pluginSettings.ts
@@ -1,0 +1,22 @@
+export const DISABLED_MAIN_PUSH_PLUGINS_KEY = 'disabledMainPushPlugin'
+
+export type PluginConfigEntry = string | { pluginName?: string | null }
+
+/** 解析配置列表，兼容旧式 { pluginName, source } 和新式 string */
+export function normalizeConfigList(data: unknown): string[] {
+  if (!Array.isArray(data)) return []
+  return data
+    .map((item: PluginConfigEntry) => (typeof item === 'string' ? item : (item?.pluginName ?? '')))
+    .filter((name): name is string => Boolean(name))
+}
+
+export function isMainPushPluginEnabled(
+  pluginName: string,
+  disabledPluginNames: string[]
+): boolean {
+  return !disabledPluginNames.includes(pluginName)
+}
+
+export function removePluginNameFromSettingList(data: string[], pluginName: string): string[] {
+  return data.filter((name) => name !== pluginName)
+}

--- a/tests/main/pluginRemovalCleanup.test.ts
+++ b/tests/main/pluginRemovalCleanup.test.ts
@@ -88,6 +88,7 @@ import {
 } from '../../src/main/api/renderer/pluginDevelopmentRegistry'
 import { PluginDevProjectsAPI } from '../../src/main/api/renderer/pluginDevProjects'
 import { PluginsAPI } from '../../src/main/api/renderer/plugins'
+import { DISABLED_MAIN_PUSH_PLUGINS_KEY } from '../../src/shared/pluginSettings'
 
 describe('plugin removal cleanup', () => {
   beforeEach(() => {
@@ -249,5 +250,62 @@ describe('plugin removal cleanup', () => {
     expect(mockClearPluginData).not.toHaveBeenCalled()
     expect(mockDbPut).toHaveBeenCalledWith('plugins', [])
     expect(mockFsRm).toHaveBeenCalledWith('D:\\plugins\\demo', { recursive: true, force: true })
+  })
+
+  it('cleans plugin settings when uninstalling and clearing plugin data', async () => {
+    mockDbGet.mockImplementation((key: string) => {
+      if (key === 'plugins') {
+        return [{ name: 'demo', path: 'D:\\plugins\\demo', isDevelopment: false }]
+      }
+      if (key === 'outKillPlugin') {
+        return ['demo', 'other']
+      }
+      if (key === 'autoDetachPlugin') {
+        return ['demo']
+      }
+      if (key === 'autoStartPlugin') {
+        return [{ pluginName: 'demo' }, { pluginName: 'other' }]
+      }
+      if (key === DISABLED_MAIN_PUSH_PLUGINS_KEY) {
+        return ['demo', 'other']
+      }
+      return []
+    })
+
+    const api = new PluginsAPI()
+    const killPlugin = vi.fn()
+    const removePluginUsageData = vi.fn()
+
+    ;(api as any).pluginManager = { killPlugin }
+    ;(api as any).devProjects = { removePluginUsageData }
+    ;(api as any).mainWindow = { webContents: { send: vi.fn() } }
+    ;(api as any).disabledPluginPathSet = new Set<string>()
+
+    const result = await api.deletePlugin('D:\\plugins\\demo', { deleteData: true })
+
+    expect(result).toEqual({ success: true })
+    expect(mockDbPut).toHaveBeenCalledWith('outKillPlugin', ['other'])
+    expect(mockDbPut).toHaveBeenCalledWith('autoDetachPlugin', [])
+    expect(mockDbPut).toHaveBeenCalledWith('autoStartPlugin', ['other'])
+    expect(mockDbPut).toHaveBeenCalledWith(DISABLED_MAIN_PUSH_PLUGINS_KEY, ['other'])
+  })
+
+  it('updates mainPush availability by plugin name and notifies command reload', async () => {
+    mockDbGet.mockImplementation((key: string) => {
+      if (key === DISABLED_MAIN_PUSH_PLUGINS_KEY) {
+        return ['other']
+      }
+      return []
+    })
+
+    const api = new PluginsAPI()
+    const send = vi.fn()
+    ;(api as any).mainWindow = { webContents: { send } }
+
+    const result = await api.setPluginMainPushDisabled('demo', true)
+
+    expect(result).toEqual({ success: true })
+    expect(mockDbPut).toHaveBeenCalledWith(DISABLED_MAIN_PUSH_PLUGINS_KEY, ['other', 'demo'])
+    expect(send).toHaveBeenCalledWith('plugins-changed')
   })
 })


### PR DESCRIPTION
# 变更内容
+ 为单个插件增加关闭 main push 的选项
+ 增加数据库 `disabledMainPushPlugin` 字段

# 动机
很多插件自带 main push 功能，目前无法自主关闭。当插件很多时，搜索栏信息会过多。
应该支持关闭单个插件 main push 的选项，

# 截图
<img width="984" height="727" alt="image" src="https://github.com/user-attachments/assets/05230a44-25e9-4d59-ba9b-4a60c8d9d57d" />
