### PR TITLE
fix:修复 mac 版本中，剪切板没有去重的 bug

### DIFF
--- a/src/main/managers/clipboardManager.ts
+++ b/src/main/managers/clipboardManager.ts
@@ -108,6 +108,9 @@ class ClipboardManager {
   private lastCopiedSequence = 0
   private lastCopiedSequenceWaiters = new Map<number, Set<(content: LastCopiedContent) => void>>()
 
+  // 上一次保存到历史的 hash，用于连续重复内容去重
+  private lastSavedHash: string | null = null
+
   // 临时取消剪贴板监听的计时器（防止 paste API 写入剪贴板时自我触发）
   private cancelWatchTimeout: ReturnType<typeof setTimeout> | null = null
 
@@ -250,7 +253,15 @@ class ClipboardManager {
       }
 
       if (item) {
+        // 连续复制相同内容时跳过记录（保留顺序去重）
+        if (item.hash && item.hash === this.lastSavedHash) {
+          console.log('[Clipboard] 连续重复内容，跳过保存:', item.preview)
+          return
+        }
         await this.saveItem(item as ClipboardItem)
+        if (item.hash) {
+          this.lastSavedHash = item.hash
+        }
         // 通知插件剪贴板变化
         pluginManager?.sendPluginMessage('clipboard-change', item)
       }


### PR DESCRIPTION
## 修复剪贴板连续复制相同内容时会重复记录的bug

### 问题描述

当用户连续复制相同内容时，剪贴板会重复记录相同条目。例如依次复制 2 次 `TEXT_a`、3 次 `TEXT_b`、3 次 `TEXT_a` 时，历史记录中会出现 8 条记录，而预期应只保留 3 条（`TEXT_a` → `TEXT_b` → `TEXT_a`）。

### 解决方案

在保存到剪切板前，比较当前内容 hash 与上一次已保存内容的 hash，若相同则跳过记录。

### 改动内容

**文件**: `src/main/managers/clipboardManager.ts`

1. 新增 `lastSavedHash` 属性，记录上一次保存到剪贴板历史的内容 hash
2. 在 `handleClipboardChange` 方法中，保存前检查当前内容 hash 是否与 `lastSavedHash` 相同，相同则跳过保存
3. 保存成功后更新 `lastSavedHash`

### 说明

- 对文本、图片、文件三种剪贴板类型均生效（均通过 `hash` 字段比对）
- 插件通知（`clipboard-change` 事件）在跳过保存时也会跳过，避免插件收到重复事件