### PR TITLE
feat(updater): 支持最小化更新窗口

### DIFF
--- a/src/main/api/updater.ts
+++ b/src/main/api/updater.ts
@@ -86,6 +86,7 @@ export class UpdaterAPI {
     ipcMain.handle('updater:get-download-status', () => this.getDownloadStatus())
 
     ipcMain.on('updater:quit-and-install', () => void this.installDownloadedUpdate())
+    ipcMain.on('updater:minimize-window', () => this.minimizeUpdateWindow())
     ipcMain.on('updater:close-window', () => this.closeUpdateWindow())
     ipcMain.on('updater:window-ready', () => {
       const info = this.availableUpdateInfo ?? this.downloadedUpdateInfo
@@ -344,7 +345,7 @@ export class UpdaterAPI {
       frame: false,
       resizable: false,
       maximizable: false,
-      minimizable: false,
+      minimizable: true,
       alwaysOnTop: true,
       hasShadow: true,
       type: 'panel',
@@ -379,6 +380,14 @@ export class UpdaterAPI {
 
   private closeUpdateWindow(): void {
     if (this.updateWindow && !this.updateWindow.isDestroyed()) this.updateWindow.close()
+  }
+
+  /**
+   * 最小化当前更新窗口，让更新流程在后台继续运行。
+   * @returns 无返回值。
+   */
+  private minimizeUpdateWindow(): void {
+    if (this.updateWindow && !this.updateWindow.isDestroyed()) this.updateWindow.minimize()
   }
 }
 

--- a/src/renderer/src/components/updater/UpdateWindow.vue
+++ b/src/renderer/src/components/updater/UpdateWindow.vue
@@ -7,6 +7,15 @@
         <div class="title">发现新版本 {{ version }}</div>
         <div class="subtitle">ZTools</div>
       </div>
+      <button
+        type="button"
+        class="window-control minimize-button"
+        aria-label="最小化更新窗口"
+        title="最小化"
+        @click="minimizeWindow"
+      >
+        <span aria-hidden="true"></span>
+      </button>
     </div>
 
     <!-- 更新内容 -->
@@ -275,6 +284,14 @@ const closeWindow = (): void => {
 }
 
 /**
+ * 请求主进程最小化更新窗口，同时保留当前更新状态。
+ * @returns 无返回值。
+ */
+const minimizeWindow = (): void => {
+  window.electron?.ipcRenderer.send('updater:minimize-window')
+}
+
+/**
  * 处理更新窗口键盘操作，下载期间按 Escape 时取消下载。
  * @param e 键盘事件。
  * @returns 无返回值。
@@ -490,6 +507,54 @@ body,
 
 .header-info {
   flex: 1;
+  min-width: 0;
+}
+
+.window-control {
+  flex: none;
+  width: 32px;
+  height: 32px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  border-radius: 6px;
+  padding: 0;
+  background: transparent;
+  color: #666;
+  cursor: pointer;
+  -webkit-app-region: no-drag;
+  transition:
+    background-color 0.15s ease,
+    color 0.15s ease;
+}
+
+.window-control:hover {
+  background: rgba(0, 0, 0, 0.08);
+  color: #222;
+}
+
+.window-control:focus-visible {
+  outline: 2px solid rgba(59, 130, 246, 0.55);
+  outline-offset: 1px;
+}
+
+.minimize-button span {
+  width: 12px;
+  height: 1.5px;
+  border-radius: 1px;
+  background: currentColor;
+}
+
+@media (prefers-color-scheme: dark) {
+  .window-control {
+    color: #aaa;
+  }
+
+  .window-control:hover {
+    background: rgba(255, 255, 255, 0.1);
+    color: #fff;
+  }
 }
 
 .title {

--- a/tests/main/updaterWindow.test.ts
+++ b/tests/main/updaterWindow.test.ts
@@ -1,0 +1,131 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+type IPCListener = (...args: unknown[]) => void
+
+const mocks = vi.hoisted(() => {
+  const ipcListeners = new Map<string, IPCListener>()
+  const latestWindow = { current: null as any }
+  const browserWindow = vi.fn(function BrowserWindowMock(
+    options: Electron.BrowserWindowConstructorOptions
+  ) {
+    const handlers = new Map<string, () => void>()
+    const win = {
+      options,
+      webContents: {
+        send: vi.fn()
+      },
+      isDestroyed: vi.fn(() => false),
+      loadURL: vi.fn(),
+      loadFile: vi.fn(),
+      show: vi.fn(),
+      focus: vi.fn(),
+      minimize: vi.fn(),
+      close: vi.fn(),
+      once: vi.fn((event: string, handler: () => void) => handlers.set(event, handler)),
+      on: vi.fn((event: string, handler: () => void) => handlers.set(event, handler))
+    }
+    latestWindow.current = win
+    return win
+  })
+
+  return { browserWindow, ipcListeners, latestWindow }
+})
+
+vi.mock('electron', () => ({
+  app: {
+    getAppPath: vi.fn(() => 'D:\\ztools'),
+    getVersion: vi.fn(() => '3.1.0'),
+    isPackaged: false
+  },
+  BrowserWindow: mocks.browserWindow,
+  dialog: {
+    showMessageBox: vi.fn()
+  },
+  ipcMain: {
+    handle: vi.fn(),
+    on: vi.fn((channel: string, listener: IPCListener) => {
+      mocks.ipcListeners.set(channel, listener)
+    })
+  },
+  screen: {
+    getPrimaryDisplay: vi.fn(() => ({
+      workArea: { x: 0, y: 0, width: 1920, height: 1080 }
+    }))
+  },
+  shell: {
+    openExternal: vi.fn()
+  }
+}))
+
+vi.mock('@electron-toolkit/utils', () => ({
+  is: { dev: false }
+}))
+
+vi.mock('@platform-updater', () => ({
+  default: vi.fn(() => ({
+    initialize: vi.fn(() => Promise.resolve()),
+    cleanup: vi.fn(),
+    getDownloadStatus: vi.fn(() => ({ hasDownloaded: false, status: 'idle' })),
+    checkForUpdates: vi.fn(),
+    startUpdate: vi.fn(),
+    cancelUpdate: vi.fn(),
+    installDownloadedUpdate: vi.fn()
+  }))
+}))
+
+vi.mock('../../src/main/api/shared/database.js', () => ({
+  default: {
+    dbGet: vi.fn(() => null)
+  }
+}))
+
+vi.mock('../../src/main/managers/windowManager', () => ({
+  default: {
+    setQuitting: vi.fn()
+  }
+}))
+
+vi.mock('../../src/main/utils/windowUtils.js', () => ({
+  applyWindowMaterial: vi.fn(),
+  getDefaultWindowMaterial: vi.fn(() => 'none')
+}))
+
+vi.mock('../../src/main/api/serverUpdateCatalog', () => ({
+  fetchLatestServerUpdate: vi.fn(() =>
+    Promise.resolve({ available: true, latestVersion: '3.2.0' })
+  ),
+  resolvePlatformUpdateInfo: vi.fn(() =>
+    Promise.resolve({
+      version: '3.2.0',
+      changelog: 'Changes',
+      sources: []
+    })
+  )
+}))
+
+import { UpdaterAPI } from '../../src/main/api/updater'
+
+describe('updater window controls', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.ipcListeners.clear()
+    mocks.latestWindow.current = null
+  })
+
+  it('creates a minimizable window and minimizes it through IPC', async () => {
+    const updater = new UpdaterAPI()
+    updater.init({ webContents: { send: vi.fn() } } as any)
+
+    const result = await updater.checkUpdate()
+
+    expect(result.error).toBeUndefined()
+    expect(result).toMatchObject({ success: true })
+    expect(mocks.browserWindow).toHaveBeenCalledWith(expect.objectContaining({ minimizable: true }))
+    const minimizeListener = mocks.ipcListeners.get('updater:minimize-window')
+    expect(minimizeListener).toBeTypeOf('function')
+
+    minimizeListener?.()
+
+    expect(mocks.latestWindow.current.minimize).toHaveBeenCalledOnce()
+  })
+})


### PR DESCRIPTION
### issue： #625
[Feature] 作者大佬，更新弹窗可否加一个缩小按钮

- 为无边框更新弹窗增加右上角最小化按钮
- 
- 启用更新窗口的 minimizable 能力
- 
- 新增 updater:minimize-window IPC，由主进程执行窗口最小化
- 
- 最小化时保留当前更新和下载状态，不中断更新流程
- 
- 补充更新窗口最小化行为的回归测试
- 
- 适配按钮的明暗主题、悬停及键盘焦点样式

动机

当前更新弹窗始终置顶，且无边框窗口没有原生最小化入口，会遮挡其他应用并影响用户继续使用电脑。

本次改动允许用户暂时最小化更新窗口，需要时再从任务栏恢复，同时不影响当前更新状态。

### 截图
<img width="500" height="450" alt="image" src="https://github.com/user-attachments/assets/0b0ef5ce-0ad2-4436-8541-a71388b77c63" />

### 相关 Issue

Closes #625
