### PR TITLE
feat: 搜索栏发送给插件的按键事件添加 modifier 支持

### DIFF
--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -576,6 +576,7 @@ declare global {
       sendInputEvent: (event: {
         type: 'keyDown' | 'keyUp' | 'char' | 'mouseDown' | 'mouseUp' | 'mouseMove'
         keyCode?: string
+        modifiers?: Array<'shift' | 'ctrl' | 'alt' | 'meta'>
         x?: number
         y?: number
         button?: 'left' | 'right' | 'middle'

--- a/src/renderer/src/App.vue
+++ b/src/renderer/src/App.vue
@@ -43,6 +43,7 @@ import SearchBox from './components/search/SearchBox.vue'
 import SearchResults from './components/search/SearchResults.vue'
 import { useCommandDataStore } from './stores/commandDataStore'
 import { useWindowStore } from './stores/windowStore'
+import { CommonKeyboardModifier, readModifiers } from '@renderer/utils/convertKeyboardEvent'
 
 // FileItem 接口（从剪贴板管理器返回的格式）
 interface FileItem {
@@ -216,10 +217,12 @@ function handlePluginStepExit(): void {
 // 将浏览器 KeyboardEvent 转换为 Electron KeyboardInputEvent 格式
 function convertToElectronKeyboardEvent(
   direction: 'left' | 'right' | 'up' | 'down' | 'enter',
-  type: 'keyDown' | 'keyUp' = 'keyDown'
+  type: 'keyDown' | 'keyUp' = 'keyDown',
+  modifiers: CommonKeyboardModifier[] = []
 ): {
   type: 'keyDown' | 'keyUp'
   keyCode: string
+  modifiers: CommonKeyboardModifier[]
 } {
   // 映射方向键和回车键的 keyCode
   const keyCodeMap: Record<string, string> = {
@@ -232,7 +235,8 @@ function convertToElectronKeyboardEvent(
 
   return {
     type,
-    keyCode: keyCodeMap[direction]
+    keyCode: keyCodeMap[direction],
+    modifiers
   }
 }
 
@@ -252,9 +256,11 @@ async function handleArrowKeydown(
     event.stopPropagation()
   }
 
+  const modifiers = readModifiers(event)
+
   // 转换为 Electron 格式
-  const keyDownEvent = convertToElectronKeyboardEvent(direction, 'keyDown')
-  const keyUpEvent = convertToElectronKeyboardEvent(direction, 'keyUp')
+  const keyDownEvent = convertToElectronKeyboardEvent(direction, 'keyDown', modifiers)
+  const keyUpEvent = convertToElectronKeyboardEvent(direction, 'keyUp', modifiers)
 
   // 发送给主进程：先发送 keyDown，再发送 keyUp
   try {

--- a/src/renderer/src/components/detached/DetachedTitlebar.vue
+++ b/src/renderer/src/components/detached/DetachedTitlebar.vue
@@ -125,6 +125,7 @@
 import { onMounted, ref } from 'vue'
 import { normalizeConfigList } from '@shared/pluginSettings'
 import AdaptiveIcon from '../common/AdaptiveIcon.vue'
+import { CommonKeyboardModifier, readModifiers } from '@renderer/utils/convertKeyboardEvent'
 
 const platform = ref<'darwin' | 'win32'>('darwin')
 const pluginName = ref('Plugin')
@@ -502,9 +503,10 @@ function handleKeydown(event: KeyboardEvent): void {
   }
 
   // 回车键传递给插件
+  const modifiers = readModifiers(event)
   if (event.key === 'Enter') {
     event.preventDefault()
-    sendKeyToPlugin('Enter')
+    sendKeyToPlugin('Enter', modifiers)
     return
   }
 
@@ -512,16 +514,16 @@ function handleKeydown(event: KeyboardEvent): void {
   if (event.key === 'ArrowUp' || event.key === 'ArrowDown') {
     // 上下方向键阻止默认行为并发送给插件
     event.preventDefault()
-    sendArrowKeyToPlugin(event.key)
+    sendArrowKeyToPlugin(event.key, modifiers)
   } else if (event.key === 'ArrowLeft' || event.key === 'ArrowRight') {
     // 左右方向键允许在输入框中移动光标，不阻止默认行为
     // 但仍然发送给插件（某些插件可能需要）
-    sendArrowKeyToPlugin(event.key)
+    sendArrowKeyToPlugin(event.key, modifiers)
   }
 }
 
 // 发送方向键到插件
-function sendArrowKeyToPlugin(key: string): void {
+function sendArrowKeyToPlugin(key: string, modifiers: CommonKeyboardModifier[] = []): void {
   const keyCodeMap: Record<string, string> = {
     ArrowLeft: 'Left',
     ArrowRight: 'Right',
@@ -534,30 +536,34 @@ function sendArrowKeyToPlugin(key: string): void {
     // 发送 keyDown 事件
     window.electron.ipcRenderer.send('send-arrow-key', {
       type: 'keyDown',
-      keyCode
+      keyCode,
+      modifiers
     })
     // 短暂延迟后发送 keyUp 事件
     setTimeout(() => {
       window.electron.ipcRenderer.send('send-arrow-key', {
         type: 'keyUp',
-        keyCode
+        keyCode,
+        modifiers
       })
     }, 10)
   }
 }
 
 // 发送按键到插件（用于回车键等）
-function sendKeyToPlugin(key: string): void {
+function sendKeyToPlugin(key: string, modifiers: CommonKeyboardModifier[] = []): void {
   // 发送 keyDown 事件
   window.electron.ipcRenderer.send('send-arrow-key', {
     type: 'keyDown',
-    keyCode: key
+    keyCode: key,
+    modifiers
   })
   // 短暂延迟后发送 keyUp 事件
   setTimeout(() => {
     window.electron.ipcRenderer.send('send-arrow-key', {
       type: 'keyUp',
-      keyCode: key
+      keyCode: key,
+      modifiers
     })
   }, 10)
 }

--- a/src/renderer/src/env.d.ts
+++ b/src/renderer/src/env.d.ts
@@ -1,5 +1,7 @@
 // Ambient type declarations for renderer, so TS knows window.ztools
 
+import type { CommonKeyboardModifier } from '@renderer/utils/convertKeyboardEvent'
+
 /**
  * 上次匹配状态接口
  */
@@ -156,6 +158,7 @@ declare global {
       sendInputEvent: (event: {
         type: 'keyDown' | 'keyUp' | 'char' | 'mouseDown' | 'mouseUp' | 'mouseMove'
         keyCode?: string
+        modifiers?: CommonKeyboardModifier[]
         x?: number
         y?: number
         button?: 'left' | 'right' | 'middle'

--- a/src/renderer/src/utils/convertKeyboardEvent.ts
+++ b/src/renderer/src/utils/convertKeyboardEvent.ts
@@ -1,0 +1,25 @@
+// 当前按下的修饰键
+export type CommonKeyboardModifier = 'shift' | 'ctrl' | 'alt' | 'meta'
+
+// 将 KeyboardEvent 中的修饰键转换成 Electron.KeyboardEvent 键盘事件中的修饰键
+export function readModifiers(event: KeyboardEvent): CommonKeyboardModifier[] {
+  const modifiers: CommonKeyboardModifier[] = []
+
+  if (event.shiftKey) {
+    modifiers.push('shift')
+  }
+
+  if (event.ctrlKey) {
+    modifiers.push('ctrl')
+  }
+
+  if (event.altKey) {
+    modifiers.push('alt')
+  }
+
+  if (event.metaKey) {
+    modifiers.push('meta')
+  }
+
+  return modifiers
+}


### PR DESCRIPTION
# 变更内容
由搜索框透传给插件的按键事件，添加 Modifier 信息。

# 动机
当前可以在输入框聚焦的情况下，透传方向键和回车键事件给插件。但是目前传递的键盘事件里面没有包含修饰键信息，使得用途比较局限。添加修饰键后，插件可以根据修饰键不同绑定不同的功能，增加灵活性。
