### PR TITLE
feat: 支持 Esc 直接隐藏窗口并回到上一应用

### DIFF
--- a/internal-plugins/setting/src/components/common/Dropdown/Dropdown.ts
+++ b/internal-plugins/setting/src/components/common/Dropdown/Dropdown.ts
@@ -9,6 +9,7 @@ export interface DropdownProps {
   modelValue: string | number
   options: DropdownOption[]
   placeholder?: string
+  disabled?: boolean
 }
 
 export interface DropdownEmits {

--- a/internal-plugins/setting/src/components/common/Dropdown/Dropdown.vue
+++ b/internal-plugins/setting/src/components/common/Dropdown/Dropdown.vue
@@ -3,7 +3,8 @@ import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
 import { DropdownEmits, DropdownOption, DropdownProps } from './Dropdown'
 
 const props = withDefaults(defineProps<DropdownProps>(), {
-  placeholder: '请选择'
+  placeholder: '请选择',
+  disabled: false
 })
 
 const emit = defineEmits<DropdownEmits>()
@@ -19,6 +20,9 @@ const selectedLabel = computed(() => {
 
 // 切换下拉菜单
 function toggleDropdown(): void {
+  if (props.disabled) {
+    return
+  }
   isOpen.value = !isOpen.value
 }
 
@@ -45,8 +49,8 @@ onBeforeUnmount(() => {
 })
 </script>
 <template>
-  <div ref="dropdownRef" class="dropdown" :class="{ open: isOpen }">
-    <button class="dropdown-trigger" @click="toggleDropdown">
+  <div ref="dropdownRef" class="dropdown" :class="{ open: isOpen, disabled: disabled }">
+    <button class="dropdown-trigger" :disabled="disabled" @click="toggleDropdown">
       <span class="dropdown-value">{{ selectedLabel }}</span>
       <svg
         class="dropdown-arrow"
@@ -125,7 +129,12 @@ onBeforeUnmount(() => {
   user-select: none;
 }
 
-.dropdown-trigger:hover {
+.dropdown-trigger:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.dropdown-trigger:hover:not(:disabled) {
   background: var(--hover-bg);
   border-color: color-mix(in srgb, var(--primary-color), black 15%);
 }

--- a/internal-plugins/setting/src/views/GeneralSetting/GeneralSetting.vue
+++ b/internal-plugins/setting/src/views/GeneralSetting/GeneralSetting.vue
@@ -196,6 +196,7 @@ const spaceOpenCommand = ref(false)
 
 // Esc 直接隐藏窗口（默认关，保持上游 Esc 回搜索）
 const escHideWindow = ref(false)
+const autoBackToSearchBeforeEscHide = ref<AutoBackToSearchOption | null>(null)
 
 // 悬浮球双击目标指令
 const floatingBallDoubleClickCommand = ref('')
@@ -570,6 +571,16 @@ async function handleAutoBackToSearchChange(): Promise<void> {
 // 处理 Esc 直接隐藏窗口变化
 async function handleEscHideWindowChange(): Promise<void> {
   try {
+    if (escHideWindow.value) {
+      autoBackToSearchBeforeEscHide.value = autoBackToSearch.value
+      if (autoBackToSearch.value !== 'immediately') {
+        autoBackToSearch.value = 'immediately'
+        await window.ztools.internal.updateAutoBackToSearch('immediately')
+      }
+    } else if (autoBackToSearchBeforeEscHide.value) {
+      autoBackToSearch.value = autoBackToSearchBeforeEscHide.value
+      await window.ztools.internal.updateAutoBackToSearch(autoBackToSearch.value)
+    }
     await saveSettings()
     console.log('Esc 直接隐藏窗口已更新:', escHideWindow.value)
   } catch (error) {
@@ -1330,6 +1341,22 @@ async function loadSettings(): Promise<void> {
       // 空格打开指令
       spaceOpenCommand.value = data.spaceOpenCommand ?? false
       escHideWindow.value = data.escHideWindow ?? false
+      autoBackToSearchBeforeEscHide.value = data.autoBackToSearchBeforeEscHide ?? null
+      if (escHideWindow.value) {
+        let shouldPersistEscHideConstraint = false
+        if (autoBackToSearchBeforeEscHide.value == null) {
+          autoBackToSearchBeforeEscHide.value = autoBackToSearch.value
+          shouldPersistEscHideConstraint = true
+        }
+        if (autoBackToSearch.value !== 'immediately') {
+          autoBackToSearch.value = 'immediately'
+          await window.ztools.internal.updateAutoBackToSearch('immediately')
+          shouldPersistEscHideConstraint = true
+        }
+        if (shouldPersistEscHideConstraint) {
+          await saveSettings()
+        }
+      }
       // 悬浮球双击目标指令
       floatingBallDoubleClickCommand.value = data.floatingBallDoubleClickCommand ?? ''
 
@@ -1421,6 +1448,7 @@ async function saveSettings(): Promise<void> {
       tabTargetCommand: tabTargetCommand.value,
       spaceOpenCommand: spaceOpenCommand.value,
       escHideWindow: escHideWindow.value,
+      autoBackToSearchBeforeEscHide: autoBackToSearchBeforeEscHide.value,
       floatingBallDoubleClickCommand: floatingBallDoubleClickCommand.value,
       floatingBallEnabled: floatingBallEnabled.value,
       floatingBallLetter: floatingBallLetter.value,
@@ -2115,6 +2143,7 @@ onUnmounted(() => {
           <Dropdown
             v-model="autoBackToSearch"
             :options="autoBackToSearchOptions"
+            :disabled="escHideWindow"
             @change="handleAutoBackToSearchChange"
           />
         </div>

--- a/internal-plugins/setting/src/views/GeneralSetting/GeneralSetting.vue
+++ b/internal-plugins/setting/src/views/GeneralSetting/GeneralSetting.vue
@@ -194,6 +194,9 @@ const tabKeyFunction = ref<'navigate' | 'target-command'>('navigate')
 // 空格打开指令
 const spaceOpenCommand = ref(false)
 
+// Esc 直接隐藏窗口（默认关，保持上游 Esc 回搜索）
+const escHideWindow = ref(false)
+
 // 悬浮球双击目标指令
 const floatingBallDoubleClickCommand = ref('')
 
@@ -561,6 +564,16 @@ async function handleAutoBackToSearchChange(): Promise<void> {
     console.log('自动返回搜索配置已更新:', autoBackToSearch.value)
   } catch (error) {
     console.error('保存自动返回搜索配置失败:', error)
+  }
+}
+
+// 处理 Esc 直接隐藏窗口变化
+async function handleEscHideWindowChange(): Promise<void> {
+  try {
+    await saveSettings()
+    console.log('Esc 直接隐藏窗口已更新:', escHideWindow.value)
+  } catch (error) {
+    console.error('保存 Esc 直接隐藏窗口失败:', error)
   }
 }
 
@@ -1316,6 +1329,7 @@ async function loadSettings(): Promise<void> {
       tabTargetCommand.value = data.tabTargetCommand ?? ''
       // 空格打开指令
       spaceOpenCommand.value = data.spaceOpenCommand ?? false
+      escHideWindow.value = data.escHideWindow ?? false
       // 悬浮球双击目标指令
       floatingBallDoubleClickCommand.value = data.floatingBallDoubleClickCommand ?? ''
 
@@ -1406,6 +1420,7 @@ async function saveSettings(): Promise<void> {
       tabKeyFunction: tabKeyFunction.value,
       tabTargetCommand: tabTargetCommand.value,
       spaceOpenCommand: spaceOpenCommand.value,
+      escHideWindow: escHideWindow.value,
       floatingBallDoubleClickCommand: floatingBallDoubleClickCommand.value,
       floatingBallEnabled: floatingBallEnabled.value,
       floatingBallLetter: floatingBallLetter.value,
@@ -2102,6 +2117,19 @@ onUnmounted(() => {
             :options="autoBackToSearchOptions"
             @change="handleAutoBackToSearchChange"
           />
+        </div>
+      </div>
+
+      <div class="setting-item">
+        <div class="setting-label">
+          <span>Esc 直接隐藏窗口</span>
+          <span class="setting-desc">按下 Esc 不返回搜索界面，直接隐藏 ZTools 并回到上一应用</span>
+        </div>
+        <div class="setting-control">
+          <label class="toggle">
+            <input v-model="escHideWindow" type="checkbox" @change="handleEscHideWindowChange" />
+            <span class="toggle-slider"></span>
+          </label>
         </div>
       </div>
 

--- a/src/main/api/plugin/ui.ts
+++ b/src/main/api/plugin/ui.ts
@@ -70,6 +70,12 @@ export class PluginUIAPI {
         return
       }
 
+      // 开：直接藏窗回上一应用，不走 hidePluginView / notifyBackToSearch
+      if (settings.escHideWindow) {
+        windowManager.hideWindow(true, true)
+        return
+      }
+
       if (this.pluginManager && typeof this.pluginManager.handlePluginEsc === 'function') {
         this.pluginManager.handlePluginEsc()
       }

--- a/src/main/api/renderer/window.ts
+++ b/src/main/api/renderer/window.ts
@@ -20,7 +20,9 @@ export class WindowAPI {
   }
 
   private setupIPC(): void {
-    ipcMain.on('hide-window', () => this.hideWindow())
+    ipcMain.on('hide-window', (_event, skipAutoBackToSearch?: boolean) =>
+      this.hideWindow(true, skipAutoBackToSearch)
+    )
     ipcMain.on('resize-window', (_event, height: number) => this.resizeWindow(height))
     ipcMain.on('update-launch-context', (_event, context: any) => this.updateLaunchContext(context))
     ipcMain.handle('get-window-position', () => this.getWindowPosition())
@@ -83,8 +85,11 @@ export class WindowAPI {
     })
   }
 
-  private hideWindow(isRestorePreWindow: boolean = true): void {
-    windowManager.hideWindow(isRestorePreWindow)
+  private hideWindow(
+    isRestorePreWindow: boolean = true,
+    skipAutoBackToSearch: boolean = false
+  ): void {
+    windowManager.hideWindow(isRestorePreWindow, skipAutoBackToSearch)
   }
 
   public resizeWindow(height: number): void {

--- a/src/main/managers/windowManager.ts
+++ b/src/main/managers/windowManager.ts
@@ -786,14 +786,8 @@ class WindowManager {
     // 判断窗口是否聚焦显示
     // 修复：同时检查聚焦和可见状态，避免alert弹窗后判断错误
     if (isFocused && isVisible) {
-      // 窗口已显示且聚焦 → 隐藏
-
-      // 记录当前的焦点状态（在隐藏之前）
-      this.recordFocusState()
-
-      this.mainWindow.blur()
-      this.mainWindow.hide()
-      this.restorePreviousWindow()
+      // 窗口已显示且聚焦 → 隐藏（macOS 走 app.hide，不是 win.hide/minimize）
+      this.hideWindow(true)
     } else {
       // 窗口已隐藏或失焦 → 显示并强制激活
       // 但如果是刚刚因为 blur 事件隐藏的（点击托盘图标导致失焦），
@@ -966,6 +960,11 @@ class WindowManager {
    */
   public showWindow(): void {
     if (!this.mainWindow) return
+
+    // app.hide() 之后必须 app.show() 才能再唤出；与 hide 成对，不抢占其它 App 的搜索框逻辑。
+    if (platform.isMacOS && typeof app.isHidden === 'function' && app.isHidden()) {
+      app.show()
+    }
 
     // 开始恢复焦点流程，防止 focus 事件监听器修改 lastFocusTarget
     this.isRestoringFocus = true

--- a/src/main/managers/windowManager.ts
+++ b/src/main/managers/windowManager.ts
@@ -1001,8 +1001,8 @@ class WindowManager {
   /**
    * 隐藏窗口
    */
-  public hideWindow(_restoreFocus: boolean = true): void {
-    console.log('[Window] 隐藏窗口', _restoreFocus)
+  public hideWindow(_restoreFocus: boolean = true, skipAutoBackToSearch: boolean = false): void {
+    console.log('[Window] 隐藏窗口', _restoreFocus, skipAutoBackToSearch)
 
     // 记录当前的焦点状态（在隐藏之前）
     this.recordFocusState()
@@ -1012,8 +1012,10 @@ class WindowManager {
       this.restorePreviousWindow()
     }
 
-    // 启动自动返回搜索定时器
-    this.startAutoBackToSearchTimer()
+    // Esc 直接藏窗时跳过，避免后台仍卸插件回搜索
+    if (!skipAutoBackToSearch) {
+      this.startAutoBackToSearchTimer()
+    }
   }
 
   public withBlurHideSuppressed<T>(

--- a/src/main/managers/windowManager.ts
+++ b/src/main/managers/windowManager.ts
@@ -999,7 +999,10 @@ class WindowManager {
   }
 
   /**
-   * 隐藏窗口
+   * 隐藏窗口。
+   * macOS 且需要还焦点时走系统级 Hide Application（app.hide / 等价 Cmd+H），
+   * 不要 win.hide / minimize，也不要再叠 restorePreviousWindow。
+   * Windows / Linux 仍 hide BrowserWindow 后再 restorePreviousWindow。
    */
   public hideWindow(_restoreFocus: boolean = true, skipAutoBackToSearch: boolean = false): void {
     console.log('[Window] 隐藏窗口', _restoreFocus, skipAutoBackToSearch)
@@ -1007,9 +1010,13 @@ class WindowManager {
     // 记录当前的焦点状态（在隐藏之前）
     this.recordFocusState()
 
-    this.mainWindow?.hide()
-    if (_restoreFocus) {
-      this.restorePreviousWindow()
+    if (platform.isMacOS && _restoreFocus) {
+      app.hide()
+    } else {
+      this.mainWindow?.hide()
+      if (_restoreFocus) {
+        this.restorePreviousWindow()
+      }
     }
 
     // Esc 直接藏窗时跳过，避免后台仍卸插件回搜索

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -53,7 +53,8 @@ const api = {
   }) => ipcRenderer.invoke('launch', options),
   launchAsAdmin: (appPath: string, name?: string) =>
     ipcRenderer.invoke('launch-as-admin', appPath, name),
-  hideWindow: () => ipcRenderer.send('hide-window'),
+  hideWindow: (skipAutoBackToSearch?: boolean) =>
+    ipcRenderer.send('hide-window', skipAutoBackToSearch),
   resizeWindow: (height: number) => ipcRenderer.send('resize-window', height),
   updateLaunchContext: (context: {
     searchQuery: string
@@ -567,7 +568,7 @@ declare global {
         cmdType?: string
         confirmDialog?: any
       }) => Promise<void>
-      hideWindow: () => void
+      hideWindow: (skipAutoBackToSearch?: boolean) => void
       resizeWindow: (height: number) => void
       updateLaunchContext: (context: {
         searchQuery: string

--- a/src/renderer/src/App.vue
+++ b/src/renderer/src/App.vue
@@ -510,6 +510,22 @@ async function handleKeydown(event: KeyboardEvent): Promise<void> {
     event.preventDefault()
 
     if (currentView.value === ViewMode.Plugin) {
+      if (
+        searchQuery.value.trim() ||
+        pastedImageData.value ||
+        pastedFilesData.value ||
+        pastedTextData.value
+      ) {
+        console.log('[PluginExit] ESC 触发分步退出逻辑')
+        handlePluginStepExit()
+        return
+      }
+      const settings = (await window.ztools.dbGet('settings-general')) || {}
+      if (settings.escHideWindow) {
+        console.log('[PluginExit] ESC 直接隐藏窗口')
+        window.ztools.hideWindow(true)
+        return
+      }
       console.log('[PluginExit] ESC 触发分步退出逻辑')
       handlePluginStepExit()
       return

--- a/src/renderer/src/env.d.ts
+++ b/src/renderer/src/env.d.ts
@@ -84,7 +84,7 @@ declare global {
         confirmDialog?: any // 确认对话框配置
       }) => Promise<any>
       launchAsAdmin: (appPath: string, name?: string) => Promise<void>
-      hideWindow: () => void
+      hideWindow: (skipAutoBackToSearch?: boolean) => void
       resizeWindow: (height: number) => void
       updateLaunchContext: (context: {
         searchQuery: string

--- a/tests/main/windowManagerMacActivation.test.ts
+++ b/tests/main/windowManagerMacActivation.test.ts
@@ -5,6 +5,8 @@ type MockHandler = (...args: any[]) => void
 const mocks = vi.hoisted(() => {
   const appFocus = vi.fn()
   const appHide = vi.fn()
+  const appShow = vi.fn()
+  const appIsHidden = vi.fn(() => false)
   const dbGet = vi.fn()
   const clipboardGetCurrentWindow = vi.fn()
   const clipboardActivateApp = vi.fn()
@@ -64,6 +66,8 @@ const mocks = vi.hoisted(() => {
   return {
     appFocus,
     appHide,
+    appShow,
+    appIsHidden,
     dbGet,
     clipboardGetCurrentWindow,
     clipboardActivateApp,
@@ -85,6 +89,8 @@ vi.mock('electron', () => ({
     getAppPath: vi.fn(() => '/tmp/ztools'),
     focus: mocks.appFocus,
     hide: mocks.appHide,
+    show: mocks.appShow,
+    isHidden: mocks.appIsHidden,
     dock: {
       show: vi.fn(),
       hide: vi.fn()
@@ -202,6 +208,7 @@ describe('windowManager macOS activation', () => {
     mocks.dbGet.mockReturnValue(null)
     mocks.clipboardGetCurrentWindow.mockReturnValue(null)
     mocks.clipboardActivateApp.mockReturnValue(true)
+    mocks.appIsHidden.mockReturnValue(false)
     mocks.latestWindow.current = null
   })
 
@@ -267,5 +274,28 @@ describe('windowManager macOS activation', () => {
     expect(mocks.appHide).not.toHaveBeenCalled()
     expect(mocks.latestWindow.current.hide).toHaveBeenCalledTimes(1)
     expect(mocks.clipboardActivateApp).not.toHaveBeenCalled()
+  })
+
+  it('after app.hide, showWindow unhides via app.show', async () => {
+    mocks.appIsHidden.mockReturnValue(true)
+    const { default: windowManager } = await import('../../src/main/managers/windowManager')
+
+    windowManager.createWindow()
+    windowManager.hideWindow(true)
+    expect(mocks.appHide).toHaveBeenCalledTimes(1)
+
+    windowManager.showWindow()
+    expect(mocks.appShow).toHaveBeenCalledTimes(1)
+  })
+
+  it('showWindow does not call app.show when the app is not hidden', async () => {
+    mocks.appIsHidden.mockReturnValue(false)
+    const { default: windowManager } = await import('../../src/main/managers/windowManager')
+
+    windowManager.createWindow()
+    windowManager.showWindow()
+
+    expect(mocks.appShow).not.toHaveBeenCalled()
+    expect(mocks.appFocus).not.toHaveBeenCalled()
   })
 })

--- a/tests/main/windowManagerMacActivation.test.ts
+++ b/tests/main/windowManagerMacActivation.test.ts
@@ -4,8 +4,10 @@ type MockHandler = (...args: any[]) => void
 
 const mocks = vi.hoisted(() => {
   const appFocus = vi.fn()
+  const appHide = vi.fn()
   const dbGet = vi.fn()
   const clipboardGetCurrentWindow = vi.fn()
+  const clipboardActivateApp = vi.fn()
   const globalInputOn = vi.fn()
   const globalInputAcquire = vi.fn()
   const globalInputRelease = vi.fn()
@@ -42,6 +44,7 @@ const mocks = vi.hoisted(() => {
       show: vi.fn(() => emit('show')),
       emit,
       hide: vi.fn(),
+      minimize: vi.fn(),
       blur: vi.fn(),
       focus: vi.fn(),
       loadFile: vi.fn(),
@@ -60,8 +63,10 @@ const mocks = vi.hoisted(() => {
 
   return {
     appFocus,
+    appHide,
     dbGet,
     clipboardGetCurrentWindow,
+    clipboardActivateApp,
     globalInputOn,
     globalInputAcquire,
     globalInputRelease,
@@ -79,6 +84,7 @@ vi.mock('electron', () => ({
   app: {
     getAppPath: vi.fn(() => '/tmp/ztools'),
     focus: mocks.appFocus,
+    hide: mocks.appHide,
     dock: {
       show: vi.fn(),
       hide: vi.fn()
@@ -154,7 +160,8 @@ vi.mock('../../src/main/core/native/index.js', () => ({
 
 vi.mock('../../src/main/managers/clipboardManager', () => ({
   default: {
-    getCurrentWindow: mocks.clipboardGetCurrentWindow
+    getCurrentWindow: mocks.clipboardGetCurrentWindow,
+    activateApp: mocks.clipboardActivateApp
   }
 }))
 
@@ -194,6 +201,7 @@ describe('windowManager macOS activation', () => {
     vi.clearAllMocks()
     mocks.dbGet.mockReturnValue(null)
     mocks.clipboardGetCurrentWindow.mockReturnValue(null)
+    mocks.clipboardActivateApp.mockReturnValue(true)
     mocks.latestWindow.current = null
   })
 
@@ -226,5 +234,38 @@ describe('windowManager macOS activation', () => {
     vi.advanceTimersByTime(201)
     mocks.latestWindow.current.emit('blur')
     expect(mocks.latestWindow.current.hide).toHaveBeenCalledTimes(1)
+  })
+
+  it('restore-focus hide on macOS uses app.hide, not window hide or activateApp', async () => {
+    const { default: windowManager } = await import('../../src/main/managers/windowManager')
+
+    windowManager.createWindow()
+    windowManager.setPreviousActiveWindow({
+      app: 'Finder',
+      bundleId: 'com.apple.finder'
+    } as any)
+
+    windowManager.hideWindow(true)
+
+    expect(mocks.appHide).toHaveBeenCalledTimes(1)
+    expect(mocks.latestWindow.current.hide).not.toHaveBeenCalled()
+    expect(mocks.latestWindow.current.minimize).not.toHaveBeenCalled()
+    expect(mocks.clipboardActivateApp).not.toHaveBeenCalled()
+  })
+
+  it('blur hide on macOS still only hides the BrowserWindow', async () => {
+    const { default: windowManager } = await import('../../src/main/managers/windowManager')
+
+    windowManager.createWindow()
+    windowManager.setPreviousActiveWindow({
+      app: 'Finder',
+      bundleId: 'com.apple.finder'
+    } as any)
+
+    windowManager.hideWindow(false)
+
+    expect(mocks.appHide).not.toHaveBeenCalled()
+    expect(mocks.latestWindow.current.hide).toHaveBeenCalledTimes(1)
+    expect(mocks.clipboardActivateApp).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
## 变更内容

- 通用设置 → 行为 增加开关「Esc 直接隐藏窗口」（`escHideWindow`，默认关闭）。
- 开启后，插件内按 Esc 不再 `notifyBackToSearch` / `exitPluginToSearch`，而是复用现有 `hideWindow(true)`，焦点回到上一应用。
- 该路径跳过 `autoBackToSearch` 定时器，避免窗口隐藏后后台仍卸插件并回到搜索。
- 未改快捷键页的内置 Esc 总开关；Cmd+W 仍按原逻辑退出插件回搜索。

## 动机

插件里 Esc 当前会回到主搜索，而不是藏窗。部分场景希望一次 Esc 就离开 ZTools，把焦点交还给上一应用，而不是先回到搜索再按一次 Esc。

已检索上游 issue/PR：没有完全相同的需求。相近的有 #556（禁用 Esc）、#320（从插件退出回搜索的体验）。

## 测试

1. 默认关闭：进入任意插件，按 Esc，应仍返回搜索界面；搜索页 Esc 仍隐藏窗口。
2. 打开「通用设置 → 行为 → Esc 直接隐藏窗口」：
   - 进入插件后按 Esc，窗口应直接隐藏，焦点回到上一应用，再次呼出仍停留在该插件（不会被自动返回搜索卸掉）。
   - 插件子输入框有内容时，Esc 仍先清空输入/粘贴，再藏窗。
3. 快捷键页关闭内置 Esc 后，本开关不应让 Esc 重新生效。
4. Cmd+W 仍退出插件并回到搜索，不隐藏窗口。