### PR TITLE
fix: 修复固定列表项鼠标悬停显示移动光标的问题

### DIFF
--- a/src/renderer/src/components/common/CommandList.vue
+++ b/src/renderer/src/components/common/CommandList.vue
@@ -16,7 +16,6 @@
           :ref="(el) => setItemRef(el, index)"
           class="app-item"
           :class="{ selected: index === selectedIndex }"
-          style="cursor: pointer"
           :title="getTitleText(app)"
           @click="$emit('select', app)"
           @contextmenu.prevent="$emit('contextmenu', app)"

--- a/src/renderer/src/components/common/CommandList.vue
+++ b/src/renderer/src/components/common/CommandList.vue
@@ -16,7 +16,7 @@
           :ref="(el) => setItemRef(el, index)"
           class="app-item"
           :class="{ selected: index === selectedIndex }"
-          style="cursor: move"
+          style="cursor: pointer"
           :title="getTitleText(app)"
           @click="$emit('select', app)"
           @contextmenu.prevent="$emit('contextmenu', app)"


### PR DESCRIPTION
## 问题

Windows 上唤起输入框后，鼠标悬停在已固定的指令图标上时，显示的是四向移动光标（move）而非点击手指样式（pointer）。

## 原因

`CommandList.vue` 中可拖拽列表项模板硬编码了 `style="cursor: move"`，导致所有固定项始终显示移动光标。

## 修复

将 `cursor: move` 改为 `cursor: pointer`。vuedraggable 在拖动时会自行处理光标样式，不影响拖拽功能。