### PR TITLE
修复 Star 历史图表并切换至新域名

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ pnpm build:unpack       # 打包但不生成安装包（调试用）
 
 ## ⭐ Star 历史
 
-[![Star History Chart](https://api.star-history.com/svg?repos=lzx8589561/ZTools&type=Date)](https://star-history.com/#lzx8589561/ZTools&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=lzx8589561/ZTools&type=Date)](https://star-history.dera.page/#lzx8589561/ZTools&Date)
 
 ---
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -239,7 +239,7 @@ This project is licensed under the [MIT License](./LICENSE).
 
 ## ⭐ Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=lzx8589561/ZTools&type=Date)](https://star-history.com/#lzx8589561/ZTools&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=lzx8589561/ZTools&type=Date)](https://star-history.dera.page/#lzx8589561/ZTools&Date)
 
 ---
 


### PR DESCRIPTION
当前 README 中的 Star History 图表因 GitHub stargazer API 限制而无法正常展示。

本次变更将图表链接切换到可用的数据源（star-history.dera.page），确保 Star 历史图表能够重新正常显示。图表徽章部分保持不变，仍使用原 star-history.com。