### PR TITLE
fix(super-panel): 从超级面板启动插件，面板会被截断

### DIFF
--- a/src/renderer/src/App.vue
+++ b/src/renderer/src/App.vue
@@ -566,6 +566,10 @@ onMounted(async () => {
     if (timeLimit > 0) {
       try {
         const copiedContent = await window.ztools.getLastCopiedContent(timeLimit)
+        // 由于获取剪贴板的异步等待，此时 currentView 可能已经发生改变
+        if ((currentView.value as ViewMode) === ViewMode.Plugin) {
+          return
+        }
         if (copiedContent) {
           if (copiedContent.type === 'image') {
             // 自动粘贴图片
@@ -584,6 +588,11 @@ onMounted(async () => {
       } catch (error) {
         console.error('自动粘贴失败:', error)
       }
+    }
+
+    // 由于获取剪贴板的异步等待，此时 currentView 可能已经发生改变
+    if ((currentView.value as ViewMode) === ViewMode.Plugin) {
+      return
     }
 
     updateWindowHeight()


### PR DESCRIPTION
## 变更内容
+ 增加了onFocusSearch中对 currentView 的二次检查

## 动机
+ 在超级面板中启动插件时，先调用show后调用launch，currentView 存在竞态。
+ onFocusSearch 中异步获取剪贴板内容后，currentView 可能已经被修改为 Plugin，此时已经打开插件面板。这时候继续执行 `updateWindowHeight`，会导致主窗口被截断为搜索栏高度，从而隐藏插件面板

## 测试
+ 经过手动测试，解决了问题

## 相关 Issue
+ Closes #610