### PR TITLE
fix(launcher): 本地启动时以程序所在目录为工作目录 (#603)

### DIFF
--- a/src/main/core/commandLauncher/windowsLauncher.ts
+++ b/src/main/core/commandLauncher/windowsLauncher.ts
@@ -165,7 +165,11 @@ export async function launchApp(
 
   // 检查是否是协议链接（如 ms-settings:, steam://, battlenet:// 等）
   // 协议链接失败时必须回退 openExternal，openPath 可能卡住。
-  if (/^[a-zA-Z][a-zA-Z0-9+\-.]*:/.test(appPath) && !path.win32.isAbsolute(appPath)) {
+  if (
+    /^[a-zA-Z][a-zA-Z0-9+\-.]*:/.test(appPath) &&
+    !appPath.includes('\\') &&
+    !path.win32.isAbsolute(appPath)
+  ) {
     try {
       await openApplicationViaExplorer(appPath, 'openExternal')
       return

--- a/src/main/core/commandLauncher/windowsLauncher.ts
+++ b/src/main/core/commandLauncher/windowsLauncher.ts
@@ -165,7 +165,7 @@ export async function launchApp(
 
   // 检查是否是协议链接（如 ms-settings:, steam://, battlenet:// 等）
   // 协议链接失败时必须回退 openExternal，openPath 可能卡住。
-  if (/^[a-zA-Z][a-zA-Z0-9+\-.]*:/.test(appPath) && !appPath.includes('\\')) {
+  if (/^[a-zA-Z][a-zA-Z0-9+\-.]*:/.test(appPath) && !path.win32.isAbsolute(appPath)) {
     try {
       await openApplicationViaExplorer(appPath, 'openExternal')
       return
@@ -238,7 +238,7 @@ export async function launchApp(
   }
 
   // 系统可执行文件（不包含路径分隔符，说明在 PATH 中）
-  if (ext === 'exe' && !appPath.includes('\\')) {
+  if (ext === 'exe' && !appPath.includes('\\') && !appPath.includes('/')) {
     // 对于 PATH 中的可执行文件，使用 shell.openPath（Electron 会自动在 PATH 中查找）
     // 这是最可靠的方式，避免路径解析问题
     const error = await shell.openPath(appPath)

--- a/src/main/core/commandLauncher/windowsLauncher.ts
+++ b/src/main/core/commandLauncher/windowsLauncher.ts
@@ -1,4 +1,5 @@
 import { spawn } from 'child_process'
+import path from 'path'
 import { dialog, shell } from 'electron'
 import { UwpManager, WindowsShellLauncher } from '../native'
 import type { ConfirmDialogOptions } from './types'
@@ -31,14 +32,42 @@ async function openWithElectronShell(
   throw new Error(`启动失败: ${error}`)
 }
 
+/**
+ * 计算可执行文件的工作目录（"启动目录"）。
+ *
+ * ShellExecuteEx 若未显式提供 lpDirectory，则子进程会继承 ZTools 主进程的
+ * 当前工作目录。当 ZTools 以开机自启/提权方式启动时，其工作目录通常是
+ * C:\WINDOWS\system32，导致被启动的程序把相对路径（如 Save 数据目录）
+ * 解析到 system32 下而报权限错误（见 issue #603）。
+ *
+ * 为对齐用户在资源管理器中直接双击 exe 的行为，这里返回 exe 所在目录，
+ * 作为其启动工作目录。仅对带有目录分隔符的 .exe 生效；.lnk 由快捷方式
+ * 自身的“起始位置”决定，故不覆盖。
+ */
+export function resolveLaunchWorkingDirectory(appPath: string): string | undefined {
+  if (!appPath.toLowerCase().endsWith('.exe')) {
+    return undefined
+  }
+  if (!appPath.includes('\\') && !appPath.includes('/')) {
+    return undefined
+  }
+  const dir = path.win32.dirname(appPath)
+  if (!dir || dir === '.' || dir === appPath) {
+    return undefined
+  }
+  return dir
+}
+
 async function openApplicationViaExplorer(
   appPath: string,
-  fallback: ElectronShellFallback
+  fallback: ElectronShellFallback,
+  workingDirectory?: string
 ): Promise<void> {
   try {
     const result = await WindowsShellLauncher.launch({
       target: appPath,
-      showCommand: 1
+      showCommand: 1,
+      ...(workingDirectory ? { workingDirectory } : {})
     })
     if (result.success) {
       console.log(`[Launcher] 已通过 Explorer 启动: ${appPath}`)
@@ -221,7 +250,7 @@ export async function launchApp(
   }
 
   if (appPath.toLowerCase().endsWith('.exe') || appPath.toLowerCase().endsWith('.lnk')) {
-    await openApplicationViaExplorer(appPath, 'openPath')
+    await openApplicationViaExplorer(appPath, 'openPath', resolveLaunchWorkingDirectory(appPath))
     return
   }
 

--- a/tests/main/windowsLauncherWorkingDirectory.test.ts
+++ b/tests/main/windowsLauncherWorkingDirectory.test.ts
@@ -71,6 +71,15 @@ describe('launchApp 传递工作目录 (#603)', () => {
     expect(opts.workingDirectory).toBe('C:\\Program Files\\MyApp')
   })
 
+  it('启动使用正斜杠的完整路径 exe 时，向原生启动器传入 exe 所在目录作为 workingDirectory', async () => {
+    await launchApp('C:/Program Files/MyApp/app.exe')
+
+    expect(mockLaunch).toHaveBeenCalledTimes(1)
+    const opts = mockLaunch.mock.calls[0][0]
+    expect(opts.target).toBe('C:/Program Files/MyApp/app.exe')
+    expect(opts.workingDirectory).toBe('C:/Program Files/MyApp')
+  })
+
   it('启动 .lnk 时不覆盖 workingDirectory（保持 undefined）', async () => {
     await launchApp('C:\\Users\\Me\\Desktop\\App.lnk')
 

--- a/tests/main/windowsLauncherWorkingDirectory.test.ts
+++ b/tests/main/windowsLauncherWorkingDirectory.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+// 回归测试：ZToolsCenter/ZTools#603
+// 通过 ZTools 本地启动的程序应以其所在目录作为工作目录（对齐资源管理器双击行为），
+// 否则子进程会继承 ZTools 主进程的 CWD（开机自启/提权时通常为 system32），
+// 导致程序把相对路径解析到 C:\WINDOWS\system32 下而报权限错误。
+
+const { mockLaunch, mockUwpLaunch, mockOpenPath, mockOpenExternal } = vi.hoisted(() => ({
+  mockLaunch: vi.fn(async () => ({ success: true, hresult: 0, stage: 'launched' })),
+  mockUwpLaunch: vi.fn(() => true),
+  mockOpenPath: vi.fn(async () => ''),
+  mockOpenExternal: vi.fn(async () => undefined)
+}))
+
+vi.mock('child_process', () => ({ spawn: vi.fn(() => ({ on: vi.fn(), unref: vi.fn() })) }))
+vi.mock('electron', () => ({
+  dialog: { showMessageBox: vi.fn() },
+  shell: { openPath: mockOpenPath, openExternal: mockOpenExternal }
+}))
+vi.mock('../../src/main/core/native', () => ({
+  UwpManager: { launchUwpApp: mockUwpLaunch },
+  WindowsShellLauncher: { launch: mockLaunch }
+}))
+
+import {
+  launchApp,
+  resolveLaunchWorkingDirectory
+} from '../../src/main/core/commandLauncher/windowsLauncher'
+
+describe('resolveLaunchWorkingDirectory', () => {
+  it('返回带路径 .exe 的所在目录（Windows 语义）', () => {
+    expect(resolveLaunchWorkingDirectory('C:\\Program Files\\MyApp\\app.exe')).toBe(
+      'C:\\Program Files\\MyApp'
+    )
+  })
+
+  it('保留含空格/中文的目录', () => {
+    expect(resolveLaunchWorkingDirectory('D:\\软件 目录\\子目录\\tool.exe')).toBe(
+      'D:\\软件 目录\\子目录'
+    )
+  })
+
+  it('对 PATH 中的裸 exe（无分隔符）返回 undefined', () => {
+    expect(resolveLaunchWorkingDirectory('notepad.exe')).toBeUndefined()
+  })
+
+  it('对 .lnk 返回 undefined（由快捷方式自身的起始目录决定）', () => {
+    expect(resolveLaunchWorkingDirectory('C:\\Users\\Me\\Desktop\\App.lnk')).toBeUndefined()
+  })
+
+  it('对非 exe 目标返回 undefined', () => {
+    expect(resolveLaunchWorkingDirectory('C:\\docs\\readme.txt')).toBeUndefined()
+  })
+})
+
+describe('launchApp 传递工作目录 (#603)', () => {
+  beforeEach(() => {
+    mockLaunch.mockClear()
+    mockOpenPath.mockClear()
+  })
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('启动带完整路径的 exe 时，向原生启动器传入 exe 所在目录作为 workingDirectory', async () => {
+    await launchApp('C:\\Program Files\\MyApp\\app.exe')
+
+    expect(mockLaunch).toHaveBeenCalledTimes(1)
+    const opts = mockLaunch.mock.calls[0][0]
+    expect(opts.target).toBe('C:\\Program Files\\MyApp\\app.exe')
+    expect(opts.workingDirectory).toBe('C:\\Program Files\\MyApp')
+  })
+
+  it('启动 .lnk 时不覆盖 workingDirectory（保持 undefined）', async () => {
+    await launchApp('C:\\Users\\Me\\Desktop\\App.lnk')
+
+    expect(mockLaunch).toHaveBeenCalledTimes(1)
+    const opts = mockLaunch.mock.calls[0][0]
+    expect(opts.workingDirectory).toBeUndefined()
+  })
+
+  it('PATH 中的裸 exe 走 shell.openPath，不进入原生启动器', async () => {
+    await launchApp('calc.exe')
+
+    expect(mockLaunch).not.toHaveBeenCalled()
+    expect(mockOpenPath).toHaveBeenCalledWith('calc.exe')
+  })
+})


### PR DESCRIPTION
## 变更内容

Windows 平台通过原生 `WindowsShellLauncher`（ShellExecuteEx）启动本地程序时，未向 `openApplicationViaExplorer` 传入工作目录（`lpDirectory`）。子进程会因此继承 ZTools 主进程的当前工作目录（CWD）。

本 PR 在启动**带完整路径的 `.exe`** 时，显式将其所在目录作为 `workingDirectory` 传给原生启动器，对齐用户在资源管理器中直接双击 exe 的行为：

- 新增 `resolveLaunchWorkingDirectory()`：仅对含目录分隔符的 `.exe` 返回其所在目录（使用 `path.win32.dirname`）。
- `.lnk` 仍由快捷方式自身的“起始位置”决定，故不覆盖。
- PATH 中的裸 exe（无分隔符）仍走 `shell.openPath`，不受影响。

## 动机

Closes #603。

当 ZTools 3.x 以开机自启/提权方式启动时，其 CWD 通常是 `C:\WINDOWS\system32`。通过 ZTools「本地启动」拉起的程序若使用相对路径读写数据（如 `Save` 目录），会被解析到 `C:\WINDOWS\system32\Save`，出现：

```
Access to the path 'C:\WINDOWS\system32\Save' is denied.
```

该程序直接双击或用 ZTools 2.x 启动均正常——因为双击时资源管理器会把工作目录设为 exe 所在目录。本 PR 恢复了这一行为。

## 测试

新增 `tests/main/windowsLauncherWorkingDirectory.test.ts`：

- `resolveLaunchWorkingDirectory` 对带路径 exe / 含空格中文目录 / 裸 exe / `.lnk` / 非 exe 的行为断言。
- `launchApp` 端到端断言：完整路径 exe 会以其所在目录作为 `workingDirectory` 调用原生启动器；`.lnk` 不覆盖；裸 exe 走 `shell.openPath`。

```
pnpm vitest run tests/main/windowsLauncherWorkingDirectory.test.ts   # 8 passed
pnpm typecheck:node                                                  # clean
pnpm exec eslint <changed files>                                     # clean
pnpm exec prettier --check <changed files>                           # clean
```

回归验证：移除修复后，端到端断言 `workingDirectory` 为 `undefined`（红），加入修复后转绿。
