### PR TITLE
feat: 本地启动项支持设置别名/快捷键

### DIFF
--- a/internal-plugins/setting/src/views/AllCommandsSetting/AllCommandsSetting.vue
+++ b/internal-plugins/setting/src/views/AllCommandsSetting/AllCommandsSetting.vue
@@ -19,6 +19,8 @@ import {
 import {
   DIRECT_APP_ALIAS_GROUP_KEY,
   DIRECT_APP_ALIAS_GROUP_TITLE,
+  LOCAL_SHORTCUT_ALIAS_GROUP_KEY,
+  LOCAL_SHORTCUT_ALIAS_GROUP_TITLE,
   getCommandId as _getCommandId,
   getLegacyDirectAppCommandId
 } from '@shared/commandShared'
@@ -107,21 +109,27 @@ function getCommandId(
 }
 
 function isDirectAppCommand(cmd: Command): boolean {
-  return cmd.type === 'direct' && cmd.subType === 'app'
+  return cmd.type === 'direct' && (cmd.subType === 'app' || cmd.subType === 'local-shortcut')
 }
 
 function buildAppAliasDraftTarget(cmd: Command): ShortcutsSettingAliasDraftTarget {
+  const isLocalShortcut = cmd.subType === 'local-shortcut'
+  const groupKey = isLocalShortcut ? LOCAL_SHORTCUT_ALIAS_GROUP_KEY : DIRECT_APP_ALIAS_GROUP_KEY
+  const groupTitle = isLocalShortcut
+    ? LOCAL_SHORTCUT_ALIAS_GROUP_TITLE
+    : DIRECT_APP_ALIAS_GROUP_TITLE
+
   return {
     commandId: getCommandId(cmd),
     type: 'direct',
-    subType: 'app',
+    subType: cmd.subType as 'app' | 'local-shortcut',
     path: cmd.path,
-    groupKey: DIRECT_APP_ALIAS_GROUP_KEY,
-    groupTitle: DIRECT_APP_ALIAS_GROUP_TITLE,
+    groupKey,
+    groupTitle,
     featureCode: cmd.path || '',
     subtitle: cmd.path || '',
-    pluginName: DIRECT_APP_ALIAS_GROUP_KEY,
-    pluginTitle: DIRECT_APP_ALIAS_GROUP_TITLE,
+    pluginName: groupKey,
+    pluginTitle: groupTitle,
     cmdName: cmd.name,
     cmdType: 'text',
     icon: cmd.icon

--- a/internal-plugins/setting/src/views/ShortcutsSetting/ShortcutsSetting.vue
+++ b/internal-plugins/setting/src/views/ShortcutsSetting/ShortcutsSetting.vue
@@ -17,6 +17,8 @@ import {
   COMMAND_ALIASES_KEY,
   DIRECT_APP_ALIAS_GROUP_KEY,
   DIRECT_APP_ALIAS_GROUP_TITLE,
+  LOCAL_SHORTCUT_ALIAS_GROUP_KEY,
+  LOCAL_SHORTCUT_ALIAS_GROUP_TITLE,
   getCommandId as _getCommandId,
   normalizeCommandAliases
 } from '@shared/commandShared'
@@ -464,9 +466,50 @@ async function loadAliasTargets(): Promise<void> {
       })
     }
 
+    const addLocalShortcutTarget = (command: any): void => {
+      if (
+        command.type !== 'direct' ||
+        command.subType !== 'local-shortcut' ||
+        !command.path ||
+        !command.name
+      ) {
+        return
+      }
+
+      const commandId = getCommandId({
+        type: 'direct',
+        subType: 'local-shortcut',
+        path: command.path,
+        name: command.name,
+        cmdType: 'text'
+      })
+
+      addTarget({
+        commandId,
+        type: 'direct',
+        subType: 'local-shortcut',
+        path: command.path,
+        groupKey: LOCAL_SHORTCUT_ALIAS_GROUP_KEY,
+        groupTitle: LOCAL_SHORTCUT_ALIAS_GROUP_TITLE,
+        featureCode: command.path,
+        subtitle: command.path,
+        pluginName: LOCAL_SHORTCUT_ALIAS_GROUP_KEY,
+        pluginTitle: LOCAL_SHORTCUT_ALIAS_GROUP_TITLE,
+        cmdName: command.name,
+        cmdType: 'text',
+        icon: command.icon,
+        label: `${LOCAL_SHORTCUT_ALIAS_GROUP_TITLE} / ${command.name}`
+      })
+    }
+
     for (const command of result.commands || []) {
       if (command.type === 'direct' && command.subType === 'app') {
         addDirectAppTarget(command)
+        continue
+      }
+
+      if (command.type === 'direct' && command.subType === 'local-shortcut') {
+        addLocalShortcutTarget(command)
         continue
       }
 
@@ -1008,6 +1051,27 @@ onMounted(() => {
   isWindows.value = platform.includes('win') || userAgent.includes('windows')
 
   void loadShortcuts()
+
+  // 监听本地启动项变化，实时更新可选目标列表
+  if (window.ztools.internal.onLocalShortcutsChanged) {
+    window.ztools.internal.onLocalShortcutsChanged(() => {
+      void loadAliasTargets()
+    })
+  }
+
+  // 监听系统应用变化，实时更新可选目标列表
+  if (window.ztools.internal.onAppsChanged) {
+    window.ztools.internal.onAppsChanged(() => {
+      void loadAliasTargets()
+    })
+  }
+
+  // 监听指令别名变化，实时更新别名列表
+  if (window.ztools.internal.onCommandAliasesChanged) {
+    window.ztools.internal.onCommandAliasesChanged(() => {
+      void loadAliasMappings()
+    })
+  }
 })
 
 useJumpFunction<ShortcutsSettingJumpFunction>(async (state) => {

--- a/resources/preload.js
+++ b/resources/preload.js
@@ -1199,6 +1199,27 @@ window.ztools = {
       electron.ipcRenderer.on('sync:account-storage-changed', handler)
       return () => electron.ipcRenderer.removeListener('sync:account-storage-changed', handler)
     },
+    onLocalShortcutsChanged: (callback) => {
+      const handler = (_event) => {
+        if (typeof callback === 'function') callback()
+      }
+      electron.ipcRenderer.on('local-shortcuts-changed', handler)
+      return () => electron.ipcRenderer.removeListener('local-shortcuts-changed', handler)
+    },
+    onAppsChanged: (callback) => {
+      const handler = (_event) => {
+        if (typeof callback === 'function') callback()
+      }
+      electron.ipcRenderer.on('apps-changed', handler)
+      return () => electron.ipcRenderer.removeListener('apps-changed', handler)
+    },
+    onCommandAliasesChanged: (callback) => {
+      const handler = (_event) => {
+        if (typeof callback === 'function') callback()
+      }
+      electron.ipcRenderer.on('command-aliases-changed', handler)
+      return () => electron.ipcRenderer.removeListener('command-aliases-changed', handler)
+    },
 
     // ==================== 其他 API ====================
     revealInFinder: async (path) =>

--- a/src/main/api/index.ts
+++ b/src/main/api/index.ts
@@ -116,6 +116,7 @@ class APIManager {
     systemSettingsAPI.init()
     syncAPI.init(mainWindow, pluginManager)
     localShortcutsAPI.init(mainWindow)
+    localShortcutsAPI.setCommandsCacheInvalidator(() => appsAPI.invalidateCommandsCache(false))
 
     // 初始化插件 API 统一分发器（必须在插件 API 初始化之前）
     initPluginApiDispatcher()

--- a/src/main/api/plugin/internal.ts
+++ b/src/main/api/plugin/internal.ts
@@ -125,7 +125,9 @@ export class InternalPluginAPI {
       }
 
       // 设置页使用这份 canonical commands 构建 alias 目标列表，不在这里展开 alias 搜索字段。
-      console.log('[Internal] 收到获取指令列表请求（设置页 alias 目标）')
+      // 强制刷新缓存，确保获取最新的指令列表（包括本地启动项）
+      console.log('[Internal] 收到获取指令列表请求（设置页 alias 目标），强制刷新缓存')
+      commandsAPI.invalidateCommandsCache(false)
       const result = await commandsAPI.getCommands()
       console.log('[Internal] 返回指令列表摘要:', {
         commands: result.commands?.length || 0,

--- a/src/main/api/renderer/localShortcuts.ts
+++ b/src/main/api/renderer/localShortcuts.ts
@@ -29,10 +29,30 @@ const LOCAL_SHORTCUTS_KEY = 'local-shortcuts'
  */
 export class LocalShortcutsAPI {
   private mainWindow: Electron.BrowserWindow | null = null
+  private commandsCacheInvalidator: (() => void) | null = null
 
   public init(mainWindow: Electron.BrowserWindow): void {
     this.mainWindow = mainWindow
     this.setupIPC()
+  }
+
+  /**
+   * 设置本地启动项变化时使用的命令缓存失效回调。
+   * @param invalidator 命令缓存失效函数
+   * @returns 无返回值
+   */
+  public setCommandsCacheInvalidator(invalidator: () => void): void {
+    this.commandsCacheInvalidator = invalidator
+  }
+
+  /**
+   * 通知渲染进程本地启动项已变化，并使指令缓存失效。
+   * 使指令缓存失效后，快捷键设置页重新获取 getCommands 时才能拿到最新的本地启动项。
+   * @returns 无返回值
+   */
+  private notifyShortcutsChanged(): void {
+    this.mainWindow?.webContents.send('local-shortcuts-changed')
+    this.commandsCacheInvalidator?.()
   }
 
   private setupIPC(): void {
@@ -190,7 +210,7 @@ export class LocalShortcutsAPI {
       console.log('[LocalShortcut] 添加本地启动项成功:', shortcut.name)
 
       // 通知渲染进程刷新本地启动项
-      this.mainWindow?.webContents.send('local-shortcuts-changed')
+      this.notifyShortcutsChanged()
 
       return { success: true }
     } catch (error) {
@@ -295,7 +315,7 @@ export class LocalShortcutsAPI {
       console.log('[LocalShortcut] 添加本地启动项成功:', shortcut.name)
 
       // 通知渲染进程刷新本地启动项
-      this.mainWindow?.webContents.send('local-shortcuts-changed')
+      this.notifyShortcutsChanged()
 
       return { success: true }
     } catch (error) {
@@ -321,7 +341,7 @@ export class LocalShortcutsAPI {
       console.log('[LocalShortcut] 删除本地启动项成功:', id)
 
       // 通知渲染进程刷新本地启动项
-      this.mainWindow?.webContents.send('local-shortcuts-changed')
+      this.notifyShortcutsChanged()
 
       return { success: true }
     } catch (error) {
@@ -367,7 +387,7 @@ export class LocalShortcutsAPI {
       )
 
       // 通知渲染进程刷新本地启动项
-      this.mainWindow?.webContents.send('local-shortcuts-changed')
+      this.notifyShortcutsChanged()
 
       return { success: true }
     } catch (error) {
@@ -433,7 +453,7 @@ export class LocalShortcutsAPI {
       console.log('[LocalShortcut] 删除失效本地启动项成功:', notExistShortcuts.toString())
 
       // 通知渲染进程刷新本地启动项
-      this.mainWindow?.webContents.send('local-shortcuts-changed')
+      this.notifyShortcutsChanged()
 
       return { success: true }
     } catch (error) {

--- a/src/shared/commandShared.ts
+++ b/src/shared/commandShared.ts
@@ -35,6 +35,8 @@ export type CommandAliasStore = Record<string, CommandAliasEntry[]>
 export const COMMAND_ALIASES_KEY = HOST_STORAGE_KEYS.commandAliases
 export const DIRECT_APP_ALIAS_GROUP_KEY = '__direct_app__'
 export const DIRECT_APP_ALIAS_GROUP_TITLE = '系统应用'
+export const LOCAL_SHORTCUT_ALIAS_GROUP_KEY = '__local_shortcut__'
+export const LOCAL_SHORTCUT_ALIAS_GROUP_TITLE = '本地启动项'
 
 function normalizeDirectAppPath(path?: string): string {
   return (path || '').replace(/\\/g, '/')
@@ -53,6 +55,13 @@ export function getCommandId(cmd: CommandIdLike): string {
     const normalizedPath = normalizeDirectAppPath(cmd.path)
     if (normalizedPath) {
       return `direct:app:${normalizedPath}`
+    }
+  }
+
+  if (cmd.type === 'direct' && cmd.subType === 'local-shortcut') {
+    const normalizedPath = normalizeDirectAppPath(cmd.path)
+    if (normalizedPath) {
+      return `direct:local-shortcut:${normalizedPath}`
     }
   }
 


### PR DESCRIPTION
本地启动项支持设置别名/快捷键，并优化数据源更新方式，防止列表数据过期