### PR TITLE
feat: 支持搜索启动嵌套子目录中的应用（macOS）

### DIFF
--- a/src/main/api/renderer/commands.ts
+++ b/src/main/api/renderer/commands.ts
@@ -30,7 +30,8 @@ interface LastMatchState {
  * 应用管理API - 主程序专用
  */
 export class AppsAPI {
-  private static readonly APP_CACHE_VERSION = 3
+  // v4: macOS 扫描下钻一层以纳入浏览器 PWA（Chrome/Edge Apps.localized）以及 Python 安装子目录下的 IDLE 等
+  private static readonly APP_CACHE_VERSION = 4
   private static readonly APP_CACHE_VERSION_KEY = 'cached-commands-version'
   private mainWindow: Electron.BrowserWindow | null = null
   private pluginManager: PluginManager | null = null

--- a/src/main/appWatcher.ts
+++ b/src/main/appWatcher.ts
@@ -71,8 +71,25 @@ class AppWatcher {
     }
 
     if (process.platform === 'darwin') {
-      // macOS: 只监听 .app 结尾的目录
-      return !basename.endsWith('.app')
+      // .app 目录始终监听（无论位于顶层还是 PWA 容器内）
+      if (basename.endsWith('.app')) {
+        return false
+      }
+
+      // 放行 watch 根目录下的「顶层子目录」（如 Chrome Apps.localized / Edge Apps.localized），
+      // 让 chokidar 下钻一层从而能检测到容器内 PWA 的增删。
+      // 仅放行目录、不放行文件（如 .DS_Store）；容器内部 / .app 内部仍只关心 .app。
+      const parent = path.dirname(filePath)
+      if (watchPaths.includes(parent)) {
+        try {
+          return !fs.statSync(filePath).isDirectory()
+        } catch {
+          // stat 失败（如 unlink 事件时目录已不存在）：不忽略，交由上层按 .app 后缀判断
+          return false
+        }
+      }
+
+      return true
     }
 
     return true

--- a/src/main/core/commandScanner/macScanner.ts
+++ b/src/main/core/commandScanner/macScanner.ts
@@ -327,6 +327,34 @@ async function getAppDisplayInfo(appPath: string): Promise<LocalizedAppMetadata>
   return { name, aliases }
 }
 
+// 递归收集目录下的 .app bundle
+// - 遇到 .app 目录：收集，不再深入（避免把 *.app 内部的 helper 子 app 扫进来）
+// - 遇到普通目录且 depth > 0：下钻一层
+//   这样可覆盖浏览器 PWA（~/Applications/Chrome Apps.localized/*.app、
+//   Edge Apps.localized 等）以及 /Applications/Microsoft Office/*.app 这类嵌套应用
+async function collectAppBundles(dir: string, depth: number, out: string[]): Promise<void> {
+  let entries: fsSync.Dirent[]
+  try {
+    entries = await fs.readdir(dir, { withFileTypes: true })
+  } catch {
+    return
+  }
+
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue
+    const fullPath = path.join(dir, entry.name)
+
+    if (entry.name.endsWith('.app')) {
+      out.push(fullPath)
+      continue
+    }
+
+    if (depth > 0) {
+      await collectAppBundles(fullPath, depth - 1, out)
+    }
+  }
+}
+
 export async function scanApplications(): Promise<Command[]> {
   try {
     console.time('[Scanner] 扫描应用')
@@ -339,21 +367,16 @@ export async function scanApplications(): Promise<Command[]> {
       `${process.env.HOME}/Applications`
     ]
 
-    const allAppPaths: string[] = []
+    const collected: string[] = []
 
-    // 快速读取所有应用路径
+    // 读取所有应用路径（下钻一层以覆盖浏览器 PWA 等嵌套在子目录中的 .app）
     for (const searchPath of searchPaths) {
-      try {
-        const entries = await fs.readdir(searchPath, { withFileTypes: true })
-        const appDirs = entries
-          .filter((entry) => entry.isDirectory() && entry.name.endsWith('.app'))
-          .map((entry) => path.join(searchPath, entry.name))
-
-        allAppPaths.push(...appDirs)
-      } catch {
-        continue
-      }
+      await collectAppBundles(searchPath, 1, collected)
     }
+
+    // 不同搜索路径可能扫到同一 .app（如 /System/Applications/Utilities 既被显式列出
+    // 又会从 /System/Applications 下钻命中），按路径去重
+    const allAppPaths = [...new Set(collected)]
 
     console.log(`[Scanner] 找到 ${allAppPaths.length} 个应用`)
 

--- a/src/main/core/commandScanner/macScanner.ts
+++ b/src/main/core/commandScanner/macScanner.ts
@@ -4,6 +4,7 @@ import fs from 'fs/promises'
 import path from 'path'
 import plist from 'simple-plist'
 import { extractAcronym } from '../../utils/common'
+import { getMacApplicationPaths } from '../../utils/systemPaths'
 import { Command } from './types'
 import { pLimit } from './utils'
 
@@ -332,6 +333,8 @@ async function getAppDisplayInfo(appPath: string): Promise<LocalizedAppMetadata>
 // - 遇到普通目录且 depth > 0：下钻一层
 //   这样可覆盖浏览器 PWA（~/Applications/Chrome Apps.localized/*.app、
 //   Edge Apps.localized 等）以及 /Applications/Microsoft Office/*.app 这类嵌套应用
+// - 符号链接：readdir 不跟随，指向目录的链接 isDirectory() 为 false，需用 stat 解析真实类型，
+//   否则像 /Applications/Safari.app 这类被链接的应用会被漏扫
 async function collectAppBundles(dir: string, depth: number, out: string[]): Promise<void> {
   let entries: fsSync.Dirent[]
   try {
@@ -341,8 +344,18 @@ async function collectAppBundles(dir: string, depth: number, out: string[]): Pro
   }
 
   for (const entry of entries) {
-    if (!entry.isDirectory()) continue
     const fullPath = path.join(dir, entry.name)
+
+    // 解析真实类型：符号链接用 stat 跟随判断是否指向目录
+    let isDirectory = entry.isDirectory()
+    if (!isDirectory && entry.isSymbolicLink()) {
+      try {
+        isDirectory = (await fs.stat(fullPath)).isDirectory()
+      } catch {
+        continue // 断链 / 无权限，跳过
+      }
+    }
+    if (!isDirectory) continue
 
     if (entry.name.endsWith('.app')) {
       out.push(fullPath)
@@ -359,13 +372,9 @@ export async function scanApplications(): Promise<Command[]> {
   try {
     console.time('[Scanner] 扫描应用')
 
-    // 只扫描常用应用目录
-    const searchPaths = [
-      '/Applications',
-      '/System/Applications',
-      '/System/Applications/Utilities/',
-      `${process.env.HOME}/Applications`
-    ]
+    // 扫描常用应用目录（与 AppWatcher 监听路径共用同一数据源）
+    // Utilities 是 /System/Applications 的直接子目录，depth=1 已自动覆盖，无需显式列出
+    const searchPaths = getMacApplicationPaths()
 
     const collected: string[] = []
 


### PR DESCRIPTION
macOS 原扫描逻辑只读取搜索路径的顶层、仅挑选以 .app 结尾的目录，凡是被收纳进子目录的应用都扫不到，例如：
- 浏览器（Chrome/Edge 等）安装的 PWA（~/Applications/Chrome Apps.localized/）
- Python 安装目录下的 IDLE、Python Launcher（/Applications/Python 3.x/）
- Office 等厂商套件子目录中的各组件 这些都是真正的 .app bundle，可直接 open 启动，缺的只是扫描覆盖。
Windows 因开始菜单本就递归扫描，此类应用已可被发现，无需改动。

改动：
- macScanner: 新增 collectAppBundles 递归收集器，搜索路径改为下钻一层 （depth=1）。遇到 .app 即收集且不再深入（避免扫入 .app 内部的 helper 子应用），仅对非 .app 目录下钻，从而覆盖 PWA 容器及厂商/安装子目录中的 嵌套应用。结果按路径去重，消除 Utilities 等目录被父目录二次下钻产生的 重复。
- commands: APP_CACHE_VERSION 3 → 4，使老用户已缓存的应用列表失效并触发 重扫，新增应用才能在升级后出现。
- appWatcher: darwin 的 shouldIgnore 放行 watch 根目录下的顶层子目录 （如 PWA 容器、Python 安装目录），让 chokidar 下钻一层以检测其中 .app 的增删，实现运行时安装/卸载的即时刷新；仍不进入 .app 内部、不放行顶层 文件。