### PR TITLE
[fix]修复Windows平台指令⌈在终端打开⌋降级方案Powershell和Cmd因缺少控制台句柄而异常终止

### DIFF
--- a/src/main/core/native/index.ts
+++ b/src/main/core/native/index.ts
@@ -127,6 +127,7 @@ interface NativeAddon {
     | { type: 'file'; data: string[] }
     | { type: 'image'; data: string }
   >
+  launchCuiShell: (shell: string, workingDirectory: string) => boolean
 }
 
 interface WindowInfo {
@@ -1088,6 +1089,31 @@ export class ColorPicker {
    */
   static get isActive(): boolean {
     return ColorPicker._isActive
+  }
+}
+
+export class CuiProcess {
+  static async launchPowerShell(workingDirectory: string): Promise<boolean> {
+    if (platform !== 'win32' || !addon || typeof addon.launchCuiShell !== 'function') {
+      return false
+    }
+    try {
+      return addon.launchCuiShell('powershell', workingDirectory)
+    } catch (err) {
+      console.error('[CuiProcess] Failed to launch PowerShell:', err)
+      return false
+    }
+  }
+  static async launchCmd(workingDirectory: string): Promise<boolean> {
+    if (platform !== 'win32' || !addon || typeof addon.launchCuiShell !== 'function') {
+      return false
+    }
+    try {
+      return addon.launchCuiShell('cmd', workingDirectory)
+    } catch (err) {
+      console.error('[CuiProcess] Failed to launch Cmd:', err)
+      return false
+    }
   }
 }
 

--- a/src/main/core/native/index.ts
+++ b/src/main/core/native/index.ts
@@ -127,6 +127,7 @@ interface NativeAddon {
     | { type: 'file'; data: string[] }
     | { type: 'image'; data: string }
   >
+  launchCuiShell: (shell: string, workingDirectory: string) => boolean
 }
 
 interface WindowInfo {
@@ -1088,6 +1089,15 @@ export class ColorPicker {
    */
   static get isActive(): boolean {
     return ColorPicker._isActive
+  }
+}
+
+export class CuiProcess {
+  static launchPowerShell(workingDirectory: string): Promise<boolean> {
+    return Promise.resolve((addon as NativeAddon).launchCuiShell('powershell', workingDirectory))
+  }
+  static launchCmd(workingDirectory: string): Promise<boolean> {
+    return Promise.resolve((addon as NativeAddon).launchCuiShell('cmd', workingDirectory))
   }
 }
 

--- a/src/main/utils/terminalLauncher.ts
+++ b/src/main/utils/terminalLauncher.ts
@@ -1,6 +1,7 @@
 import { spawn, execFile } from 'child_process'
 import { promisify } from 'util'
 import databaseAPI from '../api/shared/database'
+import { CuiProcess } from '../core/native'
 
 const execFileAsync = promisify(execFile)
 
@@ -105,12 +106,8 @@ async function launchDefaultLinux(path: string): Promise<boolean> {
 async function launchDefaultWindows(path: string): Promise<boolean> {
   return (
     (await runCli('wt.exe', ['-d', path])) ||
-    (await runCli('powershell.exe', [
-      '-NoExit',
-      '-Command',
-      `Set-Location -Path ${escapePowerShellPath(path)}`
-    ])) ||
-    (await runCli('cmd.exe', ['/K', `cd /d ${escapeCmdPath(path)}`]))
+    (await CuiProcess.launchPowerShell(path)) ||
+    (await CuiProcess.launchCmd(path))
   )
 }
 
@@ -193,12 +190,7 @@ const WINDOWS_PRESETS: PresetEntry[] = [
     label: 'PowerShell',
     preset: {
       type: 'handler',
-      run: (p) =>
-        runCli('powershell.exe', [
-          '-NoExit',
-          '-Command',
-          `Set-Location -Path ${escapePowerShellPath(p)}`
-        ])
+      run: (p) => CuiProcess.launchPowerShell(p)
     }
   },
   {
@@ -206,7 +198,7 @@ const WINDOWS_PRESETS: PresetEntry[] = [
     label: 'CMD',
     preset: {
       type: 'handler',
-      run: (p) => runCli('cmd.exe', ['/K', `cd /d ${escapeCmdPath(p)}`])
+      run: (p) => CuiProcess.launchCmd(p)
     }
   }
 ]


### PR DESCRIPTION
 感谢 #561 提供的Bug。

目前指令⌈在终端打开⌋，在Windows平台下优先使用Window terminal，并提供了PowerShell和Cmd作为降级方案，但是PowerShell和Cmd的启动方式原先是由nodejs的`child_process.spawn`函数实现，但是spawn函数在windows平台下不会为子进程分配新的控制台，导致控制台程序(PowerShell和Cmd)无法获取控制台句柄而出现异常现象。window terminal作为GUI程序，能够被spawn函数正常启动。

异常现象表现为无法显示控制台窗口，但是控制台程序依然在后台运行

指令⌈在终端打开⌋已由 #569  进行扩充，扩充后依然存在此Bug。

因此，windows平台下PowerShell和Cmd的启动方式更换为原生实现。审查此PR请一并审查ztools-native-api项目中的`#12`PR