### PR TITLE
feat: 支持多种 AI 接口协议

### DIFF
--- a/internal-plugins/setting/src/components/common/Select/Select.ts
+++ b/internal-plugins/setting/src/components/common/Select/Select.ts
@@ -1,0 +1,78 @@
+import type { PopoverPlacement, PopoverTeleportTarget } from '../shared/useOverlayPosition'
+
+export type SelectValueType = string | number
+export type SelectSingleModelValue = SelectValueType | null
+export type SelectModelValue = SelectSingleModelValue | SelectValueType[]
+export type SelectSize = 'small' | 'medium' | 'large'
+export type SelectStatus = 'success' | 'warning' | 'error'
+export type SelectMode = 'default' | 'tags'
+
+export interface SelectOption {
+  label: string
+  value: SelectValueType
+  disabled?: boolean
+}
+
+export interface SelectSelectedItem {
+  label: string
+  value: SelectValueType
+}
+
+export interface SelectTriggerProps {
+  role: 'combobox'
+  tabindex: number
+  'aria-haspopup': 'listbox'
+  'aria-expanded': 'true' | 'false'
+  'aria-disabled'?: 'true'
+  'aria-readonly'?: 'true'
+  'aria-invalid'?: 'true'
+  onClick: () => void
+}
+
+export interface SelectTriggerSlotProps {
+  visible: boolean
+  selectedLabel: string
+  selectedValues: SelectValueType[]
+  selectedItems: SelectSelectedItem[]
+  hasValue: boolean
+  disabled: boolean
+  readonly: boolean
+  multiple: boolean
+  triggerProps: SelectTriggerProps
+  setTriggerRef: (element: HTMLElement | null) => void
+  openMenu: () => void
+  closeMenu: () => void
+  toggleMenu: () => void
+}
+
+export interface SelectProps {
+  modelValue?: SelectModelValue
+  defaultModelValue?: SelectModelValue
+  options: readonly SelectOption[]
+  placeholder?: string
+  multiple?: boolean
+  clearable?: boolean
+  disabled?: boolean
+  readonly?: boolean
+  size?: SelectSize
+  status?: SelectStatus
+  message?: string
+  maxTagCount?: number
+  mode?: SelectMode
+  show?: boolean
+  defaultShow?: boolean
+  placement?: PopoverPlacement
+  autoAdjustPlacement?: boolean
+  to?: PopoverTeleportTarget
+}
+
+export interface SelectEmits {
+  (e: 'update:modelValue', value: SelectModelValue): void
+  (e: 'change', value: SelectModelValue): void
+  (e: 'update:show', value: boolean): void
+  (e: 'clear'): void
+  (e: 'scroll', event: Event): void
+  (e: 'visible-change', visible: boolean): void
+  (e: 'tag-create', value: string): void
+  (e: 'tag-remove', value: SelectValueType): void
+}

--- a/internal-plugins/setting/src/components/common/Select/Select.vue
+++ b/internal-plugins/setting/src/components/common/Select/Select.vue
@@ -1,0 +1,1015 @@
+<script setup lang="ts">
+import { computed, nextTick, onBeforeUnmount, onMounted, ref, useSlots, watch } from 'vue'
+import { useOverlayPosition } from '../shared/useOverlayPosition'
+import type {
+  SelectEmits,
+  SelectModelValue,
+  SelectOption,
+  SelectProps,
+  SelectSelectedItem,
+  SelectSingleModelValue,
+  SelectTriggerProps,
+  SelectTriggerSlotProps,
+  SelectValueType
+} from './Select'
+
+const props = withDefaults(defineProps<SelectProps>(), {
+  placeholder: '请选择',
+  multiple: false,
+  clearable: false,
+  disabled: false,
+  readonly: false,
+  size: 'medium',
+  message: '',
+  mode: 'default',
+  show: undefined,
+  defaultShow: false,
+  placement: 'bottom-start',
+  autoAdjustPlacement: true,
+  to: 'body'
+})
+
+const emit = defineEmits<SelectEmits>()
+const slots = defineSlots<{
+  trigger?: (props: SelectTriggerSlotProps) => any
+}>()
+const runtimeSlots = useSlots()
+
+void slots
+
+const selectRef = ref<HTMLElement | null>(null)
+const triggerRef = ref<HTMLElement | null>(null)
+const panelRef = ref<HTMLElement | null>(null)
+const tagInputRef = ref<HTMLInputElement | null>(null)
+const tagInputValue = ref('')
+
+const isTagsMode = computed(() => props.mode === 'tags')
+const isMultiple = computed(() => props.multiple || isTagsMode.value)
+
+/**
+ * 将外部传入的模型值规范化为单选或多选形态，保证内部统一处理。
+ * @param value 外部传入值
+ * @param multiple 是否多选
+ * @returns 规范化后的单值或数组
+ */
+function normalizeSelectValue(
+  value: SelectModelValue | undefined,
+  multiple: boolean
+): SelectModelValue {
+  if (multiple) {
+    if (Array.isArray(value)) {
+      return [...value]
+    }
+
+    if (value === undefined || value === null || value === '') {
+      return []
+    }
+
+    return [value]
+  }
+
+  if (Array.isArray(value)) {
+    return value[0] ?? null
+  }
+
+  if (value === undefined) {
+    return null
+  }
+
+  return value
+}
+
+const uncontrolledValue = ref<SelectModelValue>(
+  normalizeSelectValue(
+    props.modelValue !== undefined ? props.modelValue : props.defaultModelValue,
+    isMultiple.value
+  )
+)
+const uncontrolledShow = ref(props.show !== undefined ? props.show : props.defaultShow)
+
+const mergedValue = computed<SelectModelValue>(() => {
+  return props.modelValue !== undefined
+    ? normalizeSelectValue(props.modelValue, isMultiple.value)
+    : uncontrolledValue.value
+})
+const mergedShow = computed(() => (props.show === undefined ? uncontrolledShow.value : props.show))
+const isInteractive = computed(() => !props.disabled && !props.readonly)
+const teleportTarget = computed(() => (props.to === false ? 'body' : (props.to ?? 'body')))
+const hasCustomTrigger = computed(() => !!runtimeSlots.trigger)
+
+watch(
+  () => props.modelValue,
+  (value) => {
+    if (value !== undefined) {
+      uncontrolledValue.value = normalizeSelectValue(value, isMultiple.value)
+    }
+  }
+)
+
+watch(
+  () => props.show,
+  (value) => {
+    if (value !== undefined) {
+      uncontrolledShow.value = value
+    }
+  }
+)
+
+watch(isMultiple, (multiple) => {
+  const normalizedPropValue = normalizeSelectValue(props.modelValue, multiple)
+  const normalizedUncontrolledValue = normalizeSelectValue(uncontrolledValue.value, multiple)
+
+  uncontrolledValue.value =
+    props.modelValue !== undefined ? normalizedPropValue : normalizedUncontrolledValue
+})
+
+const selectClasses = computed(() => [
+  'z-select',
+  `select--${props.size}`,
+  {
+    open: mergedShow.value,
+    'is-disabled': props.disabled,
+    'is-readonly': props.readonly,
+    'is-success': props.status === 'success',
+    'is-warning': props.status === 'warning',
+    'is-error': props.status === 'error',
+    'is-multiple': isMultiple.value,
+    'is-tags': isTagsMode.value,
+    'has-clear': showClear.value,
+    'is-custom-trigger': hasCustomTrigger.value
+  }
+])
+
+const selectedValues = computed<SelectValueType[]>(() => {
+  const value = mergedValue.value
+
+  if (Array.isArray(value)) {
+    return value
+  }
+
+  if (value === '' || value === null || value === undefined) {
+    return []
+  }
+
+  return [value]
+})
+
+const singleValue = computed<SelectValueType | undefined>(() => selectedValues.value[0])
+const selectedLabel = computed(() => {
+  const selected = props.options.find((opt) => opt.value === singleValue.value)
+  return selected ? selected.label : props.placeholder
+})
+
+const selectedItems = computed<SelectSelectedItem[]>(() =>
+  selectedValues.value.map((value) => {
+    const option = props.options.find((opt) => opt.value === value)
+    return {
+      label: option?.label ?? String(value),
+      value
+    }
+  })
+)
+
+const visibleSelectedItems = computed(() => {
+  if (typeof props.maxTagCount !== 'number' || props.maxTagCount < 0) {
+    return selectedItems.value
+  }
+
+  return selectedItems.value.slice(0, props.maxTagCount)
+})
+
+const hiddenTagCount = computed(
+  () => selectedItems.value.length - visibleSelectedItems.value.length
+)
+const hasValue = computed(() => selectedValues.value.length > 0)
+const showClear = computed(() => props.clearable && isInteractive.value && hasValue.value)
+
+const { resolvedPlacement, panelStyle, containsTarget, scheduleUpdate } = useOverlayPosition({
+  visible: mergedShow,
+  triggerRef: selectRef,
+  anchorRef: triggerRef,
+  panelRef,
+  placement: computed(() => props.placement),
+  autoAdjustPlacement: computed(() => props.autoAdjustPlacement),
+  width: computed(() => 'trigger')
+})
+
+/**
+ * 将一次面板定位刷新推迟到下一帧执行。
+ * @returns 无返回值
+ */
+function scheduleOverlayUpdate(): void {
+  nextTick(() => scheduleUpdate())
+}
+
+/**
+ * 切换菜单显隐，并同步对外事件；受交互性与可见状态约束。
+ * @param visible 目标可见状态
+ * @returns 无返回值
+ */
+function setOpen(visible: boolean): void {
+  if (!isInteractive.value && visible) return
+  if (mergedShow.value === visible) return
+
+  if (props.show === undefined) {
+    uncontrolledShow.value = visible
+  }
+
+  emit('update:show', visible)
+  emit('visible-change', visible)
+}
+
+/**
+ * 打开菜单；标签模式下聚焦输入框。
+ * @returns 无返回值
+ */
+function openMenu(): void {
+  if (isTagsMode.value) {
+    focusTagInput()
+  }
+
+  setOpen(true)
+}
+
+/**
+ * 关闭菜单。
+ * @returns 无返回值
+ */
+function closeMenu(): void {
+  setOpen(false)
+}
+
+/**
+ * 在下一帧聚焦标签输入框；非标签模式不做任何事。
+ * @returns 无返回值
+ */
+function focusTagInput(): void {
+  if (!isTagsMode.value) return
+  nextTick(() => tagInputRef.value?.focus())
+}
+
+/**
+ * 切换菜单展开状态；标签模式下始终执行打开。
+ * @returns 无返回值
+ */
+function toggleSelect(): void {
+  if (!isInteractive.value) return
+
+  if (isTagsMode.value) {
+    openMenu()
+    return
+  }
+
+  setOpen(!mergedShow.value)
+}
+
+/**
+ * 判断给定值是否处于当前选中集合中。
+ * @param value 待判断的值
+ * @returns 是否已选中
+ */
+function isSelected(value: SelectValueType): boolean {
+  return selectedValues.value.includes(value)
+}
+
+/**
+ * 同步内部非受控值并对外发出更新与 change 事件。
+ * @param value 新值
+ * @returns 无返回值
+ */
+function updateValue(value: SelectModelValue): void {
+  if (props.modelValue === undefined) {
+    uncontrolledValue.value = normalizeSelectValue(value, isMultiple.value)
+  }
+
+  emit('update:modelValue', value)
+  emit('change', value)
+}
+
+/**
+ * 以单选形态发出新值。
+ * @param value 新的单选值
+ * @returns 无返回值
+ */
+function emitSingleValue(value: SelectSingleModelValue): void {
+  updateValue(value)
+}
+
+/**
+ * 以多选形态发出新值数组。
+ * @param value 新的多选值数组
+ * @returns 无返回值
+ */
+function emitMultipleValue(value: SelectValueType[]): void {
+  updateValue(value)
+}
+
+/**
+ * 处理选项点击：多选下增删该值并保持展开，单选下选中并关闭。
+ * @param option 被点击的选项
+ * @returns 无返回值
+ */
+function selectOption(option: SelectOption): void {
+  if (!isInteractive.value || option.disabled) return
+
+  if (isMultiple.value) {
+    const nextValues = isSelected(option.value)
+      ? selectedValues.value.filter((value) => value !== option.value)
+      : [...selectedValues.value, option.value]
+    emitMultipleValue(nextValues)
+    focusTagInput()
+    scheduleOverlayUpdate()
+    return
+  }
+
+  emitSingleValue(option.value)
+  setOpen(false)
+}
+
+/**
+ * 从选中集合中移除一个值，并发出移除事件。
+ * @param value 要移除的值
+ * @returns 无返回值
+ */
+function removeValue(value: SelectValueType): void {
+  if (!isInteractive.value) return
+  emitMultipleValue(selectedValues.value.filter((item) => item !== value))
+  emit('tag-remove', value)
+  focusTagInput()
+  scheduleOverlayUpdate()
+}
+
+/**
+ * 清空当前选择并重置输入框。
+ * @returns 无返回值
+ */
+function handleClear(): void {
+  if (isMultiple.value) {
+    emitMultipleValue([])
+  } else {
+    emitSingleValue(null)
+  }
+
+  emit('clear')
+  tagInputValue.value = ''
+  scheduleOverlayUpdate()
+}
+
+/**
+ * 转发菜单滚动事件。
+ * @param event 滚动事件
+ * @returns 无返回值
+ */
+function handleMenuScroll(event: Event): void {
+  emit('scroll', event)
+}
+
+/**
+ * 提交标签输入：匹配已有选项则选中，否则以输入文本创建新值。
+ * @returns 无返回值
+ */
+function commitTagInput(): void {
+  if (!isInteractive.value || !isTagsMode.value) return
+
+  const text = tagInputValue.value.trim()
+  if (!text) return
+
+  const matchedOption = props.options.find(
+    (option) => !option.disabled && (option.label === text || String(option.value) === text)
+  )
+  const value = matchedOption?.value ?? text
+
+  if (!selectedValues.value.includes(value)) {
+    emitMultipleValue([...selectedValues.value, value])
+    if (!matchedOption) {
+      emit('tag-create', text)
+    }
+  }
+
+  tagInputValue.value = ''
+  setOpen(true)
+  scheduleOverlayUpdate()
+}
+
+/**
+ * 标签输入键盘处理：Enter 提交、Backspace 删除末项、Escape 关闭。
+ * @param event 键盘事件
+ * @returns 无返回值
+ */
+function handleTagInputKeydown(event: KeyboardEvent): void {
+  if (event.key === 'Enter') {
+    event.preventDefault()
+    if (!event.isComposing) {
+      commitTagInput()
+    }
+    return
+  }
+
+  if (event.key === 'Backspace' && tagInputValue.value === '' && selectedValues.value.length > 0) {
+    removeValue(selectedValues.value[selectedValues.value.length - 1])
+    return
+  }
+
+  if (event.key === 'Escape') {
+    event.preventDefault()
+    setOpen(false)
+  }
+}
+
+/**
+ * 触发器键盘处理：Enter/Space 切换，Escape 关闭。
+ * @param event 键盘事件
+ * @returns 无返回值
+ */
+function handleTriggerKeydown(event: KeyboardEvent): void {
+  if (!isInteractive.value) return
+
+  if (event.key === 'Enter' || event.key === ' ') {
+    event.preventDefault()
+    toggleSelect()
+    return
+  }
+
+  if (event.key === 'Escape') {
+    setOpen(false)
+  }
+}
+
+/**
+ * 记录自定义触发器的 DOM 元素引用，供定位 composable 使用。
+ * @param element 触发器元素；卸载时为 null
+ * @returns 无返回值
+ */
+function setTriggerRef(element: HTMLElement | null): void {
+  triggerRef.value = element
+}
+
+const triggerProps = computed<SelectTriggerProps>(() => ({
+  role: 'combobox',
+  tabindex: props.disabled ? -1 : 0,
+  'aria-haspopup': 'listbox',
+  'aria-expanded': mergedShow.value ? 'true' : 'false',
+  'aria-disabled': props.disabled ? 'true' : undefined,
+  'aria-readonly': props.readonly ? 'true' : undefined,
+  'aria-invalid': props.status === 'error' ? 'true' : undefined,
+  onClick: toggleSelect
+}))
+
+const triggerSlotProps = computed<SelectTriggerSlotProps>(() => ({
+  visible: mergedShow.value,
+  selectedLabel: selectedLabel.value,
+  selectedValues: selectedValues.value,
+  selectedItems: selectedItems.value,
+  hasValue: hasValue.value,
+  disabled: props.disabled,
+  readonly: props.readonly,
+  multiple: isMultiple.value,
+  triggerProps: triggerProps.value,
+  setTriggerRef,
+  openMenu,
+  closeMenu,
+  toggleMenu: toggleSelect
+}))
+
+/**
+ * 文档级指针按下处理：菜单展开且点击落在触发器或面板之外时关闭。
+ * @param event 指针事件
+ * @returns 无返回值
+ */
+function handleDocumentPointerDown(event: PointerEvent): void {
+  if (!mergedShow.value || containsTarget(event.target)) {
+    return
+  }
+
+  setOpen(false)
+}
+
+/**
+ * 文档级键盘处理：菜单展开时按 Escape 关闭。
+ * @param event 键盘事件
+ * @returns 无返回值
+ */
+function handleDocumentKeydown(event: KeyboardEvent): void {
+  if (mergedShow.value && event.key === 'Escape') {
+    setOpen(false)
+  }
+}
+
+watch(
+  () => [mergedValue.value, tagInputValue.value, props.options.length, mergedShow.value] as const,
+  () => {
+    if (mergedShow.value) {
+      scheduleOverlayUpdate()
+    }
+  },
+  { flush: 'post' }
+)
+
+onMounted(() => {
+  document.addEventListener('pointerdown', handleDocumentPointerDown)
+  document.addEventListener('keydown', handleDocumentKeydown)
+})
+
+onBeforeUnmount(() => {
+  document.removeEventListener('pointerdown', handleDocumentPointerDown)
+  document.removeEventListener('keydown', handleDocumentKeydown)
+})
+</script>
+
+<template>
+  <div ref="selectRef" :class="selectClasses">
+    <slot v-if="hasCustomTrigger" name="trigger" v-bind="triggerSlotProps" />
+    <div
+      v-else
+      ref="triggerRef"
+      class="select-trigger"
+      role="combobox"
+      :tabindex="disabled ? -1 : 0"
+      aria-haspopup="listbox"
+      :aria-expanded="mergedShow"
+      :aria-disabled="disabled ? 'true' : undefined"
+      :aria-readonly="readonly ? 'true' : undefined"
+      :aria-invalid="status === 'error' ? 'true' : undefined"
+      @click="toggleSelect"
+      @keydown="handleTriggerKeydown"
+    >
+      <div class="select-selection">
+        <span v-if="!isMultiple" class="select-value">{{ selectedLabel }}</span>
+        <template v-else>
+          <span v-if="!hasValue && !isTagsMode" class="select-placeholder">{{ placeholder }}</span>
+          <span v-for="item in visibleSelectedItems" :key="item.value" class="select-tag">
+            <span class="select-tag-label">{{ item.label }}</span>
+            <button
+              v-if="isInteractive"
+              class="select-tag-close"
+              type="button"
+              aria-label="移除标签"
+              @click.stop="removeValue(item.value)"
+            >
+              ×
+            </button>
+          </span>
+          <span v-if="hiddenTagCount > 0" class="select-tag select-tag-more">
+            +{{ hiddenTagCount }}
+          </span>
+          <input
+            v-if="isTagsMode"
+            ref="tagInputRef"
+            v-model="tagInputValue"
+            class="select-tag-input"
+            type="text"
+            :placeholder="hasValue ? '' : placeholder"
+            :disabled="disabled"
+            :readonly="readonly"
+            @click.stop="setOpen(true)"
+            @keydown.stop="handleTagInputKeydown"
+          />
+        </template>
+      </div>
+
+      <button
+        v-if="showClear"
+        class="select-clear"
+        type="button"
+        aria-label="清空选择"
+        @click.stop="handleClear"
+      >
+        ×
+      </button>
+
+      <svg
+        class="select-arrow"
+        :class="{ rotate: mergedShow }"
+        width="16"
+        height="16"
+        viewBox="0 0 16 16"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M4 6L8 10L12 6"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        />
+      </svg>
+    </div>
+
+    <Teleport :to="teleportTarget" :disabled="props.to === false">
+      <Transition name="select-menu">
+        <div
+          v-if="mergedShow"
+          ref="panelRef"
+          class="select-menu"
+          :data-placement="resolvedPlacement"
+          :style="panelStyle"
+          role="listbox"
+          :aria-multiselectable="isMultiple ? 'true' : undefined"
+          @scroll="handleMenuScroll"
+        >
+          <div
+            v-for="option in options"
+            :key="option.value"
+            class="select-item"
+            :class="{ active: isSelected(option.value), disabled: option.disabled }"
+            role="option"
+            :aria-selected="isSelected(option.value)"
+            :aria-disabled="option.disabled ? 'true' : undefined"
+            @click="selectOption(option)"
+          >
+            <span class="select-item-label">{{ option.label }}</span>
+            <svg
+              v-if="isSelected(option.value)"
+              class="select-item-check"
+              width="16"
+              height="16"
+              viewBox="0 0 16 16"
+              fill="none"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M13 4L6 11L3 8"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              />
+            </svg>
+          </div>
+        </div>
+      </Transition>
+    </Teleport>
+
+    <div v-if="message" class="select-footer">
+      <span class="select-message">{{ message }}</span>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.z-select {
+  position: relative;
+  display: inline-flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 150px;
+  color: var(--text-color);
+}
+
+.z-select.is-custom-trigger {
+  min-width: 0;
+}
+
+.select-trigger {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  background: var(--control-bg);
+  border: 2px solid var(--control-border);
+  border-radius: 6px;
+  color: var(--text-color);
+  cursor: pointer;
+  transition: all 0.2s;
+  outline: none;
+  user-select: none;
+  box-sizing: border-box;
+}
+
+.select-trigger:hover {
+  background: var(--hover-bg);
+  border-color: color-mix(in srgb, var(--primary-color), black 15%);
+}
+
+.z-select.open .select-trigger,
+.select-trigger:focus-visible {
+  background: var(--active-bg);
+  border-color: color-mix(in srgb, var(--primary-color), black 15%);
+  box-shadow: 0 0 0 3px var(--primary-light-bg);
+}
+
+.z-select.is-disabled:not(.is-custom-trigger) {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.z-select.is-disabled .select-trigger,
+.z-select.is-disabled.is-custom-trigger {
+  cursor: not-allowed;
+}
+
+.z-select.is-readonly .select-trigger {
+  cursor: default;
+}
+
+.z-select.is-success {
+  --select-status-color: var(--success-color);
+  --select-status-bg: var(--success-light-bg);
+}
+
+.z-select.is-warning {
+  --select-status-color: var(--warning-color);
+  --select-status-bg: var(--warning-light-bg);
+}
+
+.z-select.is-error {
+  --select-status-color: var(--danger-color);
+  --select-status-bg: var(--danger-light-bg);
+}
+
+.z-select.is-success .select-trigger,
+.z-select.is-success .select-trigger:hover,
+.z-select.is-warning .select-trigger,
+.z-select.is-warning .select-trigger:hover,
+.z-select.is-error .select-trigger,
+.z-select.is-error .select-trigger:hover {
+  border-color: color-mix(in srgb, var(--select-status-color), black 15%);
+}
+
+.z-select.is-success.open .select-trigger,
+.z-select.is-success .select-trigger:focus-visible,
+.z-select.is-warning.open .select-trigger,
+.z-select.is-warning .select-trigger:focus-visible,
+.z-select.is-error.open .select-trigger,
+.z-select.is-error .select-trigger:focus-visible {
+  box-shadow: 0 0 0 3px var(--select-status-bg);
+}
+
+.select--small .select-trigger {
+  min-height: 28px;
+  padding: 3px 10px;
+  font-size: 12px;
+}
+
+.select--medium .select-trigger {
+  min-height: 34px;
+  padding: 5px 12px;
+  font-size: 14px;
+}
+
+.select--large .select-trigger {
+  min-height: 40px;
+  padding: 8px 14px;
+  font-size: 15px;
+}
+
+.select-selection {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 4px;
+  min-width: 0;
+}
+
+.select-value,
+.select-placeholder {
+  flex: 1;
+  text-align: left;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.select-placeholder {
+  color: var(--placeholder-color);
+}
+
+.select-tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  max-width: 100%;
+  padding: 3px 7px;
+  border: 1px solid color-mix(in srgb, var(--primary-color), transparent 65%);
+  border-radius: 4px;
+  background: var(--primary-light-bg);
+  color: var(--primary-color);
+  font-size: 12px;
+  font-weight: 500;
+  line-height: 1;
+}
+
+.select-tag-label {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.select-tag-more {
+  color: var(--text-secondary);
+  border-color: color-mix(in srgb, var(--text-secondary), transparent 70%);
+  background: color-mix(in srgb, var(--text-secondary), transparent 88%);
+}
+
+.select-tag-close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 14px;
+  height: 14px;
+  margin-left: 2px;
+  border: none;
+  border-radius: 50%;
+  background: transparent;
+  color: currentColor;
+  font-size: 14px;
+  line-height: 1;
+  cursor: pointer;
+  opacity: 0.75;
+  transition: all 0.2s;
+}
+
+.select-tag-close:hover {
+  background: color-mix(in srgb, currentColor, transparent 85%);
+  opacity: 1;
+}
+
+.select-tag-input {
+  flex: 1;
+  min-width: 72px;
+  border: none;
+  outline: none;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  line-height: 1.5;
+}
+
+.select-tag-input::placeholder {
+  color: var(--placeholder-color);
+}
+
+.select-clear {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  width: 18px;
+  height: 18px;
+  border: none;
+  border-radius: 50%;
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: 16px;
+  line-height: 1;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.select-clear:hover {
+  background: var(--hover-bg);
+  color: var(--primary-color);
+}
+
+.select-arrow {
+  flex-shrink: 0;
+  color: var(--text-secondary);
+  transition: transform 0.2s;
+}
+
+.select-arrow.rotate {
+  transform: rotate(180deg);
+}
+
+.select-menu {
+  position: fixed;
+  left: 0;
+  top: 0;
+  z-index: 10000;
+  min-width: 150px;
+  max-height: 300px;
+  overflow-y: auto;
+  visibility: hidden;
+  background: rgba(255, 255, 255, 0.98);
+  border: 2px solid var(--control-border);
+  border-radius: 6px;
+  backdrop-filter: blur(100px) saturate(200%) brightness(110%);
+  -webkit-backdrop-filter: blur(100px) saturate(200%) brightness(110%);
+}
+
+/* 菜单 Teleport 到 body 后脱离组件作用域，但 Vue 3 的 data-v 哈希仍作用于 teleport 根，
+   因此 scoped 规则同样生效；暗色按插件约定走 prefers-color-scheme，不使用 html.dark */
+@media (prefers-color-scheme: dark) {
+  .select-menu {
+    background: rgba(48, 48, 48, 0.98);
+  }
+}
+
+.select-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 6px 16px;
+  color: var(--text-color);
+  font-size: 14px;
+  cursor: pointer;
+  transition: all 0.2s;
+  user-select: none;
+}
+
+.select-item:hover {
+  background: var(--hover-bg);
+}
+
+.select-item.active {
+  background: var(--active-bg);
+  color: var(--primary-color);
+  font-weight: 500;
+}
+
+.select-item.disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.select-item.disabled:hover {
+  background: transparent;
+}
+
+.select-item-label {
+  flex: 1;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.select-item-check {
+  flex-shrink: 0;
+  color: var(--primary-color);
+}
+
+.select-footer {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-height: 18px;
+  color: var(--text-secondary);
+  font-size: 12px;
+  line-height: 1.4;
+}
+
+.select-message {
+  flex: 1;
+  min-width: 0;
+}
+
+.z-select.is-success .select-message {
+  color: var(--success-color);
+}
+
+.z-select.is-warning .select-message {
+  color: var(--warning-color);
+}
+
+.z-select.is-error .select-message {
+  color: var(--danger-color);
+}
+
+.select-menu {
+  --select-menu-offset-x: 0px;
+  --select-menu-offset-y: -4px;
+}
+
+.select-menu[data-placement^='top'] {
+  --select-menu-offset-y: 4px;
+}
+
+.select-menu[data-placement^='left'] {
+  --select-menu-offset-x: 4px;
+  --select-menu-offset-y: 0px;
+}
+
+.select-menu[data-placement^='right'] {
+  --select-menu-offset-x: -4px;
+  --select-menu-offset-y: 0px;
+}
+
+.select-menu-enter-active {
+  transition:
+    opacity 0.15s ease-out,
+    transform 0.15s ease-out;
+}
+
+.select-menu-leave-active {
+  transition:
+    opacity 0.1s ease-in,
+    transform 0.1s ease-in;
+}
+
+.select-menu-enter-from,
+.select-menu-leave-to {
+  opacity: 0;
+  transform: translate(var(--select-menu-offset-x), var(--select-menu-offset-y));
+}
+
+.select-menu-enter-to,
+.select-menu-leave-from {
+  opacity: 1;
+  transform: translate(0, 0);
+}
+</style>

--- a/internal-plugins/setting/src/components/common/Select/index.ts
+++ b/internal-plugins/setting/src/components/common/Select/index.ts
@@ -1,0 +1,2 @@
+export { default as Select, default as ZSelect } from './Select.vue'
+export * from './Select'

--- a/internal-plugins/setting/src/components/common/index.ts
+++ b/internal-plugins/setting/src/components/common/index.ts
@@ -1,4 +1,5 @@
 export * from './Dropdown'
+export * from './Select'
 export * from './HotkeyInput'
 export * from './Slider'
 export * from './Toast'

--- a/internal-plugins/setting/src/components/common/shared/useOverlayPosition.ts
+++ b/internal-plugins/setting/src/components/common/shared/useOverlayPosition.ts
@@ -1,0 +1,472 @@
+import { nextTick, onBeforeUnmount, ref, watch } from 'vue'
+import type { CSSProperties, ComputedRef, Ref } from 'vue'
+
+// setting 插件没有独立 Popover 组件，这里就地定义 Select/useOverlayPosition 共用的
+// 定位相关类型联合；保留与 ZTools-UI 相同的命名，便于将来与上游同步。
+export type PopoverPlacement =
+  | 'top-start'
+  | 'top'
+  | 'top-end'
+  | 'right-start'
+  | 'right'
+  | 'right-end'
+  | 'bottom-start'
+  | 'bottom'
+  | 'bottom-end'
+  | 'left-start'
+  | 'left'
+  | 'left-end'
+
+export type PopoverWidth = number | 'trigger'
+
+export type PopoverTeleportTarget = string | HTMLElement | false
+
+type OverlaySide = 'top' | 'right' | 'bottom' | 'left'
+type OverlayAlign = 'start' | 'center' | 'end'
+type ElementRef =
+  | Readonly<Ref<HTMLElement | null | undefined>>
+  | ComputedRef<HTMLElement | null | undefined>
+type ValueRef<T> = Readonly<Ref<T>> | ComputedRef<T>
+
+interface PlacementParts {
+  side: OverlaySide
+  align: OverlayAlign
+}
+
+interface OverlayPositionedContext {
+  placement: PopoverPlacement
+  panelRect: DOMRect
+  triggerRect: DOMRect | null
+}
+
+interface UseOverlayPositionOptions {
+  visible: ValueRef<boolean>
+  triggerRef: ElementRef
+  panelRef: ElementRef
+  placement: ValueRef<PopoverPlacement>
+  anchorRef?: ElementRef
+  autoAdjustPlacement?: ValueRef<boolean | undefined>
+  overlap?: ValueRef<boolean | undefined>
+  showArrow?: ValueRef<boolean | undefined>
+  width?: ValueRef<PopoverWidth | undefined>
+  x?: ValueRef<number | undefined>
+  y?: ValueRef<number | undefined>
+  zIndex?: ValueRef<number | undefined>
+  gap?: number
+  viewportPadding?: number
+  onPositioned?: (context: OverlayPositionedContext) => void
+}
+
+const DEFAULT_PANEL_GAP = 8
+const DEFAULT_VIEWPORT_PADDING = 8
+const DEFAULT_ARROW_SIZE = 10
+const DEFAULT_Z_INDEX = 10000
+const ARROW_HALF = DEFAULT_ARROW_SIZE / 2
+
+/**
+ * 将形如 "top-start" 的方位描述拆分为边与对齐方式两段。
+ * @param placement 方位描述字符串
+ * @returns 包含 side 与 align（缺省为 center）的结构
+ */
+export function parsePlacement(placement: PopoverPlacement): PlacementParts {
+  const [side, align] = placement.split('-') as [OverlaySide, OverlayAlign | undefined]
+
+  return {
+    side,
+    align: align ?? 'center'
+  }
+}
+
+/**
+ * 由边与对齐方式组合出方位描述字符串；center 对齐时省略后缀。
+ * @param side 目标边
+ * @param align 对齐方式
+ * @returns 组合后的方位描述
+ */
+export function createPlacement(side: OverlaySide, align: OverlayAlign): PopoverPlacement {
+  return (align === 'center' ? side : `${side}-${align}`) as PopoverPlacement
+}
+
+/**
+ * 返回给定边的对边，用于空间不足时的翻转。
+ * @param side 原始边
+ * @returns 对边
+ */
+export function flipSide(side: OverlaySide): OverlaySide {
+  if (side === 'top') return 'bottom'
+  if (side === 'bottom') return 'top'
+  if (side === 'left') return 'right'
+  return 'left'
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max)
+}
+
+function createHiddenPanelStyle(zIndex: number): CSSProperties {
+  return {
+    position: 'fixed',
+    left: '0px',
+    top: '0px',
+    zIndex,
+    visibility: 'hidden'
+  }
+}
+
+function getPanelGap(options: UseOverlayPositionOptions): number {
+  if (options.overlap?.value) {
+    return 0
+  }
+
+  const baseGap = options.gap ?? DEFAULT_PANEL_GAP
+  return baseGap + (options.showArrow?.value ? ARROW_HALF : 0)
+}
+
+/**
+ * 依据方位与触发节点矩形，计算面板左上角的理想坐标；仅做几何计算，不夹取到视口。
+ * @param placement 方位描述
+ * @param triggerRect 触发节点矩形
+ * @param panelWidth 面板宽度
+ * @param panelHeight 面板高度
+ * @param gap 面板与触发节点的间距
+ * @returns 面板左上角的 left/top
+ */
+export function getPlacementPosition(
+  placement: PopoverPlacement,
+  triggerRect: DOMRect,
+  panelWidth: number,
+  panelHeight: number,
+  gap: number
+): { left: number; top: number } {
+  const { side, align } = parsePlacement(placement)
+
+  if (side === 'top' || side === 'bottom') {
+    const top = side === 'top' ? triggerRect.top - gap - panelHeight : triggerRect.bottom + gap
+    let left = triggerRect.left
+
+    if (align === 'center') {
+      left = triggerRect.left + (triggerRect.width - panelWidth) / 2
+    } else if (align === 'end') {
+      left = triggerRect.right - panelWidth
+    }
+
+    return { left, top }
+  }
+
+  const left = side === 'left' ? triggerRect.left - gap - panelWidth : triggerRect.right + gap
+  let top = triggerRect.top
+
+  if (align === 'center') {
+    top = triggerRect.top + (triggerRect.height - panelHeight) / 2
+  } else if (align === 'end') {
+    top = triggerRect.bottom - panelHeight
+  }
+
+  return { left, top }
+}
+
+/**
+ * 在视口空间不足时翻转边或对齐方式，给出能完整容纳面板的方位；仍无法容纳时返回尽量贴近原意的方位。
+ * @param placement 原始方位
+ * @param triggerRect 触发节点矩形
+ * @param panelWidth 面板宽度
+ * @param panelHeight 面板高度
+ * @param viewportWidth 视口宽度
+ * @param viewportHeight 视口高度
+ * @param gap 面板与触发节点的间距
+ * @param viewportPadding 与视口边缘的最小留白
+ * @returns 调整后的方位
+ */
+export function resolveAutoAdjustedPlacement(
+  placement: PopoverPlacement,
+  triggerRect: DOMRect,
+  panelWidth: number,
+  panelHeight: number,
+  viewportWidth: number,
+  viewportHeight: number,
+  gap: number,
+  viewportPadding: number
+): PopoverPlacement {
+  let nextPlacement = placement
+  const initial = parsePlacement(nextPlacement)
+
+  if (initial.side === 'top' || initial.side === 'bottom') {
+    const availableTop = triggerRect.top - gap - viewportPadding
+    const availableBottom = viewportHeight - triggerRect.bottom - gap - viewportPadding
+    const shouldFlipToBottom =
+      initial.side === 'top' && panelHeight > availableTop && availableBottom > availableTop
+    const shouldFlipToTop =
+      initial.side === 'bottom' && panelHeight > availableBottom && availableTop > availableBottom
+
+    if (shouldFlipToBottom || shouldFlipToTop) {
+      nextPlacement = createPlacement(flipSide(initial.side), initial.align)
+    }
+
+    const position = getPlacementPosition(nextPlacement, triggerRect, panelWidth, panelHeight, gap)
+    const resolved = parsePlacement(nextPlacement)
+    const minLeft = viewportPadding
+    const maxRight = viewportWidth - viewportPadding
+
+    if (position.left + panelWidth > maxRight && resolved.align !== 'end') {
+      nextPlacement = createPlacement(resolved.side, 'end')
+    } else if (position.left < minLeft && resolved.align !== 'start') {
+      nextPlacement = createPlacement(resolved.side, 'start')
+    }
+
+    return nextPlacement
+  }
+
+  const availableLeft = triggerRect.left - gap - viewportPadding
+  const availableRight = viewportWidth - triggerRect.right - gap - viewportPadding
+  const shouldFlipToRight =
+    initial.side === 'left' && panelWidth > availableLeft && availableRight > availableLeft
+  const shouldFlipToLeft =
+    initial.side === 'right' && panelWidth > availableRight && availableLeft > availableRight
+
+  if (shouldFlipToRight || shouldFlipToLeft) {
+    nextPlacement = createPlacement(flipSide(initial.side), initial.align)
+  }
+
+  const position = getPlacementPosition(nextPlacement, triggerRect, panelWidth, panelHeight, gap)
+  const resolved = parsePlacement(nextPlacement)
+  const minTop = viewportPadding
+  const maxBottom = viewportHeight - viewportPadding
+
+  if (position.top + panelHeight > maxBottom && resolved.align !== 'end') {
+    nextPlacement = createPlacement(resolved.side, 'end')
+  } else if (position.top < minTop && resolved.align !== 'start') {
+    nextPlacement = createPlacement(resolved.side, 'start')
+  }
+
+  return nextPlacement
+}
+
+function applyPanelWidth(
+  panel: HTMLElement,
+  width: PopoverWidth | undefined,
+  triggerRect: DOMRect | null
+): string | undefined {
+  if (width === 'trigger' && triggerRect) {
+    const nextWidth = `${triggerRect.width}px`
+    panel.style.width = nextWidth
+    return nextWidth
+  }
+
+  if (typeof width === 'number') {
+    const nextWidth = `${width}px`
+    panel.style.width = nextWidth
+    return nextWidth
+  }
+
+  panel.style.width = ''
+  return undefined
+}
+
+/**
+ * 浮层定位 composable：根据触发节点与面板尺寸计算 fixed 定位坐标，支持视口自动翻转与对齐修正，
+ * 并在滚动/resize 时通过 requestAnimationFrame 节流刷新。
+ * @param options 触发节点、面板引用、方位、宽度等配置
+ * @returns resolvedPlacement（最终方位）、panelStyle（绑定到面板的内联样式）、containsTarget（判断点击是否落在触发或面板内）、updatePosition/scheduleUpdate（手动刷新）等
+ */
+export function useOverlayPosition(options: UseOverlayPositionOptions) {
+  const resolvedPlacement = ref<PopoverPlacement>(options.placement.value)
+  const panelReady = ref(false)
+  const panelStyle = ref<CSSProperties>(
+    createHiddenPanelStyle(options.zIndex?.value ?? DEFAULT_Z_INDEX)
+  )
+  let panelPositionFrame = 0
+
+  function getTriggerElement(): HTMLElement | null {
+    return options.triggerRef.value ?? null
+  }
+
+  function getAnchorElement(): HTMLElement | null {
+    return options.anchorRef?.value ?? getTriggerElement()
+  }
+
+  function containsTarget(target: EventTarget | null): boolean {
+    const node = target as Node | null
+    const trigger = getTriggerElement()
+    const panel = options.panelRef.value ?? null
+
+    return !!node && (trigger?.contains(node) || panel?.contains(node) || false)
+  }
+
+  function updatePosition(): void {
+    const panel = options.panelRef.value
+
+    if (!panel) {
+      return
+    }
+
+    const triggerRect = getAnchorElement()?.getBoundingClientRect() ?? null
+    const appliedWidth = applyPanelWidth(panel, options.width?.value, triggerRect)
+    const panelRect = panel.getBoundingClientRect()
+    const viewportWidth = window.innerWidth
+    const viewportHeight = window.innerHeight
+    const panelWidth = panelRect.width
+    const panelHeight = panelRect.height
+    const viewportPadding = options.viewportPadding ?? DEFAULT_VIEWPORT_PADDING
+    const gap = getPanelGap(options)
+    const zIndex = options.zIndex?.value ?? DEFAULT_Z_INDEX
+    let nextPlacement = options.placement.value
+    let left = viewportPadding
+    let top = viewportPadding
+
+    if (typeof options.x?.value === 'number' && typeof options.y?.value === 'number') {
+      left = clamp(
+        options.x.value,
+        viewportPadding,
+        Math.max(viewportPadding, viewportWidth - panelWidth - viewportPadding)
+      )
+      top = clamp(
+        options.y.value,
+        viewportPadding,
+        Math.max(viewportPadding, viewportHeight - panelHeight - viewportPadding)
+      )
+    } else if (triggerRect) {
+      if (options.autoAdjustPlacement?.value !== false) {
+        nextPlacement = resolveAutoAdjustedPlacement(
+          options.placement.value,
+          triggerRect,
+          panelWidth,
+          panelHeight,
+          viewportWidth,
+          viewportHeight,
+          gap,
+          viewportPadding
+        )
+      }
+
+      const position = getPlacementPosition(
+        nextPlacement,
+        triggerRect,
+        panelWidth,
+        panelHeight,
+        gap
+      )
+      left = clamp(
+        position.left,
+        viewportPadding,
+        Math.max(viewportPadding, viewportWidth - panelWidth - viewportPadding)
+      )
+      top = clamp(
+        position.top,
+        viewportPadding,
+        Math.max(viewportPadding, viewportHeight - panelHeight - viewportPadding)
+      )
+    }
+
+    resolvedPlacement.value = nextPlacement
+    panelReady.value = true
+
+    panel.style.position = 'fixed'
+    panel.style.left = `${left}px`
+    panel.style.top = `${top}px`
+    panel.style.zIndex = String(zIndex)
+    panel.style.visibility = 'visible'
+
+    if (appliedWidth === undefined) {
+      panel.style.removeProperty('width')
+    }
+
+    panelStyle.value = {
+      position: 'fixed',
+      left: `${left}px`,
+      top: `${top}px`,
+      zIndex,
+      visibility: 'visible',
+      width: appliedWidth
+    }
+
+    options.onPositioned?.({
+      placement: nextPlacement,
+      panelRect: panel.getBoundingClientRect(),
+      triggerRect
+    })
+  }
+
+  function scheduleUpdate(): void {
+    if (!options.visible.value || panelPositionFrame) {
+      return
+    }
+
+    panelPositionFrame = window.requestAnimationFrame(() => {
+      panelPositionFrame = 0
+      updatePosition()
+    })
+  }
+
+  function cancelUpdate(): void {
+    if (!panelPositionFrame) {
+      return
+    }
+
+    window.cancelAnimationFrame(panelPositionFrame)
+    panelPositionFrame = 0
+  }
+
+  function addListeners(): void {
+    window.addEventListener('resize', scheduleUpdate)
+    window.addEventListener('scroll', scheduleUpdate, true)
+  }
+
+  function removeListeners(): void {
+    window.removeEventListener('resize', scheduleUpdate)
+    window.removeEventListener('scroll', scheduleUpdate, true)
+  }
+
+  watch(
+    options.visible,
+    async (visible) => {
+      if (!visible) {
+        panelReady.value = false
+        removeListeners()
+        cancelUpdate()
+        return
+      }
+
+      resolvedPlacement.value = options.placement.value
+      panelReady.value = false
+      panelStyle.value = createHiddenPanelStyle(options.zIndex?.value ?? DEFAULT_Z_INDEX)
+      addListeners()
+      await nextTick()
+      updatePosition()
+    },
+    { immediate: true }
+  )
+
+  watch(
+    () =>
+      [
+        options.placement.value,
+        options.autoAdjustPlacement?.value ?? true,
+        options.overlap?.value ?? false,
+        options.width?.value,
+        options.x?.value,
+        options.y?.value,
+        options.zIndex?.value,
+        options.showArrow?.value ?? false
+      ] as const,
+    () => {
+      if (options.visible.value) {
+        scheduleUpdate()
+      }
+    }
+  )
+
+  onBeforeUnmount(() => {
+    removeListeners()
+    cancelUpdate()
+  })
+
+  return {
+    resolvedPlacement,
+    panelReady,
+    panelStyle,
+    containsTarget,
+    updatePosition,
+    scheduleUpdate,
+    cancelUpdate
+  }
+}

--- a/internal-plugins/setting/src/views/AiModelsSetting/AiModelsSetting.vue
+++ b/internal-plugins/setting/src/views/AiModelsSetting/AiModelsSetting.vue
@@ -5,6 +5,7 @@ import { weightedSearch } from '@/utils'
 import { AiProviderEditor } from './components'
 import { useZtoolsSubInput } from '@/composables'
 import type { AiProvider, AiProviderInput, AiProviderStore } from '@shared/aiProviderShared'
+import { AI_API_FORMAT_OPTIONS } from '@shared/aiProviderShared'
 
 const { success, error, confirm } = useToast()
 const store = ref<AiProviderStore>({ version: 2, providers: [] })
@@ -176,6 +177,18 @@ function maskApiKey(apiKey: string): string {
   return `${apiKey.slice(0, 4)}****${apiKey.slice(-4)}`
 }
 
+/**
+ * 将接口格式枚举值转换为展示用标签。
+ * @param apiFormat 供应商接口格式
+ * @returns 格式标签
+ */
+function formatLabel(apiFormat: AiProvider['apiFormat']): string {
+  return (
+    AI_API_FORMAT_OPTIONS.find((option) => option.value === apiFormat)?.label ||
+    'OpenAI Chat Completions'
+  )
+}
+
 onMounted(loadProviders)
 </script>
 
@@ -247,6 +260,7 @@ onMounted(loadProviders)
 
             <div class="provider-meta">
               <span>{{ provider.selectedModels.length }} 个模型</span>
+              <span>{{ formatLabel(provider.apiFormat) }}</span>
               <span>{{ maskApiKey(provider.apiKey) }}</span>
             </div>
 

--- a/internal-plugins/setting/src/views/AiModelsSetting/components/AiModelEditor/AiModelEditor.vue
+++ b/internal-plugins/setting/src/views/AiModelsSetting/components/AiModelEditor/AiModelEditor.vue
@@ -1,11 +1,15 @@
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue'
-import { BaseDialog, DetailPanel } from '@/components'
-import type {
-  AiProvider,
-  AiProviderInput,
-  AiProviderModelInput,
-  AiRemoteModel
+import { BaseDialog, DetailPanel, Select, type SelectModelValue } from '@/components'
+import {
+  AI_API_FORMAT_OPTIONS,
+  DEFAULT_AI_API_FORMAT,
+  type AiApiFormat,
+  normalizeAiApiFormat,
+  type AiProvider,
+  type AiProviderInput,
+  type AiProviderModelInput,
+  type AiRemoteModel
 } from '@shared/aiProviderShared'
 
 interface Props {
@@ -32,7 +36,20 @@ const showModelDialog = ref(false)
 const formData = ref({
   name: '',
   apiUrl: '',
-  apiKey: ''
+  apiKey: '',
+  apiFormat: DEFAULT_AI_API_FORMAT as AiApiFormat
+})
+
+/**
+ * Select 的 v-model 代理：Select 发出的值类型宽于窄字面量 AiApiFormat，
+ * 经 normalizeAiApiFormat 归一化后写回表单，保证类型与取值合法。
+ * @returns 可读写的 AiApiFormat 代理
+ */
+const apiFormatProxy = computed<SelectModelValue>({
+  get: () => formData.value.apiFormat,
+  set: (value) => {
+    formData.value.apiFormat = normalizeAiApiFormat(value)
+  }
 })
 
 const filteredSelectedModelIds = computed(() => {
@@ -57,7 +74,8 @@ function resetEditor(provider: AiProvider | null): void {
   formData.value = {
     name: provider?.name || '',
     apiUrl: provider?.apiUrl || '',
-    apiKey: provider?.apiKey || ''
+    apiKey: provider?.apiKey || '',
+    apiFormat: provider?.apiFormat ?? DEFAULT_AI_API_FORMAT
   }
   fetchedModels.value = []
   selectedModelIds.value = new Set(provider?.selectedModels.map((model) => model.modelId) || [])
@@ -176,6 +194,7 @@ function handleSave(): void {
     name: formData.value.name,
     apiUrl: formData.value.apiUrl,
     apiKey: formData.value.apiKey,
+    apiFormat: formData.value.apiFormat,
     selectedModels
   })
 }
@@ -192,6 +211,17 @@ function handleSave(): void {
           </div>
 
           <div class="form-group">
+            <label class="form-label">API 格式 *</label>
+            <Select
+              v-model="apiFormatProxy"
+              :options="AI_API_FORMAT_OPTIONS"
+              size="medium"
+              placeholder="选择 API 格式"
+              style="width: 100%"
+            />
+          </div>
+
+          <div class="form-group full-width-field">
             <label class="form-label">API 地址 *</label>
             <input
               v-model="formData.apiUrl"
@@ -201,7 +231,7 @@ function handleSave(): void {
             />
           </div>
 
-          <div class="form-group">
+          <div class="form-group full-width-field">
             <label class="form-label">API 密钥 *</label>
             <div class="input-wrapper">
               <input
@@ -404,7 +434,7 @@ function handleSave(): void {
   gap: 18px;
 }
 
-.connection-fields .form-group:last-child {
+.full-width-field {
   grid-column: 1 / -1;
 }
 
@@ -637,7 +667,7 @@ function handleSave(): void {
     grid-template-columns: 1fr;
   }
 
-  .connection-fields .form-group:last-child {
+  .connection-fields .full-width-field {
     grid-column: auto;
   }
 

--- a/src/main/api/plugin/ai.ts
+++ b/src/main/api/plugin/ai.ts
@@ -1,9 +1,9 @@
 import { ipcMain } from 'electron'
 import type { PluginManager } from '../../managers/pluginManager'
-import OpenAI from 'openai'
 import detachedWindowManager from '../../core/detachedWindowManager'
 import aiProviderService, { type ResolvedAiModel } from '../../core/aiProviderService.js'
-import type { AiModelChoice, AiProvider } from '../../../shared/aiProviderShared.js'
+import { createAdapter } from './aiProtocol/adapters'
+import type { AiModelChoice } from '../../../shared/aiProviderShared.js'
 
 /**
  * AI 选项
@@ -206,70 +206,6 @@ class PluginAiAPI {
     return aiProviderService.resolveModel(modelRef)
   }
 
-  /**
-   * 使用供应商凭据创建 OpenAI 兼容客户端。
-   * @param provider 已解析的供应商连接配置
-   * @returns OpenAI SDK 客户端
-   */
-  private createClient(provider: AiProvider): OpenAI {
-    return new OpenAI({
-      apiKey: provider.apiKey,
-      baseURL: provider.apiUrl
-    })
-  }
-  /**
-   * 将 Message[] 转为 OpenAI SDK 格式
-   * 关键：保留 assistant 消息的 reasoning_content，解决 DeepSeek thinking mode 报错
-   */
-  private convertMessages(messages: Message[]): OpenAI.ChatCompletionMessageParam[] {
-    return messages.map((msg) => {
-      if (msg.role === 'assistant') {
-        const assistantMsg: Record<string, unknown> = {
-          role: 'assistant',
-          content: msg.content || ''
-        }
-        if (msg.reasoning_content) {
-          assistantMsg.reasoning_content = msg.reasoning_content
-        }
-        if (msg.tool_calls?.length) {
-          assistantMsg.tool_calls = msg.tool_calls
-        }
-        return assistantMsg as unknown as OpenAI.ChatCompletionMessageParam
-      }
-      if (msg.role === 'tool') {
-        return {
-          role: 'tool' as const,
-          content: (typeof msg.content === 'string' ? msg.content : '') || '',
-          tool_call_id: msg.tool_call_id || ''
-        }
-      }
-      // user 消息：支持字符串或内容块数组（多模态）
-      if (msg.role === 'user' && Array.isArray(msg.content)) {
-        return {
-          role: 'user' as const,
-          content: msg.content as OpenAI.ChatCompletionContentPart[]
-        }
-      }
-      return {
-        role: msg.role as 'system' | 'user',
-        content: (typeof msg.content === 'string' ? msg.content : '') || ''
-      }
-    })
-  }
-
-  private convertTools(tools: Tool[]): OpenAI.ChatCompletionTool[] {
-    return tools
-      .filter((t) => t.function)
-      .map((t) => ({
-        type: 'function' as const,
-        function: {
-          name: t.function!.name,
-          description: t.function!.description,
-          parameters: t.function!.parameters as OpenAI.FunctionParameters
-        }
-      }))
-  }
-
   private async executeToolCall(
     toolCall: { id: string; function: { name: string; arguments: string } },
     webContents: Electron.WebContents
@@ -317,68 +253,43 @@ class PluginAiAPI {
 
     try {
       this.notifyAiStatus('sending', webContents)
-      const client = this.createClient(resolvedModel.provider)
-      const openaiTools = option.tools?.length ? this.convertTools(option.tools) : undefined
+      // 按供应商配置的接口格式选择适配器，统一工具调用循环。
+      const adapter = createAdapter(resolvedModel.provider)
+      const tools = option.tools?.length ? option.tools : undefined
       const messages = [...option.messages]
 
       for (let round = 0; round < MAX_TOOL_ROUNDS; round++) {
         this.notifyAiStatus(round === 0 ? 'sending' : 'receiving', webContents)
 
-        const response = await client.chat.completions.create(
-          {
-            model: resolvedModel.model.modelId,
-            messages: this.convertMessages(messages),
-            ...(openaiTools?.length ? { tools: openaiTools } : {})
-          },
-          { signal: abortController.signal }
+        const turn = await adapter.complete(
+          { model: resolvedModel.model.modelId, messages, tools },
+          abortController.signal
         )
 
-        const choice = response.choices[0]
-        if (!choice) {
-          this.notifyAiStatus('idle', webContents)
-          return { success: true, data: { role: 'assistant', content: '' } }
-        }
-
-        const assistantMsg = choice.message
-        // 提取 reasoning_content（DeepSeek 等模型的非标准字段）
-        const reasoningContent = (assistantMsg as unknown as Record<string, unknown>)
-          .reasoning_content as string | undefined
-
-        // 没有工具调用，直接返回结果
-        if (!assistantMsg.tool_calls?.length) {
+        // 没有工具调用，直接返回结果。
+        if (turn.toolCalls.length === 0) {
           this.notifyAiStatus('idle', webContents)
           return {
             success: true,
             data: {
               role: 'assistant',
-              content: assistantMsg.content || '',
-              reasoning_content: reasoningContent
+              content: turn.content,
+              reasoning_content: turn.reasoningContent
             }
           }
         }
-        // 有工具调用：提取 function 类型的工具调用
-        const fnToolCalls = assistantMsg.tool_calls
-          .filter(
-            (tc): tc is OpenAI.ChatCompletionMessageToolCall & { type: 'function' } =>
-              tc.type === 'function'
-          )
-          .map((tc) => ({
-            id: tc.id,
-            type: 'function' as const,
-            function: { name: tc.function.name, arguments: tc.function.arguments }
-          }))
 
+        // 记录助手回复（含 reasoning_content 与工具调用）后执行工具。
         messages.push({
           role: 'assistant',
-          content: assistantMsg.content || '',
-          reasoning_content: reasoningContent,
-          tool_calls: fnToolCalls
+          content: turn.content,
+          reasoning_content: turn.reasoningContent,
+          tool_calls: turn.toolCalls
         })
 
-        // 执行所有工具调用并追加结果
-        for (const tc of fnToolCalls) {
-          const result = await this.executeToolCall(tc, webContents)
-          messages.push({ role: 'tool', content: result, tool_call_id: tc.id })
+        for (const toolCall of turn.toolCalls) {
+          const result = await this.executeToolCall(toolCall, webContents)
+          messages.push({ role: 'tool', content: result, tool_call_id: toolCall.id })
         }
       }
 
@@ -421,88 +332,49 @@ class PluginAiAPI {
 
     try {
       this.notifyAiStatus('sending', webContents)
-      const client = this.createClient(resolvedModel.provider)
-      const openaiTools = option.tools?.length ? this.convertTools(option.tools) : undefined
+      // 按供应商配置的接口格式选择适配器，统一工具调用循环。
+      const adapter = createAdapter(resolvedModel.provider)
+      const tools = option.tools?.length ? option.tools : undefined
       const messages = [...option.messages]
 
       for (let round = 0; round < MAX_TOOL_ROUNDS; round++) {
         this.notifyAiStatus(round === 0 ? 'sending' : 'receiving', webContents)
 
-        const stream = await client.chat.completions.create(
-          {
-            model: resolvedModel.model.modelId,
-            messages: this.convertMessages(messages),
-            stream: true,
-            ...(openaiTools?.length ? { tools: openaiTools } : {})
-          },
-          { signal: abortController.signal }
-        )
-
-        let fullContent = ''
-        let fullReasoning = ''
-        const toolCalls: Map<number, { id: string; name: string; arguments: string }> = new Map()
-
-        this.notifyAiStatus('receiving', webContents)
-
-        for await (const chunk of stream) {
-          const delta = chunk.choices[0]?.delta
-          if (!delta) continue
-          // 处理 reasoning_content（DeepSeek thinking mode 流式片段）
-          const deltaAny = delta as Record<string, unknown>
-          const reasoningDelta = deltaAny.reasoning_content as string | undefined
-
-          // 处理文本内容
-          const contentDelta = delta.content || ''
-
-          if (contentDelta || reasoningDelta) {
-            fullContent += contentDelta
-            fullReasoning += reasoningDelta || ''
+        // 首个增量到达时切换为接收状态，与既有 UX 保持一致。
+        let receivingNotified = false
+        const turn = await adapter.stream(
+          { model: resolvedModel.model.modelId, messages, tools },
+          abortController.signal,
+          (delta) => {
+            if (!receivingNotified) {
+              receivingNotified = true
+              this.notifyAiStatus('receiving', webContents)
+            }
             onChunk({
               role: 'assistant',
-              content: contentDelta,
-              reasoning_content: reasoningDelta
+              content: delta.content ?? '',
+              reasoning_content: delta.reasoningContent
             })
           }
+        )
 
-          // 累积工具调用片段
-          if (delta.tool_calls) {
-            for (const tc of delta.tool_calls) {
-              const existing = toolCalls.get(tc.index)
-              if (existing) {
-                existing.arguments += tc.function?.arguments || ''
-              } else {
-                toolCalls.set(tc.index, {
-                  id: tc.id || '',
-                  name: tc.function?.name || '',
-                  arguments: tc.function?.arguments || ''
-                })
-              }
-            }
-          }
-        }
-
-        // 流结束，检查是否有工具调用
-        if (toolCalls.size === 0) {
+        // 流结束且无工具调用，本轮直接结束。
+        if (turn.toolCalls.length === 0) {
           this.notifyAiStatus('idle', webContents)
           return
         }
-        // 有工具调用：将 assistant 消息（含 reasoning_content）加入历史
-        const tcArray = Array.from(toolCalls.values()).map((tc) => ({
-          id: tc.id,
-          type: 'function' as const,
-          function: { name: tc.name, arguments: tc.arguments }
-        }))
+
+        // 将助手回复（含 reasoning_content）加入历史后执行工具调用。
         messages.push({
           role: 'assistant',
-          content: fullContent,
-          reasoning_content: fullReasoning || undefined,
-          tool_calls: tcArray
+          content: turn.content,
+          reasoning_content: turn.reasoningContent,
+          tool_calls: turn.toolCalls
         })
 
-        // 执行所有工具调用并追加结果
-        for (const tc of tcArray) {
-          const result = await this.executeToolCall(tc, webContents)
-          messages.push({ role: 'tool', content: result, tool_call_id: tc.id })
+        for (const toolCall of turn.toolCalls) {
+          const result = await this.executeToolCall(toolCall, webContents)
+          messages.push({ role: 'tool', content: result, tool_call_id: toolCall.id })
         }
       }
 

--- a/src/main/api/plugin/aiProtocol/adapters.ts
+++ b/src/main/api/plugin/aiProtocol/adapters.ts
@@ -1,0 +1,512 @@
+import OpenAI from 'openai'
+import type { AiProvider } from '../../../../shared/aiProviderShared.js'
+import type { Message, Tool, ToolCall } from '../ai'
+import {
+  ANTHROPIC_DEFAULT_MAX_TOKENS,
+  fromAnthropicContent,
+  fromResponsesOutput,
+  toAnthropicMessages,
+  toAnthropicTools,
+  toResponsesInput,
+  toResponsesTools,
+  type AssistantTurn
+} from './converters'
+
+export type { AssistantTurn }
+
+/** 单轮调用的输入：模型、消息历史与可选工具。 */
+export interface AdapterInput {
+  model: string
+  messages: Message[]
+  tools?: Tool[]
+}
+
+/** 流式增量回调携带的字段，缺省表示本轮该字段无增量。 */
+interface AdapterDelta {
+  content?: string
+  reasoningContent?: string
+}
+
+/** 三种接口格式的统一调用契约。 */
+export interface AiProtocolAdapter {
+  /**
+   * 非流式调用，返回单轮完整回复。
+   * @param input 模型、消息与工具
+   * @param signal 中止信号
+   * @returns 归一化的助手回复
+   */
+  complete(input: AdapterInput, signal: AbortSignal): Promise<AssistantTurn>
+  /**
+   * 流式调用，实时回传增量并在结束时返回完整回复。
+   * @param input 模型、消息与工具
+   * @param signal 中止信号
+   * @param onDelta 接收文本与推理增量的回调
+   * @returns 归一化的助手回复
+   */
+  stream(
+    input: AdapterInput,
+    signal: AbortSignal,
+    onDelta: (delta: AdapterDelta) => void
+  ): Promise<AssistantTurn>
+}
+
+/**
+ * 按供应商配置的接口格式选择对应适配器。
+ * @param provider 已解析的供应商连接配置
+ * @returns 该供应商的接口适配器
+ */
+export function createAdapter(provider: AiProvider): AiProtocolAdapter {
+  switch (provider.apiFormat) {
+    case 'openai-chat':
+      return new OpenAiChatAdapter(createOpenAiClient(provider))
+    case 'openai-responses':
+      return new OpenAiResponsesAdapter(createOpenAiClient(provider))
+    case 'anthropic-messages':
+      return new AnthropicMessagesAdapter(provider)
+    default:
+      // 理论上不会到达，防御未知格式以避免静默失败。
+      throw new Error(`不支持的接口格式: ${String(provider.apiFormat)}`)
+  }
+}
+
+/**
+ * 使用供应商凭据创建 OpenAI 兼容客户端，供 Chat 与 Responses 适配器复用。
+ * @param provider 供应商连接配置
+ * @returns OpenAI SDK 客户端
+ */
+function createOpenAiClient(provider: AiProvider): OpenAI {
+  return new OpenAI({ apiKey: provider.apiKey, baseURL: provider.apiUrl })
+}
+
+/**
+ * 将插件消息转为 OpenAI Chat Completions 的消息参数。
+ * @param messages 标准消息历史
+ * @returns OpenAI SDK 消息参数数组
+ */
+function convertMessages(messages: Message[]): OpenAI.ChatCompletionMessageParam[] {
+  return messages.map((msg) => {
+    // 助手消息保留 reasoning_content 与 tool_calls，解决 DeepSeek thinking mode 透传。
+    if (msg.role === 'assistant') {
+      const assistantMsg: Record<string, unknown> = {
+        role: 'assistant',
+        content: msg.content || ''
+      }
+      if (msg.reasoning_content) {
+        assistantMsg.reasoning_content = msg.reasoning_content
+      }
+      if (msg.tool_calls?.length) {
+        assistantMsg.tool_calls = msg.tool_calls
+      }
+      return assistantMsg as unknown as OpenAI.ChatCompletionMessageParam
+    }
+    if (msg.role === 'tool') {
+      return {
+        role: 'tool' as const,
+        content: (typeof msg.content === 'string' ? msg.content : '') || '',
+        tool_call_id: msg.tool_call_id || ''
+      }
+    }
+    // user 消息支持字符串或内容块数组（多模态）。
+    if (msg.role === 'user' && Array.isArray(msg.content)) {
+      return {
+        role: 'user' as const,
+        content: msg.content as OpenAI.ChatCompletionContentPart[]
+      }
+    }
+    return {
+      role: msg.role as 'system' | 'user',
+      content: (typeof msg.content === 'string' ? msg.content : '') || ''
+    }
+  })
+}
+
+/**
+ * 将插件工具定义转为 OpenAI Chat Completions 的工具参数。
+ * @param tools 可选的工具列表
+ * @returns OpenAI SDK 工具参数数组
+ */
+function convertChatTools(tools?: Tool[]): OpenAI.ChatCompletionTool[] {
+  return (tools ?? [])
+    .filter((tool) => tool.function)
+    .map((tool) => ({
+      type: 'function' as const,
+      function: {
+        name: tool.function!.name,
+        description: tool.function!.description,
+        parameters: tool.function!.parameters as OpenAI.FunctionParameters
+      }
+    }))
+}
+
+/**
+ * 从 Chat Completions 返回中提取函数类型的工具调用。
+ * @param toolCalls 模型返回的原始工具调用
+ * @returns 归一化的 ToolCall 数组
+ */
+function extractChatToolCalls(toolCalls?: OpenAI.ChatCompletionMessageToolCall[]): ToolCall[] {
+  if (!toolCalls?.length) return []
+  return toolCalls
+    .filter(
+      (toolCall): toolCall is OpenAI.ChatCompletionMessageFunctionToolCall =>
+        toolCall.type === 'function'
+    )
+    .map((toolCall) => ({
+      id: toolCall.id,
+      type: 'function' as const,
+      function: {
+        name: toolCall.function.name,
+        arguments: toolCall.function.arguments
+      }
+    }))
+}
+
+/**
+ * OpenAI Chat Completions 适配器，沿用既有调用与透传逻辑。
+ */
+class OpenAiChatAdapter implements AiProtocolAdapter {
+  constructor(private readonly client: OpenAI) {}
+
+  public async complete(input: AdapterInput, signal: AbortSignal): Promise<AssistantTurn> {
+    const tools = convertChatTools(input.tools)
+    const response = await this.client.chat.completions.create(
+      {
+        model: input.model,
+        messages: convertMessages(input.messages),
+        ...(tools.length ? { tools } : {})
+      },
+      { signal }
+    )
+
+    const choice = response.choices[0]
+    if (!choice) return { content: '', toolCalls: [] }
+    const assistantMsg = choice.message
+    // 提取 reasoning_content（DeepSeek 等模型的非标准字段）。
+    const reasoningContent = (assistantMsg as unknown as Record<string, unknown>)
+      .reasoning_content as string | undefined
+    return {
+      content: assistantMsg.content || '',
+      reasoningContent,
+      toolCalls: extractChatToolCalls(assistantMsg.tool_calls)
+    }
+  }
+
+  public async stream(
+    input: AdapterInput,
+    signal: AbortSignal,
+    onDelta: (delta: AdapterDelta) => void
+  ): Promise<AssistantTurn> {
+    const tools = convertChatTools(input.tools)
+    const stream = await this.client.chat.completions.create(
+      {
+        model: input.model,
+        messages: convertMessages(input.messages),
+        stream: true,
+        ...(tools.length ? { tools } : {})
+      },
+      { signal }
+    )
+
+    let fullContent = ''
+    let fullReasoning = ''
+    // 工具调用按 index 累积参数片段，流结束后统一归一化。
+    const toolCalls = new Map<number, { id: string; name: string; arguments: string }>()
+
+    for await (const chunk of stream) {
+      const delta = chunk.choices[0]?.delta
+      if (!delta) continue
+      const deltaAny = delta as Record<string, unknown>
+      const reasoningDelta = deltaAny.reasoning_content as string | undefined
+      const contentDelta = delta.content || ''
+
+      if (contentDelta || reasoningDelta) {
+        fullContent += contentDelta
+        fullReasoning += reasoningDelta || ''
+        onDelta({
+          content: contentDelta || undefined,
+          reasoningContent: reasoningDelta || undefined
+        })
+      }
+
+      if (delta.tool_calls) {
+        for (const toolCall of delta.tool_calls) {
+          const existing = toolCalls.get(toolCall.index)
+          if (existing) {
+            existing.arguments += toolCall.function?.arguments || ''
+          } else {
+            toolCalls.set(toolCall.index, {
+              id: toolCall.id || '',
+              name: toolCall.function?.name || '',
+              arguments: toolCall.function?.arguments || ''
+            })
+          }
+        }
+      }
+    }
+
+    return {
+      content: fullContent,
+      reasoningContent: fullReasoning || undefined,
+      toolCalls: Array.from(toolCalls.values()).map((toolCall) => ({
+        id: toolCall.id,
+        type: 'function' as const,
+        function: { name: toolCall.name, arguments: toolCall.arguments }
+      }))
+    }
+  }
+}
+
+/**
+ * OpenAI Responses API 适配器。
+ */
+class OpenAiResponsesAdapter implements AiProtocolAdapter {
+  constructor(private readonly client: OpenAI) {}
+
+  public async complete(input: AdapterInput, signal: AbortSignal): Promise<AssistantTurn> {
+    const tools = toResponsesTools(input.tools)
+    // store:false 使请求无状态化，工具调用历史由输入项完整回传。
+    const params = {
+      model: input.model,
+      input: toResponsesInput(input.messages),
+      store: false,
+      ...(tools ? { tools } : {})
+    } as unknown as OpenAI.Responses.ResponseCreateParamsNonStreaming
+    const response = await this.client.responses.create(params, { signal })
+    return fromResponsesOutput(response.output)
+  }
+
+  public async stream(
+    input: AdapterInput,
+    signal: AbortSignal,
+    onDelta: (delta: AdapterDelta) => void
+  ): Promise<AssistantTurn> {
+    const tools = toResponsesTools(input.tools)
+    const params = {
+      model: input.model,
+      input: toResponsesInput(input.messages),
+      store: false,
+      stream: true,
+      ...(tools ? { tools } : {})
+    } as unknown as OpenAI.Responses.ResponseCreateParamsStreaming
+    const stream = await this.client.responses.create(params, { signal })
+
+    let completed: OpenAI.Responses.Response | null = null
+    for await (const event of stream) {
+      // 文本与推理增量实时回传，工具调用在 completed 事件中一次性归一化。
+      if (event.type === 'response.output_text.delta') {
+        onDelta({ content: event.delta })
+      } else if (event.type === 'response.reasoning_text.delta') {
+        onDelta({ reasoningContent: event.delta })
+      } else if (event.type === 'response.completed') {
+        completed = event.response
+      } else if (event.type === 'response.failed' || event.type === 'response.incomplete') {
+        throw new Error('Responses API 返回失败或不完整事件')
+      }
+    }
+    if (!completed) throw new Error('Responses API 未返回完整响应')
+    return fromResponsesOutput(completed.output)
+  }
+}
+
+/**
+ * Anthropic Messages API 适配器，使用原生 fetch 以避免新增依赖并兼容自定义中转地址。
+ */
+class AnthropicMessagesAdapter implements AiProtocolAdapter {
+  constructor(private readonly provider: AiProvider) {}
+
+  public async complete(input: AdapterInput, signal: AbortSignal): Promise<AssistantTurn> {
+    const response = await this.request(this.buildBody(input, false), signal)
+    // 非流式响应体为单个 JSON 对象，content 字段即模型输出块。
+    const json = (await response.json()) as { content?: unknown }
+    return fromAnthropicContent(json.content)
+  }
+
+  public async stream(
+    input: AdapterInput,
+    signal: AbortSignal,
+    onDelta: (delta: AdapterDelta) => void
+  ): Promise<AssistantTurn> {
+    const response = await this.request(this.buildBody(input, true), signal)
+    return parseAnthropicSse(response.body, onDelta)
+  }
+
+  /**
+   * 构造 Anthropic Messages 请求体。
+   * @param input 模型、消息与工具
+   * @param stream 是否流式
+   * @returns 请求体对象
+   */
+  private buildBody(input: AdapterInput, stream: boolean): Record<string, unknown> {
+    const { system, messages } = toAnthropicMessages(input.messages)
+    // max_tokens 是 Anthropic 必填字段，使用较高默认值减少截断。
+    const body: Record<string, unknown> = {
+      model: input.model,
+      messages,
+      max_tokens: ANTHROPIC_DEFAULT_MAX_TOKENS,
+      stream
+    }
+    if (system) body.system = system
+    const tools = toAnthropicTools(input.tools)
+    if (tools) body.tools = tools
+    return body
+  }
+
+  /**
+   * 发起 Anthropic 请求并校验响应状态。
+   * @param body 请求体
+   * @param signal 中止信号
+   * @returns fetch 响应
+   * @throws 鉴权或参数错误时抛出携带状态码与响应文本的错误
+   */
+  private async request(body: Record<string, unknown>, signal: AbortSignal): Promise<Response> {
+    const endpoint = buildAnthropicEndpoint(this.provider.apiUrl)
+    const response = await fetch(endpoint, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-api-key': this.provider.apiKey,
+        'anthropic-version': '2023-06-01'
+      },
+      body: JSON.stringify(body),
+      signal
+    })
+    if (!response.ok) {
+      // 读取错误响应体以便定位鉴权或参数问题。
+      const errorText = await response.text().catch(() => '')
+      throw new Error(
+        `Anthropic 请求失败 (${response.status}): ${errorText || response.statusText}`
+      )
+    }
+    return response
+  }
+}
+
+/**
+ * 根据供应商地址构造 Anthropic Messages 接口地址。
+ * @param apiUrl 用户填写的接口地址
+ * @returns 完整的 /messages 端点
+ */
+function buildAnthropicEndpoint(apiUrl: string): string {
+  const base = apiUrl.replace(/\/+$/, '')
+  // 已包含 /v1 的中转地址直接拼接 /messages，否则补 /v1/messages。
+  return base.endsWith('/v1') ? `${base}/messages` : `${base}/v1/messages`
+}
+
+/** Anthropic 流式中按索引累积的工具调用片段。 */
+interface AnthropicToolCallAccumulator {
+  id: string
+  name: string
+  args: string
+}
+
+/**
+ * 解析 Anthropic 流式响应的 SSE，实时回传增量并累积工具调用。
+ * @param body fetch 响应的可读流
+ * @param onDelta 接收文本与推理增量的回调
+ * @returns 归一化的助手回复
+ * @throws 流中断或收到 error 事件时抛出错误
+ */
+async function parseAnthropicSse(
+  body: ReadableStream<Uint8Array> | null,
+  onDelta: (delta: AdapterDelta) => void
+): Promise<AssistantTurn> {
+  if (!body) throw new Error('Anthropic 流式响应缺少 body')
+  const reader = body.getReader()
+  const decoder = new TextDecoder()
+  let buffer = ''
+  let fullContent = ''
+  let fullReasoning = ''
+  const toolCalls: ToolCall[] = []
+  // 每个 content_block 的状态按 index 跟踪，content_block_stop 时完成工具调用解析。
+  const blocks = new Map<number, AnthropicToolCallAccumulator>()
+
+  for (;;) {
+    const { done, value } = await reader.read()
+    if (done) break
+    buffer += decoder.decode(value, { stream: true })
+
+    // SSE 事件以空行分隔，逐块解析后保留未完成的尾部。
+    const events = buffer.split(/\r?\n\r?\n/)
+    buffer = events.pop() ?? ''
+    for (const rawEvent of events) {
+      const data = extractSseData(rawEvent)
+      if (!data) continue
+      const event = JSON.parse(data) as Record<string, unknown>
+      const type = typeof event.type === 'string' ? event.type : ''
+
+      if (type === 'content_block_start') {
+        const index = event.index as number
+        const block = event.content_block as Record<string, unknown> | undefined
+        if (block && block.type === 'tool_use') {
+          blocks.set(index, {
+            id: typeof block.id === 'string' ? block.id : '',
+            name: typeof block.name === 'string' ? block.name : '',
+            args: ''
+          })
+        }
+      } else if (type === 'content_block_delta') {
+        const index = event.index as number
+        const delta = event.delta as Record<string, unknown> | undefined
+        if (!delta) continue
+        // 文本增量：回传并累积为最终内容。
+        if (delta.type === 'text_delta' && typeof delta.text === 'string') {
+          fullContent += delta.text
+          onDelta({ content: delta.text })
+        } else if (delta.type === 'thinking_delta' && typeof delta.thinking === 'string') {
+          // 扩展思考默认未启用，仅当中转站或模型返回时透传。
+          fullReasoning += delta.thinking
+          onDelta({ reasoningContent: delta.thinking })
+        } else if (delta.type === 'input_json_delta' && typeof delta.partial_json === 'string') {
+          const accumulator = blocks.get(index)
+          if (accumulator) accumulator.args += delta.partial_json
+        }
+      } else if (type === 'content_block_stop') {
+        const index = event.index as number
+        const accumulator = blocks.get(index)
+        if (accumulator) {
+          // 工具调用参数为累积的 JSON 片段，解析失败时回退为空对象。
+          let input: unknown
+          try {
+            input = accumulator.args ? JSON.parse(accumulator.args) : {}
+          } catch {
+            input = {}
+          }
+          toolCalls.push({
+            id: accumulator.id,
+            type: 'function',
+            function: {
+              name: accumulator.name,
+              arguments: typeof input === 'string' ? input : JSON.stringify(input)
+            }
+          })
+          blocks.delete(index)
+        }
+      } else if (type === 'error') {
+        const error = event.error as Record<string, unknown> | undefined
+        throw new Error(
+          `Anthropic 流式响应错误: ${typeof error?.message === 'string' ? error.message : data}`
+        )
+      }
+    }
+  }
+
+  return {
+    content: fullContent,
+    reasoningContent: fullReasoning || undefined,
+    toolCalls
+  }
+}
+
+/**
+ * 从单个 SSE 事件文本中提取 data 字段的 JSON 负载。
+ * @param rawEvent 单个 SSE 事件的原始文本
+ * @returns data 字段拼接后的字符串；无 data 行时返回 null
+ */
+function extractSseData(rawEvent: string): string | null {
+  const dataLines: string[] = []
+  for (const line of rawEvent.split(/\r?\n/)) {
+    if (line.startsWith('data:')) {
+      dataLines.push(line.slice(5).trimStart())
+    }
+  }
+  return dataLines.length ? dataLines.join('\n') : null
+}

--- a/src/main/api/plugin/aiProtocol/converters.ts
+++ b/src/main/api/plugin/aiProtocol/converters.ts
@@ -1,0 +1,386 @@
+import type { ContentPart, Message, Tool, ToolCall } from '../ai'
+
+/** 单轮模型回复的归一化结果，跨三种接口格式统一。 */
+export interface AssistantTurn {
+  content: string
+  reasoningContent?: string
+  toolCalls: ToolCall[]
+}
+
+/** Anthropic 接口要求的默认最大输出 token 数。 */
+export const ANTHROPIC_DEFAULT_MAX_TOKENS = 8192
+
+/* ===================== OpenAI Responses API 转换 ===================== */
+
+/**
+ * 将插件消息列表转为 OpenAI Responses API 的输入项。
+ * @param messages 插件维护的标准消息历史
+ * @returns Responses API 的 input 数组（以普通对象表达，交由适配器按需断言）
+ */
+export function toResponsesInput(messages: Message[]): Record<string, unknown>[] {
+  const items: Record<string, unknown>[] = []
+  for (const message of messages) {
+    // 工具结果回传为独立的 function_call_output 输入项，沿用模型生成的 call_id。
+    if (message.role === 'tool') {
+      items.push({
+        type: 'function_call_output',
+        call_id: message.tool_call_id || '',
+        output: typeof message.content === 'string' ? message.content : ''
+      })
+      continue
+    }
+    // 助手消息先回放文本，再补充其发起的函数调用，保持多轮调用历史完整。
+    if (message.role === 'assistant') {
+      const text = typeof message.content === 'string' ? message.content : ''
+      if (text) {
+        items.push({ type: 'message', role: 'assistant', content: text })
+      }
+      for (const toolCall of message.tool_calls ?? []) {
+        items.push({
+          type: 'function_call',
+          call_id: toolCall.id,
+          name: toolCall.function.name,
+          arguments: toolCall.function.arguments
+        })
+      }
+      continue
+    }
+    // user / system / developer 消息统一以消息项回传，支持多模态内容。
+    items.push({
+      type: 'message',
+      role: message.role,
+      content: toResponsesMessageContent(message.content)
+    })
+  }
+  return items
+}
+
+/**
+ * 将插件工具定义转为 OpenAI Responses API 的函数工具。
+ * @param tools 可选的工具列表
+ * @returns 函数工具数组；无工具时返回 undefined
+ */
+export function toResponsesTools(tools?: Tool[]): Record<string, unknown>[] | undefined {
+  if (!tools?.length) return undefined
+  return tools.map((tool) => ({
+    type: 'function',
+    name: tool.function?.name,
+    description: tool.function?.description,
+    parameters: tool.function?.parameters ?? { type: 'object', properties: {} },
+    // Responses API 要求 strict 字段，这里关闭严格校验以兼容中转站的自定义 schema。
+    strict: false
+  }))
+}
+
+/**
+ * 将 OpenAI Responses API 的输出项归一化为单轮回复结果。
+ * @param output Responses 返回的 output 项数组
+ * @returns 归一化的助手回复
+ */
+export function fromResponsesOutput(output: unknown): AssistantTurn {
+  let content = ''
+  let reasoningContent = ''
+  const toolCalls: ToolCall[] = []
+  // 输出项可能是文本消息、函数调用或推理项，按 type 分流后分别归一化。
+  for (const item of Array.isArray(output) ? output : []) {
+    const type = readString((item as Record<string, unknown>).type)
+    if (type === 'message') {
+      for (const part of toArray((item as Record<string, unknown>).content)) {
+        if (readString(part.type) === 'output_text') content += readString(part.text)
+      }
+    } else if (type === 'function_call') {
+      toolCalls.push({
+        id: readString((item as Record<string, unknown>).call_id),
+        type: 'function',
+        function: {
+          name: readString((item as Record<string, unknown>).name),
+          arguments: readString((item as Record<string, unknown>).arguments)
+        }
+      })
+    } else if (type === 'reasoning') {
+      // 推理项可能同时包含 summary 与 content 文本，全部汇总为 reasoning_content。
+      for (const part of toArray((item as Record<string, unknown>).summary)) {
+        if (readString(part.type) === 'summary_text') reasoningContent += readString(part.text)
+      }
+      for (const part of toArray((item as Record<string, unknown>).content)) {
+        if (readString(part.type) === 'reasoning_text') reasoningContent += readString(part.text)
+      }
+    }
+  }
+  return { content, reasoningContent: reasoningContent || undefined, toolCalls }
+}
+
+/**
+ * 将插件消息内容转为 Responses API 消息项的 content 字段。
+ * @param content 纯文本或多模态内容块
+ * @returns 字符串或 Responses 输入内容块数组
+ */
+function toResponsesMessageContent(
+  content: Message['content']
+): string | Record<string, unknown>[] {
+  if (typeof content === 'string') return content
+  if (!Array.isArray(content)) return typeof content === 'string' ? content : ''
+  const parts: Record<string, unknown>[] = []
+  for (const part of content) {
+    if (part.type === 'text') {
+      parts.push({ type: 'input_text', text: part.text })
+    } else if (part.type === 'image_url') {
+      parts.push({ type: 'input_image', image_url: part.image_url.url, detail: 'auto' })
+    }
+  }
+  return parts
+}
+
+/* ===================== Anthropic Messages API 转换 ===================== */
+
+interface AnthropicMessage {
+  role: 'user' | 'assistant'
+  content: string | AnthropicContentBlock[]
+}
+
+type AnthropicContentBlock =
+  | { type: 'text'; text: string }
+  | {
+      type: 'image'
+      source: { type: 'base64' | 'url'; media_type?: string; data?: string; url?: string }
+    }
+  | { type: 'tool_use'; id: string; name: string; input: unknown }
+  | { type: 'tool_result'; tool_use_id: string; content: string }
+  | { type: 'thinking'; thinking: string }
+
+interface AnthropicTool {
+  name: string
+  description: string
+  input_schema: Record<string, unknown>
+}
+
+/** Anthropic 消息序列与提取出的 system 指令。 */
+export interface AnthropicConversation {
+  system: string
+  messages: AnthropicMessage[]
+}
+
+/**
+ * 将插件消息列表转为 Anthropic 消息序列，并提取 system 指令。
+ * Anthropic 要求 user/assistant 严格交替，因此会合并连续同角色的消息。
+ * @param messages 插件维护的标准消息历史
+ * @returns 提取出的 system 文本与转换后的消息序列
+ */
+export function toAnthropicMessages(messages: Message[]): AnthropicConversation {
+  const systemParts: string[] = []
+  const turns: AnthropicMessage[] = []
+
+  for (const message of messages) {
+    // system 指令合并为顶层 system，不进入消息序列。
+    if (message.role === 'system') {
+      if (typeof message.content === 'string') systemParts.push(message.content)
+      continue
+    }
+    if (message.role === 'assistant') {
+      const blocks: AnthropicContentBlock[] = []
+      const text = typeof message.content === 'string' ? message.content : ''
+      if (text) blocks.push({ type: 'text', text })
+      // 助手发起的工具调用转为 tool_use 块，input 由 JSON 字符串解析为对象。
+      for (const toolCall of message.tool_calls ?? []) {
+        blocks.push({
+          type: 'tool_use',
+          id: toolCall.id,
+          name: toolCall.function.name,
+          input: safeParseJson(toolCall.function.arguments, {})
+        })
+      }
+      turns.push({ role: 'assistant', content: blocks })
+      continue
+    }
+    if (message.role === 'tool') {
+      // 工具结果归入 user 轮的 tool_result 块，匹配 Anthropic 的工具调用约定。
+      turns.push({
+        role: 'user',
+        content: [
+          {
+            type: 'tool_result',
+            tool_use_id: message.tool_call_id || '',
+            content: typeof message.content === 'string' ? message.content : ''
+          }
+        ]
+      })
+      continue
+    }
+    // user 消息：支持纯文本或多模态内容块。
+    turns.push({ role: 'user', content: toAnthropicUserContent(message.content) })
+  }
+
+  // 合并连续同角色消息，满足 Anthropic 严格交替要求。
+  const merged = mergeConsecutiveTurns(turns)
+  // Anthropic 要求首条消息为 user，缺失时补一条占位消息避免请求被拒。
+  if (merged.length === 0 || merged[0].role !== 'user') {
+    merged.unshift({ role: 'user', content: ' ' })
+  }
+  return { system: systemParts.join('\n\n').trim(), messages: merged }
+}
+
+/**
+ * 将插件工具定义转为 Anthropic 的工具定义。
+ * @param tools 可选的工具列表
+ * @returns Anthropic 工具数组；无工具时返回 undefined
+ */
+export function toAnthropicTools(tools?: Tool[]): AnthropicTool[] | undefined {
+  if (!tools?.length) return undefined
+  return tools.map((tool) => ({
+    name: tool.function?.name ?? '',
+    description: tool.function?.description ?? '',
+    input_schema: (tool.function?.parameters as Record<string, unknown>) ?? {
+      type: 'object',
+      properties: {}
+    }
+  }))
+}
+
+/**
+ * 将 Anthropic 返回的 content 块归一化为单轮回复结果。
+ * @param content Anthropic 响应的 content 数组
+ * @returns 归一化的助手回复
+ */
+export function fromAnthropicContent(content: unknown): AssistantTurn {
+  let textContent = ''
+  let reasoning = ''
+  const toolCalls: ToolCall[] = []
+  for (const block of Array.isArray(content) ? content : []) {
+    const type = readString((block as Record<string, unknown>).type)
+    if (type === 'text') {
+      textContent += readString((block as Record<string, unknown>).text)
+    } else if (type === 'thinking') {
+      // 扩展思考默认未启用，仅当模型或中转站返回 thinking 块时透传。
+      reasoning += readString((block as Record<string, unknown>).thinking)
+    } else if (type === 'tool_use') {
+      const input = (block as Record<string, unknown>).input
+      toolCalls.push({
+        id: readString((block as Record<string, unknown>).id),
+        type: 'function',
+        function: {
+          name: readString((block as Record<string, unknown>).name),
+          // Anthropic 的 input 是对象，统一序列化为 JSON 字符串以匹配标准 ToolCall。
+          arguments: typeof input === 'string' ? input : JSON.stringify(input ?? {})
+        }
+      })
+    }
+  }
+  return { content: textContent, reasoningContent: reasoning || undefined, toolCalls }
+}
+
+/**
+ * 将插件 user 消息内容转为 Anthropic 的 content 字段。
+ * @param content 纯文本或多模态内容块
+ * @returns 字符串或 Anthropic 内容块数组
+ */
+function toAnthropicUserContent(content: Message['content']): string | AnthropicContentBlock[] {
+  if (typeof content === 'string') return content
+  if (!Array.isArray(content)) return typeof content === 'string' ? content : ''
+  const blocks: AnthropicContentBlock[] = []
+  for (const part of content) {
+    const block = toAnthropicContentPart(part)
+    if (block) blocks.push(block)
+  }
+  return blocks
+}
+
+/**
+ * 将单个插件内容块转为 Anthropic 内容块。
+ * @param part 文本或图片内容块
+ * @returns Anthropic 内容块；无法识别时返回 null
+ */
+function toAnthropicContentPart(part: ContentPart): AnthropicContentBlock | null {
+  if (part.type === 'text') {
+    return { type: 'text', text: part.text }
+  }
+  if (part.type === 'image_url') {
+    return toAnthropicImage(part.image_url.url)
+  }
+  return null
+}
+
+/**
+ * 将图片 URL 转为 Anthropic 图片来源，支持 data URI 与 http(s) URL。
+ * @param url 图片地址
+ * @returns Anthropic 图片内容块；不支持的地址返回 null
+ */
+function toAnthropicImage(url: string): AnthropicContentBlock | null {
+  // data URI 形如 data:image/png;base64,XXXX，拆分为 base64 来源。
+  const match = /^data:([^;]+);base64,(.*)$/s.exec(url)
+  if (match) {
+    return {
+      type: 'image',
+      source: { type: 'base64', media_type: match[1], data: match[2] }
+    }
+  }
+  if (/^https?:\/\//.test(url)) {
+    return { type: 'image', source: { type: 'url', url } }
+  }
+  return null
+}
+
+/**
+ * 合并连续同角色的消息，确保满足 Anthropic 的角色交替要求。
+ * @param turns 原始消息序列
+ * @returns 合并后的消息序列
+ */
+function mergeConsecutiveTurns(turns: AnthropicMessage[]): AnthropicMessage[] {
+  const result: AnthropicMessage[] = []
+  for (const turn of turns) {
+    const last = result[result.length - 1]
+    if (last && last.role === turn.role) {
+      // 同角色：把两侧内容统一为数组后拼接，避免被接口拒绝。
+      last.content = concatContent(last.content, turn.content)
+    } else {
+      result.push({ role: turn.role, content: turn.content })
+    }
+  }
+  return result
+}
+
+/**
+ * 拼接两条 Anthropic 内容（字符串或块数组），结果统一为块数组。
+ * @param a 前一条内容
+ * @param b 后一条内容
+ * @returns 合并后的内容块数组
+ */
+function concatContent(
+  a: string | AnthropicContentBlock[],
+  b: string | AnthropicContentBlock[]
+): AnthropicContentBlock[] {
+  const toBlocks = (value: string | AnthropicContentBlock[]): AnthropicContentBlock[] =>
+    typeof value === 'string' ? (value ? [{ type: 'text', text: value }] : []) : value
+  return [...toBlocks(a), ...toBlocks(b)]
+}
+
+/**
+ * 安全解析 JSON 字符串，失败时返回兜底值。
+ * @param value 待解析的 JSON 字符串
+ * @param fallback 解析失败时的兜底值
+ * @returns 解析结果或兜底值
+ */
+function safeParseJson(value: string, fallback: unknown): unknown {
+  try {
+    return JSON.parse(value)
+  } catch {
+    return fallback
+  }
+}
+
+/**
+ * 从未知值中读取字符串，非字符串返回空串。
+ * @param value 待读取的值
+ * @returns 字符串值
+ */
+function readString(value: unknown): string {
+  return typeof value === 'string' ? value : ''
+}
+
+/**
+ * 将未知值转为可遍历的对象数组，非数组返回空数组。
+ * @param value 待转换的值
+ * @returns 对象数组
+ */
+function toArray(value: unknown): Record<string, unknown>[] {
+  return Array.isArray(value) ? (value as Record<string, unknown>[]) : []
+}

--- a/src/main/core/aiProviderService.ts
+++ b/src/main/core/aiProviderService.ts
@@ -4,7 +4,9 @@ import databaseAPI from '../api/shared/database.js'
 import { HOST_STORAGE_KEYS } from '../../shared/storageKeys.js'
 import {
   AI_PROVIDER_STORE_VERSION,
+  DEFAULT_AI_API_FORMAT,
   isAiProviderStore,
+  normalizeAiApiFormat,
   normalizeAiApiUrl,
   type AiModelChoice,
   type AiProvider,
@@ -82,6 +84,7 @@ export function migrateLegacyAiModels(
         name: sequence === 1 ? baseName : `${baseName} ${sequence}`,
         apiUrl,
         apiKey,
+        apiFormat: DEFAULT_AI_API_FORMAT,
         enabled: true,
         selectedModels: []
       }
@@ -166,6 +169,7 @@ class AiProviderService {
       name: input.name.trim(),
       apiUrl: normalizeAiApiUrl(input.apiUrl),
       apiKey: input.apiKey.trim(),
+      apiFormat: normalizeAiApiFormat(input.apiFormat),
       enabled: true,
       selectedModels: this.buildSelectedModels(input, [])
     }
@@ -216,6 +220,7 @@ class AiProviderService {
       name: nextName,
       apiUrl: normalizeAiApiUrl(input.apiUrl),
       apiKey: input.apiKey.trim(),
+      apiFormat: normalizeAiApiFormat(input.apiFormat),
       enabled: previous.enabled,
       selectedModels: nextModels
     }
@@ -454,6 +459,13 @@ class AiProviderService {
       // 旧版供应商没有开启状态，升级时保持原有可用行为。
       if (typeof provider.enabled !== 'boolean') {
         provider.enabled = true
+        changed = true
+      }
+
+      // 历史供应商未保存接口格式，升级时回退为默认的 OpenAI Chat Completions。
+      const normalizedFormat = normalizeAiApiFormat(provider.apiFormat)
+      if (provider.apiFormat !== normalizedFormat) {
+        provider.apiFormat = normalizedFormat
         changed = true
       }
 

--- a/src/shared/aiProviderShared.ts
+++ b/src/shared/aiProviderShared.ts
@@ -1,6 +1,19 @@
 /** AI 供应商配置的当前存储版本。 */
 export const AI_PROVIDER_STORE_VERSION = 2 as const
 
+/** AI 供应商采用的接口协议格式。 */
+export type AiApiFormat = 'openai-chat' | 'anthropic-messages' | 'openai-responses'
+
+/** 新增或历史数据缺失时使用的默认接口格式。 */
+export const DEFAULT_AI_API_FORMAT: AiApiFormat = 'openai-chat'
+
+/** 供应商接口格式选项，供设置界面复用。 */
+export const AI_API_FORMAT_OPTIONS: ReadonlyArray<{ value: AiApiFormat; label: string }> = [
+  { value: 'openai-chat', label: 'OpenAI Chat Completions' },
+  { value: 'anthropic-messages', label: 'Anthropic Messages' },
+  { value: 'openai-responses', label: 'OpenAI Responses API' }
+]
+
 /** 旧版按单个模型保存的配置。 */
 export interface LegacyAiModel {
   id: string
@@ -31,6 +44,8 @@ export interface AiProvider {
   name: string
   apiUrl: string
   apiKey: string
+  /** 供应商采用的接口格式。 */
+  apiFormat: AiApiFormat
   /** 是否允许插件发现和调用该供应商的模型。 */
   enabled: boolean
   selectedModels: AiProviderModel[]
@@ -56,6 +71,8 @@ export interface AiProviderInput {
   name: string
   apiUrl: string
   apiKey: string
+  /** 供应商采用的接口格式；缺省时回退到默认格式。 */
+  apiFormat?: AiApiFormat
   selectedModels: AiProviderModelInput[]
 }
 
@@ -105,4 +122,16 @@ export function isAiProviderStore(value: unknown): value is AiProviderStore {
  */
 export function normalizeAiApiUrl(apiUrl: string): string {
   return apiUrl.trim().replace(/\/+$/, '')
+}
+
+/**
+ * 将任意值归一化为合法的接口格式，非法或缺失时回退到默认格式。
+ * @param value 待归一化的接口格式
+ * @returns 合法的接口格式
+ */
+export function normalizeAiApiFormat(value: unknown): AiApiFormat {
+  for (const option of AI_API_FORMAT_OPTIONS) {
+    if (value === option.value) return option.value
+  }
+  return DEFAULT_AI_API_FORMAT
 }

--- a/tests/main/aiProtocol/converters.test.ts
+++ b/tests/main/aiProtocol/converters.test.ts
@@ -1,0 +1,292 @@
+import { describe, expect, it } from 'vitest'
+import type { ContentPart, Tool } from '../../../src/main/api/plugin/ai'
+import {
+  fromAnthropicContent,
+  fromResponsesOutput,
+  toAnthropicMessages,
+  toAnthropicTools,
+  toResponsesInput,
+  toResponsesTools
+} from '../../../src/main/api/plugin/aiProtocol/converters'
+
+describe('aiProtocol converters', () => {
+  describe('toAnthropicMessages', () => {
+    it('extracts system instructions and keeps alternating roles', () => {
+      const { system, messages } = toAnthropicMessages([
+        { role: 'system', content: 'You are helpful' },
+        { role: 'user', content: 'hi' },
+        { role: 'assistant', content: 'hello' }
+      ])
+
+      expect(system).toBe('You are helpful')
+      expect(messages).toEqual([
+        { role: 'user', content: 'hi' },
+        { role: 'assistant', content: [{ type: 'text', text: 'hello' }] }
+      ])
+    })
+
+    it('maps assistant tool calls to tool_use blocks and tool results to tool_result blocks', () => {
+      const { system, messages } = toAnthropicMessages([
+        { role: 'user', content: 'use the tool' },
+        {
+          role: 'assistant',
+          content: '',
+          tool_calls: [
+            {
+              id: 'call_1',
+              type: 'function',
+              function: { name: 'getWeather', arguments: '{"city":"NY"}' }
+            }
+          ]
+        },
+        { role: 'tool', content: '{"temp":72}', tool_call_id: 'call_1' },
+        { role: 'assistant', content: 'The temp is 72' }
+      ])
+
+      expect(system).toBe('')
+      expect(messages[0]).toEqual({ role: 'user', content: 'use the tool' })
+      // 助手无文本时仅发出 tool_use 块。
+      expect(messages[1]).toEqual({
+        role: 'assistant',
+        content: [{ type: 'tool_use', id: 'call_1', name: 'getWeather', input: { city: 'NY' } }]
+      })
+      // 工具结果归入 user 轮。
+      expect(messages[2]).toEqual({
+        role: 'user',
+        content: [{ type: 'tool_result', tool_use_id: 'call_1', content: '{"temp":72}' }]
+      })
+      expect(messages[3]).toEqual({
+        role: 'assistant',
+        content: [{ type: 'text', text: 'The temp is 72' }]
+      })
+    })
+
+    it('merges consecutive same-role messages to satisfy strict alternation', () => {
+      const { messages } = toAnthropicMessages([
+        { role: 'user', content: 'a' },
+        { role: 'user', content: 'b' }
+      ])
+
+      expect(messages).toEqual([
+        {
+          role: 'user',
+          content: [
+            { type: 'text', text: 'a' },
+            { type: 'text', text: 'b' }
+          ]
+        }
+      ])
+    })
+
+    it('maps multimodal user content with a base64 data URI image', () => {
+      const content: ContentPart[] = [
+        { type: 'text', text: 'look' },
+        { type: 'image_url', image_url: { url: 'data:image/png;base64,ABC=' } }
+      ]
+      const { messages } = toAnthropicMessages([{ role: 'user', content }])
+
+      expect(messages[0]).toEqual({
+        role: 'user',
+        content: [
+          { type: 'text', text: 'look' },
+          {
+            type: 'image',
+            source: { type: 'base64', media_type: 'image/png', data: 'ABC=' }
+          }
+        ]
+      })
+    })
+
+    it('prepends a placeholder user message when the conversation does not start with user', () => {
+      const { messages } = toAnthropicMessages([{ role: 'assistant', content: 'hi' }])
+
+      expect(messages[0].role).toBe('user')
+      expect(messages[1]).toEqual({
+        role: 'assistant',
+        content: [{ type: 'text', text: 'hi' }]
+      })
+    })
+  })
+
+  describe('fromAnthropicContent', () => {
+    it('normalizes text, thinking and tool_use blocks', () => {
+      const turn = fromAnthropicContent([
+        { type: 'text', text: 'Hi' },
+        { type: 'thinking', thinking: 'reasoning' },
+        { type: 'tool_use', id: 't1', name: 'do', input: { x: 1 } }
+      ])
+
+      expect(turn.content).toBe('Hi')
+      expect(turn.reasoningContent).toBe('reasoning')
+      expect(turn.toolCalls).toEqual([
+        {
+          id: 't1',
+          type: 'function',
+          function: { name: 'do', arguments: '{"x":1}' }
+        }
+      ])
+    })
+  })
+
+  describe('toAnthropicTools', () => {
+    it('converts plugin tool definitions to Anthropic tools', () => {
+      const tools: Tool[] = [
+        {
+          type: 'function',
+          function: {
+            name: 'do',
+            description: 'does it',
+            parameters: { type: 'object', properties: {} }
+          }
+        }
+      ]
+
+      expect(toAnthropicTools(tools)).toEqual([
+        {
+          name: 'do',
+          description: 'does it',
+          input_schema: { type: 'object', properties: {} }
+        }
+      ])
+    })
+
+    it('returns undefined when there are no tools', () => {
+      expect(toAnthropicTools()).toBeUndefined()
+    })
+  })
+
+  describe('toResponsesInput', () => {
+    it('maps a tool-call round trip to function_call and function_call_output items', () => {
+      const items = toResponsesInput([
+        { role: 'user', content: 'use the tool' },
+        {
+          role: 'assistant',
+          content: '',
+          tool_calls: [
+            {
+              id: 'call_1',
+              type: 'function',
+              function: { name: 'getWeather', arguments: '{"city":"NY"}' }
+            }
+          ]
+        },
+        { role: 'tool', content: '{"temp":72}', tool_call_id: 'call_1' }
+      ])
+
+      // 助手无文本时不发出消息项，仅补充函数调用项。
+      expect(items).toEqual([
+        { type: 'message', role: 'user', content: 'use the tool' },
+        {
+          type: 'function_call',
+          call_id: 'call_1',
+          name: 'getWeather',
+          arguments: '{"city":"NY"}'
+        },
+        {
+          type: 'function_call_output',
+          call_id: 'call_1',
+          output: '{"temp":72}'
+        }
+      ])
+    })
+
+    it('emits an assistant message item followed by function_call items when text is present', () => {
+      const items = toResponsesInput([
+        {
+          role: 'assistant',
+          content: 'thinking',
+          tool_calls: [
+            {
+              id: 'c1',
+              type: 'function',
+              function: { name: 'f', arguments: '{}' }
+            }
+          ]
+        }
+      ])
+
+      expect(items).toEqual([
+        { type: 'message', role: 'assistant', content: 'thinking' },
+        { type: 'function_call', call_id: 'c1', name: 'f', arguments: '{}' }
+      ])
+    })
+
+    it('maps multimodal user content to Responses input parts', () => {
+      const content: ContentPart[] = [
+        { type: 'text', text: 'hi' },
+        { type: 'image_url', image_url: { url: 'https://x/y.png' } }
+      ]
+      const items = toResponsesInput([{ role: 'user', content }])
+
+      expect(items).toEqual([
+        {
+          type: 'message',
+          role: 'user',
+          content: [
+            { type: 'input_text', text: 'hi' },
+            { type: 'input_image', image_url: 'https://x/y.png', detail: 'auto' }
+          ]
+        }
+      ])
+    })
+  })
+
+  describe('fromResponsesOutput', () => {
+    it('normalizes message, function_call and reasoning output items', () => {
+      const turn = fromResponsesOutput([
+        { type: 'message', content: [{ type: 'output_text', text: 'Hello' }] },
+        { type: 'function_call', call_id: 'c1', name: 'f', arguments: '{"a":1}' },
+        {
+          type: 'reasoning',
+          summary: [{ type: 'summary_text', text: 'sum' }],
+          content: [{ type: 'reasoning_text', text: 'r' }]
+        }
+      ])
+
+      expect(turn.content).toBe('Hello')
+      expect(turn.reasoningContent).toBe('sumr')
+      expect(turn.toolCalls).toEqual([
+        {
+          id: 'c1',
+          type: 'function',
+          function: { name: 'f', arguments: '{"a":1}' }
+        }
+      ])
+    })
+
+    it('returns an empty turn when the output is missing', () => {
+      const turn = fromResponsesOutput(undefined)
+      expect(turn.content).toBe('')
+      expect(turn.toolCalls).toEqual([])
+    })
+  })
+
+  describe('toResponsesTools', () => {
+    it('converts plugin tools to Responses function tools with strict disabled', () => {
+      const tools: Tool[] = [
+        {
+          type: 'function',
+          function: {
+            name: 'do',
+            description: 'does it',
+            parameters: { type: 'object', properties: {} }
+          }
+        }
+      ]
+
+      expect(toResponsesTools(tools)).toEqual([
+        {
+          type: 'function',
+          name: 'do',
+          description: 'does it',
+          parameters: { type: 'object', properties: {} },
+          strict: false
+        }
+      ])
+    })
+
+    it('returns undefined when there are no tools', () => {
+      expect(toResponsesTools()).toBeUndefined()
+    })
+  })
+})

--- a/tests/main/aiProviderService.test.ts
+++ b/tests/main/aiProviderService.test.ts
@@ -71,6 +71,7 @@ describe('aiProviderService', () => {
       'gpt-4o',
       'gpt-4o-mini'
     ])
+    expect(migrated.providers.every((provider) => provider.apiFormat === 'openai-chat')).toBe(true)
     expect('defaultModelRef' in migrated).toBe(false)
   })
 
@@ -226,6 +227,7 @@ describe('aiProviderService', () => {
     ])
     expect(stored.providers[1].selectedModels[0].aliases).toEqual(['中转站 - model-a'])
     expect(stored.providers.every((provider) => provider.enabled)).toBe(true)
+    expect(stored.providers.every((provider) => provider.apiFormat === 'openai-chat')).toBe(true)
     expect('defaultModelRef' in stored).toBe(false)
     expect('label' in stored.providers[0].selectedModels[0]).toBe(false)
     expect('label' in stored.providers[1].selectedModels[0]).toBe(false)
@@ -240,5 +242,64 @@ describe('aiProviderService', () => {
     await expect(
       aiProviderService.fetchRemoteModels('https://example.com/v1/', 'secret')
     ).resolves.toEqual([{ id: 'model-a' }, { id: 'model-z' }])
+  })
+
+  it('persists the api format and defaults legacy values to OpenAI Chat Completions', () => {
+    // 未指定接口格式的新建供应商回退为默认格式。
+    expect(
+      aiProviderService.addProvider({
+        name: '默认供应商',
+        apiUrl: 'https://one.example/v1',
+        apiKey: 'key-one',
+        selectedModels: [{ modelId: 'model-a' }]
+      }).success
+    ).toBe(true)
+    expect(stored!.providers[0].apiFormat).toBe('openai-chat')
+
+    // 显式指定 Anthropic Messages 的供应商原样保存。
+    expect(
+      aiProviderService.addProvider({
+        name: 'Anthropic 供应商',
+        apiUrl: 'https://two.example/v1',
+        apiKey: 'key-two',
+        apiFormat: 'anthropic-messages',
+        selectedModels: [{ modelId: 'model-a' }]
+      }).success
+    ).toBe(true)
+    expect(stored!.providers[1].apiFormat).toBe('anthropic-messages')
+
+    // 更新时可以切换为 OpenAI Responses API。
+    const provider = stored!.providers[1]
+    expect(
+      aiProviderService.updateProvider({
+        id: provider.id,
+        name: provider.name,
+        apiUrl: provider.apiUrl,
+        apiKey: provider.apiKey,
+        apiFormat: 'openai-responses',
+        selectedModels: [{ modelId: 'model-a' }]
+      }).success
+    ).toBe(true)
+    expect(stored!.providers[1].apiFormat).toBe('openai-responses')
+
+    // 历史供应商保存了非法接口格式时，读取时回退为默认的 OpenAI Chat Completions。
+    stored = {
+      version: 2,
+      providers: [
+        {
+          id: provider.id,
+          name: provider.name,
+          apiUrl: provider.apiUrl,
+          apiKey: provider.apiKey,
+          apiFormat: 'bogus-format',
+          enabled: true,
+          selectedModels: [{ ref: 'ref-a', modelId: 'model-a' }]
+        }
+      ]
+    } as AiProviderStore
+
+    expect(aiProviderService.getModelChoices()[0].value).toBe('ref-a')
+    expect(stored!.providers[0].apiFormat).toBe('openai-chat')
+    expect(mockDbPut).toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
- 新增 AiApiFormat（openai-chat / anthropic-messages / openai-responses），持久化到供应商配置并支持历史数据迁移归一化
- 抽象 aiProtocol 适配器层（adapters/converters），重构插件 AI 调用流程，替换直接依赖 OpenAI SDK 的实现
- 设置插件新增 Select 组件与 useOverlayPosition 工具，AI 模型编辑器支持选择接口格式
- 补充 aiProtocol converters 与 aiProviderService 接口格式归一化/迁移测试