### PR TITLE
feat: 全局快捷键按下隐藏

### DIFF
--- a/internal-plugins/setting/src/env.d.ts
+++ b/internal-plugins/setting/src/env.d.ts
@@ -342,8 +342,7 @@ declare global {
           shortcut: string,
           target: string,
           autoCopy?: boolean,
-          preScreenshotOptimization?: boolean,
-          hideOnPress?: boolean
+          preScreenshotOptimization?: boolean
         ) => Promise<{ success: boolean; error?: string }>
         unregisterGlobalShortcut: (shortcut: string) => Promise<{
           success: boolean
@@ -351,7 +350,7 @@ declare global {
         }>
         updateGlobalShortcutConfig: (
           shortcut: string,
-          config: { autoCopy: boolean; preScreenshotOptimization: boolean; hideOnPress: boolean }
+          config: { autoCopy: boolean; preScreenshotOptimization: boolean }
         ) => Promise<{ success: boolean; error?: string }>
         registerAppShortcut: (
           shortcut: string,

--- a/internal-plugins/setting/src/env.d.ts
+++ b/internal-plugins/setting/src/env.d.ts
@@ -395,6 +395,7 @@ declare global {
         updateAutoBackToSearch: (autoBackToSearch: string) => Promise<void>
         updateWindowPositionStrategy: (strategy: string) => Promise<void>
         updateShowRecentInSearch: (showRecentInSearch: boolean) => Promise<void>
+        updateShowSystemApps: (showSystemApps: boolean) => Promise<void>
         updateMatchRecommendation: (showMatchRecommendation: boolean) => Promise<void>
         updateLocalAppSearch: (enabled: boolean) => Promise<void>
         updateRecentRows: (rows: number) => Promise<void>

--- a/internal-plugins/setting/src/env.d.ts
+++ b/internal-plugins/setting/src/env.d.ts
@@ -342,7 +342,8 @@ declare global {
           shortcut: string,
           target: string,
           autoCopy?: boolean,
-          preScreenshotOptimization?: boolean
+          preScreenshotOptimization?: boolean,
+          hideOnPress?: boolean
         ) => Promise<{ success: boolean; error?: string }>
         unregisterGlobalShortcut: (shortcut: string) => Promise<{
           success: boolean
@@ -350,7 +351,7 @@ declare global {
         }>
         updateGlobalShortcutConfig: (
           shortcut: string,
-          config: { autoCopy: boolean; preScreenshotOptimization: boolean }
+          config: { autoCopy: boolean; preScreenshotOptimization: boolean; hideOnPress: boolean }
         ) => Promise<{ success: boolean; error?: string }>
         registerAppShortcut: (
           shortcut: string,

--- a/internal-plugins/setting/src/views/GeneralSetting/GeneralSetting.vue
+++ b/internal-plugins/setting/src/views/GeneralSetting/GeneralSetting.vue
@@ -182,6 +182,7 @@ const windowPositionStrategy = ref<WindowPositionStrategy>('remember')
 const showRecentInSearch = ref(true)
 const showMatchRecommendation = ref(true)
 const localAppSearch = ref(true)
+const showSystemApps = ref(false)
 const recentRows = ref(2)
 const pinnedRows = ref(2)
 const searchMode = ref<'aggregate' | 'list'>('aggregate')
@@ -619,6 +620,16 @@ async function handleLocalAppSearchChange(): Promise<void> {
     console.log('本地应用搜索配置已更新:', localAppSearch.value)
   } catch (error) {
     console.error('保存本地应用搜索配置失败:', error)
+  }
+}
+
+async function handleShowSystemAppsChange(): Promise<void> {
+  try {
+    await saveSettings()
+    await window.ztools.internal.updateShowSystemApps(showSystemApps.value)
+    console.log('显示系统自带应用配置已更新:', showSystemApps.value)
+  } catch (error) {
+    console.error('保存显示系统自带应用配置失败:', error)
   }
 }
 
@@ -1304,6 +1315,7 @@ async function loadSettings(): Promise<void> {
       showRecentInSearch.value = data.showRecentInSearch ?? true
       showMatchRecommendation.value = data.showMatchRecommendation ?? true
       localAppSearch.value = data.localAppSearch ?? true
+      showSystemApps.value = data.showSystemApps ?? false
       recentRows.value = data.recentRows ?? 2
       pinnedRows.value = data.pinnedRows ?? 2
       theme.value = data.theme ?? 'system'
@@ -1400,6 +1412,7 @@ async function saveSettings(): Promise<void> {
       showRecentInSearch: showRecentInSearch.value,
       showMatchRecommendation: showMatchRecommendation.value,
       localAppSearch: localAppSearch.value,
+      showSystemApps: showSystemApps.value,
       recentRows: recentRows.value,
       pinnedRows: pinnedRows.value,
       searchMode: searchMode.value,
@@ -1969,6 +1982,19 @@ onUnmounted(() => {
         <div class="setting-control">
           <label class="toggle">
             <input v-model="localAppSearch" type="checkbox" @change="handleLocalAppSearchChange" />
+            <span class="toggle-slider"></span>
+          </label>
+        </div>
+      </div>
+
+      <div class="setting-item">
+        <div class="setting-label">
+          <span>显示系统自带应用</span>
+          <span class="setting-desc">开启后搜索结果包含系统自带应用（如访达、计算器）</span>
+        </div>
+        <div class="setting-control">
+          <label class="toggle">
+            <input v-model="showSystemApps" type="checkbox" @change="handleShowSystemAppsChange" />
             <span class="toggle-slider"></span>
           </label>
         </div>

--- a/internal-plugins/setting/src/views/ShortcutsSetting/ShortcutsSetting.vue
+++ b/internal-plugins/setting/src/views/ShortcutsSetting/ShortcutsSetting.vue
@@ -36,7 +36,6 @@ interface GlobalShortcut {
   configKey?: BuiltInShortcutKey
   autoCopy?: boolean
   preScreenshotOptimization?: boolean
-  hideOnPress?: boolean
 }
 
 type BuiltInShortcutKey = 'search' | 'closePlugin' | 'killPlugin' | 'esc'
@@ -150,6 +149,7 @@ const appShortcuts = ref<GlobalShortcut[]>([])
 const isDeleting = ref(false)
 const loading = ref(true)
 const builtInShortcutsEnabled = ref<BuiltInShortcutConfig>({ ...DEFAULT_BUILTIN_SHORTCUTS_ENABLED })
+const hideOnPress = ref(false)
 
 const aliasMappings = ref<CommandAliasStore>({})
 // alias 目标列表来自主进程整理后的 canonical commands，仅包含允许直接触发的插件指令和系统应用。
@@ -347,12 +347,14 @@ async function saveAliasMappings(nextStore: CommandAliasStore): Promise<boolean>
 async function loadGlobalShortcuts(): Promise<void> {
   try {
     const data = await window.ztools.internal.dbGet('global-shortcuts')
-    globalShortcuts.value = (data || []).map((shortcut: any) => ({
-      ...shortcut,
-      autoCopy: shortcut.autoCopy ?? false,
-      preScreenshotOptimization: shortcut.preScreenshotOptimization ?? false,
-      hideOnPress: shortcut.hideOnPress ?? false
-    }))
+    globalShortcuts.value = (data || []).map((shortcut: any) => {
+      const { hideOnPress: _removed, ...rest } = shortcut
+      return {
+        ...rest,
+        autoCopy: shortcut.autoCopy ?? false,
+        preScreenshotOptimization: shortcut.preScreenshotOptimization ?? false
+      }
+    })
   } catch (err) {
     console.error('加载全局快捷键失败:', err)
   }
@@ -375,6 +377,7 @@ async function loadBuiltInShortcutSettings(): Promise<void> {
       ...DEFAULT_BUILTIN_SHORTCUTS_ENABLED,
       ...config
     }
+    hideOnPress.value = settings.hideOnPress === true
   } catch (err) {
     console.error('加载内置快捷键开关失败:', err)
   }
@@ -752,7 +755,6 @@ async function handleSaveGlobalShortcut(
     const oldShortcut = editingShortcut.value.shortcut
     const oldTarget = editingShortcut.value.target
     const autoCopy = editingShortcut.value.autoCopy ?? false // 保留原有 autoCopy 配置
-    const hideOnPress = editingShortcut.value.hideOnPress ?? false // 保留原有按下隐藏配置
     const oldPreScreenshotOptimization = editingShortcut.value.preScreenshotOptimization ?? false
     const shouldRestorePreviousRegistration =
       oldShortcut !== recordedShortcut ||
@@ -768,8 +770,7 @@ async function handleSaveGlobalShortcut(
         recordedShortcut,
         targetCommand,
         autoCopy,
-        preScreenshotOptimization,
-        hideOnPress
+        preScreenshotOptimization
       )
 
       if (result.success) {
@@ -789,8 +790,7 @@ async function handleSaveGlobalShortcut(
             oldShortcut,
             oldTarget,
             autoCopy,
-            oldPreScreenshotOptimization,
-            hideOnPress
+            oldPreScreenshotOptimization
           )
         }
         error(`快捷键注册失败: ${result.error}`)
@@ -801,8 +801,7 @@ async function handleSaveGlobalShortcut(
           oldShortcut,
           oldTarget,
           autoCopy,
-          oldPreScreenshotOptimization,
-          hideOnPress
+          oldPreScreenshotOptimization
         )
       }
       console.error('更新快捷键失败:', err)
@@ -823,7 +822,6 @@ async function handleSaveGlobalShortcut(
     target: targetCommand,
     enabled: true,
     autoCopy: false,
-    hideOnPress: false,
     preScreenshotOptimization
   }
 
@@ -835,8 +833,7 @@ async function handleSaveGlobalShortcut(
       recordedShortcut,
       targetCommand,
       false,
-      preScreenshotOptimization,
-      false
+      preScreenshotOptimization
     )
     if (result.success) {
       success('快捷键添加成功!')
@@ -1016,7 +1013,6 @@ async function handleAutoCopyToggle(shortcut: any, event: Event): Promise<void> 
       enabled: s.enabled,
       autoCopy: s.autoCopy,
       preScreenshotOptimization: s.preScreenshotOptimization,
-      hideOnPress: s.hideOnPress,
       ...(s.configurable !== undefined && { configurable: s.configurable }),
       ...(s.configKey !== undefined && { configKey: s.configKey })
     }))
@@ -1027,13 +1023,11 @@ async function handleAutoCopyToggle(shortcut: any, event: Event): Promise<void> 
     console.log('[AutoCopy] 通知主进程更新配置:', {
       shortcut: shortcut.shortcut,
       autoCopy: newAutoCopy,
-      preScreenshotOptimization: shortcut.preScreenshotOptimization ?? false,
-      hideOnPress: shortcut.hideOnPress ?? false
+      preScreenshotOptimization: shortcut.preScreenshotOptimization ?? false
     })
     const result = await window.ztools.internal.updateGlobalShortcutConfig(shortcut.shortcut, {
       autoCopy: newAutoCopy,
-      preScreenshotOptimization: shortcut.preScreenshotOptimization ?? false,
-      hideOnPress: shortcut.hideOnPress ?? false
+      preScreenshotOptimization: shortcut.preScreenshotOptimization ?? false
     })
     console.log('[AutoCopy] 主进程配置更新结果:', result)
 
@@ -1054,50 +1048,25 @@ async function handleAutoCopyToggle(shortcut: any, event: Event): Promise<void> 
   }
 }
 
-// 处理按下隐藏开关切换
-async function handleHideOnPressToggle(shortcut: any, event: Event): Promise<void> {
+// 处理全局「按下隐藏」开关
+async function handleGlobalHideOnPressToggle(event: Event): Promise<void> {
   const target = event.target as HTMLInputElement | null
   if (!target) {
     return
   }
 
-  const newHideOnPress = target.checked
+  const enabled = target.checked
+  const previous = hideOnPress.value
+  hideOnPress.value = enabled
 
   try {
-    const index = globalShortcuts.value.findIndex((s) => s.id === shortcut.id)
-    if (index >= 0) {
-      globalShortcuts.value[index].hideOnPress = newHideOnPress
-    }
-
-    const dataToSave = globalShortcuts.value.map((s) => ({
-      id: s.id,
-      shortcut: s.shortcut,
-      target: s.target,
-      enabled: s.enabled,
-      autoCopy: s.autoCopy,
-      preScreenshotOptimization: s.preScreenshotOptimization,
-      hideOnPress: s.hideOnPress,
-      ...(s.configurable !== undefined && { configurable: s.configurable }),
-      ...(s.configKey !== undefined && { configKey: s.configKey })
-    }))
-    await window.ztools.internal.dbPut('global-shortcuts', dataToSave)
-
-    const result = await window.ztools.internal.updateGlobalShortcutConfig(shortcut.shortcut, {
-      autoCopy: shortcut.autoCopy ?? false,
-      preScreenshotOptimization: shortcut.preScreenshotOptimization ?? false,
-      hideOnPress: newHideOnPress
-    })
-
-    if (!result.success) {
-      throw new Error(result.error || '更新配置失败')
-    }
+    const settings = (await window.ztools.internal.dbGet('settings-general')) || {}
+    settings.hideOnPress = enabled
+    await window.ztools.internal.dbPut('settings-general', settings)
   } catch (err: any) {
     console.error('[HideOnPress] 更新按下隐藏开关失败:', err)
-    target.checked = !newHideOnPress
-    const index = globalShortcuts.value.findIndex((s) => s.id === shortcut.id)
-    if (index >= 0) {
-      globalShortcuts.value[index].hideOnPress = !newHideOnPress
-    }
+    hideOnPress.value = previous
+    target.checked = previous
   }
 }
 
@@ -1184,6 +1153,21 @@ useJumpFunction<ShortcutsSettingJumpFunction>(async (state) => {
         </div>
 
         <div class="panel-header">
+          <div
+            v-if="activeTab === 'global'"
+            class="auto-copy-control"
+            :title="hideOnPress ? '已启用按下隐藏' : '已禁用按下隐藏'"
+          >
+            <span class="auto-copy-label">按下隐藏</span>
+            <label class="toggle auto-copy-toggle">
+              <input
+                type="checkbox"
+                :checked="hideOnPress"
+                @change="handleGlobalHideOnPressToggle($event)"
+              />
+              <span class="toggle-slider"></span>
+            </label>
+          </div>
           <button class="btn" @click="showAddEditor">{{ addButtonLabel }}</button>
         </div>
 
@@ -1411,22 +1395,6 @@ useJumpFunction<ShortcutsSettingJumpFunction>(async (state) => {
                   </label>
                 </div>
 
-                <div
-                  v-if="activeTab === 'global'"
-                  class="auto-copy-control"
-                  :title="(shortcut.hideOnPress ?? false) ? '已启用按下隐藏' : '已禁用按下隐藏'"
-                >
-                  <span class="auto-copy-label">按下隐藏</span>
-                  <label class="toggle auto-copy-toggle">
-                    <input
-                      type="checkbox"
-                      :checked="shortcut.hideOnPress ?? false"
-                      @change="handleHideOnPressToggle(shortcut, $event)"
-                    />
-                    <span class="toggle-slider"></span>
-                  </label>
-                </div>
-
                 <button
                   class="icon-btn edit-btn"
                   title="编辑"
@@ -1642,7 +1610,9 @@ useJumpFunction<ShortcutsSettingJumpFunction>(async (state) => {
 
 .panel-header {
   display: flex;
+  align-items: center;
   justify-content: flex-end;
+  gap: 8px;
   margin-bottom: 20px;
 }
 

--- a/internal-plugins/setting/src/views/ShortcutsSetting/ShortcutsSetting.vue
+++ b/internal-plugins/setting/src/views/ShortcutsSetting/ShortcutsSetting.vue
@@ -36,6 +36,7 @@ interface GlobalShortcut {
   configKey?: BuiltInShortcutKey
   autoCopy?: boolean
   preScreenshotOptimization?: boolean
+  hideOnPress?: boolean
 }
 
 type BuiltInShortcutKey = 'search' | 'closePlugin' | 'killPlugin' | 'esc'
@@ -349,7 +350,8 @@ async function loadGlobalShortcuts(): Promise<void> {
     globalShortcuts.value = (data || []).map((shortcut: any) => ({
       ...shortcut,
       autoCopy: shortcut.autoCopy ?? false,
-      preScreenshotOptimization: shortcut.preScreenshotOptimization ?? false
+      preScreenshotOptimization: shortcut.preScreenshotOptimization ?? false,
+      hideOnPress: shortcut.hideOnPress ?? false
     }))
   } catch (err) {
     console.error('加载全局快捷键失败:', err)
@@ -750,6 +752,7 @@ async function handleSaveGlobalShortcut(
     const oldShortcut = editingShortcut.value.shortcut
     const oldTarget = editingShortcut.value.target
     const autoCopy = editingShortcut.value.autoCopy ?? false // 保留原有 autoCopy 配置
+    const hideOnPress = editingShortcut.value.hideOnPress ?? false // 保留原有按下隐藏配置
     const oldPreScreenshotOptimization = editingShortcut.value.preScreenshotOptimization ?? false
     const shouldRestorePreviousRegistration =
       oldShortcut !== recordedShortcut ||
@@ -765,7 +768,8 @@ async function handleSaveGlobalShortcut(
         recordedShortcut,
         targetCommand,
         autoCopy,
-        preScreenshotOptimization
+        preScreenshotOptimization,
+        hideOnPress
       )
 
       if (result.success) {
@@ -785,7 +789,8 @@ async function handleSaveGlobalShortcut(
             oldShortcut,
             oldTarget,
             autoCopy,
-            oldPreScreenshotOptimization
+            oldPreScreenshotOptimization,
+            hideOnPress
           )
         }
         error(`快捷键注册失败: ${result.error}`)
@@ -796,7 +801,8 @@ async function handleSaveGlobalShortcut(
           oldShortcut,
           oldTarget,
           autoCopy,
-          oldPreScreenshotOptimization
+          oldPreScreenshotOptimization,
+          hideOnPress
         )
       }
       console.error('更新快捷键失败:', err)
@@ -817,6 +823,7 @@ async function handleSaveGlobalShortcut(
     target: targetCommand,
     enabled: true,
     autoCopy: false,
+    hideOnPress: false,
     preScreenshotOptimization
   }
 
@@ -828,7 +835,8 @@ async function handleSaveGlobalShortcut(
       recordedShortcut,
       targetCommand,
       false,
-      preScreenshotOptimization
+      preScreenshotOptimization,
+      false
     )
     if (result.success) {
       success('快捷键添加成功!')
@@ -1008,6 +1016,7 @@ async function handleAutoCopyToggle(shortcut: any, event: Event): Promise<void> 
       enabled: s.enabled,
       autoCopy: s.autoCopy,
       preScreenshotOptimization: s.preScreenshotOptimization,
+      hideOnPress: s.hideOnPress,
       ...(s.configurable !== undefined && { configurable: s.configurable }),
       ...(s.configKey !== undefined && { configKey: s.configKey })
     }))
@@ -1018,11 +1027,13 @@ async function handleAutoCopyToggle(shortcut: any, event: Event): Promise<void> 
     console.log('[AutoCopy] 通知主进程更新配置:', {
       shortcut: shortcut.shortcut,
       autoCopy: newAutoCopy,
-      preScreenshotOptimization: shortcut.preScreenshotOptimization ?? false
+      preScreenshotOptimization: shortcut.preScreenshotOptimization ?? false,
+      hideOnPress: shortcut.hideOnPress ?? false
     })
     const result = await window.ztools.internal.updateGlobalShortcutConfig(shortcut.shortcut, {
       autoCopy: newAutoCopy,
-      preScreenshotOptimization: shortcut.preScreenshotOptimization ?? false
+      preScreenshotOptimization: shortcut.preScreenshotOptimization ?? false,
+      hideOnPress: shortcut.hideOnPress ?? false
     })
     console.log('[AutoCopy] 主进程配置更新结果:', result)
 
@@ -1039,6 +1050,53 @@ async function handleAutoCopyToggle(shortcut: any, event: Event): Promise<void> 
     if (index >= 0) {
       globalShortcuts.value[index].autoCopy = !newAutoCopy
       console.log('[AutoCopy] 已回滚本地数据')
+    }
+  }
+}
+
+// 处理按下隐藏开关切换
+async function handleHideOnPressToggle(shortcut: any, event: Event): Promise<void> {
+  const target = event.target as HTMLInputElement | null
+  if (!target) {
+    return
+  }
+
+  const newHideOnPress = target.checked
+
+  try {
+    const index = globalShortcuts.value.findIndex((s) => s.id === shortcut.id)
+    if (index >= 0) {
+      globalShortcuts.value[index].hideOnPress = newHideOnPress
+    }
+
+    const dataToSave = globalShortcuts.value.map((s) => ({
+      id: s.id,
+      shortcut: s.shortcut,
+      target: s.target,
+      enabled: s.enabled,
+      autoCopy: s.autoCopy,
+      preScreenshotOptimization: s.preScreenshotOptimization,
+      hideOnPress: s.hideOnPress,
+      ...(s.configurable !== undefined && { configurable: s.configurable }),
+      ...(s.configKey !== undefined && { configKey: s.configKey })
+    }))
+    await window.ztools.internal.dbPut('global-shortcuts', dataToSave)
+
+    const result = await window.ztools.internal.updateGlobalShortcutConfig(shortcut.shortcut, {
+      autoCopy: shortcut.autoCopy ?? false,
+      preScreenshotOptimization: shortcut.preScreenshotOptimization ?? false,
+      hideOnPress: newHideOnPress
+    })
+
+    if (!result.success) {
+      throw new Error(result.error || '更新配置失败')
+    }
+  } catch (err: any) {
+    console.error('[HideOnPress] 更新按下隐藏开关失败:', err)
+    target.checked = !newHideOnPress
+    const index = globalShortcuts.value.findIndex((s) => s.id === shortcut.id)
+    if (index >= 0) {
+      globalShortcuts.value[index].hideOnPress = !newHideOnPress
     }
   }
 }
@@ -1348,6 +1406,22 @@ useJumpFunction<ShortcutsSettingJumpFunction>(async (state) => {
                       type="checkbox"
                       :checked="shortcut.autoCopy ?? false"
                       @change="handleAutoCopyToggle(shortcut, $event)"
+                    />
+                    <span class="toggle-slider"></span>
+                  </label>
+                </div>
+
+                <div
+                  v-if="activeTab === 'global'"
+                  class="auto-copy-control"
+                  :title="(shortcut.hideOnPress ?? false) ? '已启用按下隐藏' : '已禁用按下隐藏'"
+                >
+                  <span class="auto-copy-label">按下隐藏</span>
+                  <label class="toggle auto-copy-toggle">
+                    <input
+                      type="checkbox"
+                      :checked="shortcut.hideOnPress ?? false"
+                      @change="handleHideOnPressToggle(shortcut, $event)"
                     />
                     <span class="toggle-slider"></span>
                   </label>

--- a/resources/preload.js
+++ b/resources/preload.js
@@ -1014,13 +1014,20 @@ window.ztools = {
       await electron.ipcRenderer.invoke('internal:get-plugin-memory-info', pluginPath),
 
     // ==================== 全局快捷键 API ====================
-    registerGlobalShortcut: async (shortcut, target, autoCopy, preScreenshotOptimization) =>
+    registerGlobalShortcut: async (
+      shortcut,
+      target,
+      autoCopy,
+      preScreenshotOptimization,
+      hideOnPress
+    ) =>
       await electron.ipcRenderer.invoke(
         'internal:register-global-shortcut',
         shortcut,
         target,
         autoCopy,
-        preScreenshotOptimization
+        preScreenshotOptimization,
+        hideOnPress
       ),
     unregisterGlobalShortcut: async (shortcut) =>
       await electron.ipcRenderer.invoke('internal:unregister-global-shortcut', shortcut),

--- a/resources/preload.js
+++ b/resources/preload.js
@@ -1097,6 +1097,8 @@ window.ztools = {
         'internal:update-show-recent-in-search',
         showRecentInSearch
       ),
+    updateShowSystemApps: async (showSystemApps) =>
+      await electron.ipcRenderer.invoke('internal:update-show-system-apps', showSystemApps),
     // 通知主渲染进程更新匹配推荐配置
     updateMatchRecommendation: async (showMatchRecommendation) =>
       await electron.ipcRenderer.invoke(

--- a/resources/preload.js
+++ b/resources/preload.js
@@ -1014,20 +1014,13 @@ window.ztools = {
       await electron.ipcRenderer.invoke('internal:get-plugin-memory-info', pluginPath),
 
     // ==================== 全局快捷键 API ====================
-    registerGlobalShortcut: async (
-      shortcut,
-      target,
-      autoCopy,
-      preScreenshotOptimization,
-      hideOnPress
-    ) =>
+    registerGlobalShortcut: async (shortcut, target, autoCopy, preScreenshotOptimization) =>
       await electron.ipcRenderer.invoke(
         'internal:register-global-shortcut',
         shortcut,
         target,
         autoCopy,
-        preScreenshotOptimization,
-        hideOnPress
+        preScreenshotOptimization
       ),
     unregisterGlobalShortcut: async (shortcut) =>
       await electron.ipcRenderer.invoke('internal:unregister-global-shortcut', shortcut),

--- a/src/main/api/index.ts
+++ b/src/main/api/index.ts
@@ -547,6 +547,8 @@ class APIManager {
    */
   private async launchDirectCommand(command: any, context?: ShortcutLaunchContext): Promise<void> {
     console.log('[API] 通过全局快捷键启动系统应用:', command.name, command.path)
+    // 再保险：launch 前系统级隐藏，避免 ZTools 盖住第三方导致 activate 失败。
+    windowManager.hideWindow(true)
     await appsAPI.launch({
       path: command.path,
       type: 'direct',

--- a/src/main/api/plugin/internal.ts
+++ b/src/main/api/plugin/internal.ts
@@ -1071,6 +1071,14 @@ export class InternalPluginAPI {
       }
     )
 
+    ipcMain.handle('internal:update-show-system-apps', async (event, showSystemApps: boolean) => {
+      if (!requireInternalPlugin(this.pluginManager, event)) {
+        throw new PermissionDeniedError('internal:update-show-system-apps')
+      }
+      this.mainWindow?.webContents.send('update-show-system-apps', showSystemApps)
+      return { success: true }
+    })
+
     // 通知主渲染进程更新匹配推荐配置
     ipcMain.handle(
       'internal:update-match-recommendation',

--- a/src/main/api/plugin/internal.ts
+++ b/src/main/api/plugin/internal.ts
@@ -811,7 +811,8 @@ export class InternalPluginAPI {
         shortcut: string,
         target: string,
         autoCopy?: boolean,
-        preScreenshotOptimization?: boolean
+        preScreenshotOptimization?: boolean,
+        hideOnPress?: boolean
       ) => {
         if (!requireInternalPlugin(this.pluginManager, event)) {
           throw new PermissionDeniedError('internal:register-global-shortcut')
@@ -820,7 +821,8 @@ export class InternalPluginAPI {
           shortcut,
           target,
           autoCopy ?? false,
-          preScreenshotOptimization ?? false
+          preScreenshotOptimization ?? false,
+          hideOnPress ?? false
         )
       }
     )
@@ -858,7 +860,7 @@ export class InternalPluginAPI {
       async (
         event,
         shortcut: string,
-        config: { autoCopy: boolean; preScreenshotOptimization: boolean }
+        config: { autoCopy: boolean; preScreenshotOptimization: boolean; hideOnPress: boolean }
       ) => {
         if (!requireInternalPlugin(this.pluginManager, event)) {
           throw new PermissionDeniedError('internal:update-global-shortcut-config')

--- a/src/main/api/plugin/internal.ts
+++ b/src/main/api/plugin/internal.ts
@@ -811,8 +811,7 @@ export class InternalPluginAPI {
         shortcut: string,
         target: string,
         autoCopy?: boolean,
-        preScreenshotOptimization?: boolean,
-        hideOnPress?: boolean
+        preScreenshotOptimization?: boolean
       ) => {
         if (!requireInternalPlugin(this.pluginManager, event)) {
           throw new PermissionDeniedError('internal:register-global-shortcut')
@@ -821,8 +820,7 @@ export class InternalPluginAPI {
           shortcut,
           target,
           autoCopy ?? false,
-          preScreenshotOptimization ?? false,
-          hideOnPress ?? false
+          preScreenshotOptimization ?? false
         )
       }
     )
@@ -860,7 +858,7 @@ export class InternalPluginAPI {
       async (
         event,
         shortcut: string,
-        config: { autoCopy: boolean; preScreenshotOptimization: boolean; hideOnPress: boolean }
+        config: { autoCopy: boolean; preScreenshotOptimization: boolean }
       ) => {
         if (!requireInternalPlugin(this.pluginManager, event)) {
           throw new PermissionDeniedError('internal:update-global-shortcut-config')

--- a/src/main/api/renderer/commands.ts
+++ b/src/main/api/renderer/commands.ts
@@ -30,8 +30,8 @@ interface LastMatchState {
  * 应用管理API - 主程序专用
  */
 export class AppsAPI {
-  // v4: macOS 扫描下钻一层以纳入浏览器 PWA（Chrome/Edge Apps.localized）以及 Python 安装子目录下的 IDLE 等
-  private static readonly APP_CACHE_VERSION = 4
+  // v5: 为 macOS /System/Applications 下的应用标记 isSystemApp
+  private static readonly APP_CACHE_VERSION = 5
   private static readonly APP_CACHE_VERSION_KEY = 'cached-commands-version'
   private mainWindow: Electron.BrowserWindow | null = null
   private pluginManager: PluginManager | null = null
@@ -1104,7 +1104,8 @@ export class AppsAPI {
           path: app.path,
           icon: app.icon,
           type: 'direct',
-          subType: 'app'
+          subType: 'app',
+          isSystemApp: app.isSystemApp
         })
       }
 

--- a/src/main/api/renderer/settings.ts
+++ b/src/main/api/renderer/settings.ts
@@ -80,7 +80,8 @@ export class SettingsAPI {
   private isGlobalShortcutTriggering = false
   /**
    * hideOnPress 只负责 ZTools 自己：已在前台再按 → hideWindow（macOS 为 app.hide）。
-   * 不在前台（含刚 launch 过别的 App）→ showWindow，不 launch、不 pending-hide。
+   * 不在前台（含刚 launch 过别的 App、对方搜索框开着）→ showWindow。
+   * 不再设置 hideOnPressPendingHideShortcut：launch 后再按是 SHOW，不能被 pending-hide 吃掉，也不再 launch。
    */
 
   // 启动 native 优化快捷键监听，并把命中事件回流到既有执行链路。

--- a/src/main/api/renderer/settings.ts
+++ b/src/main/api/renderer/settings.ts
@@ -41,7 +41,6 @@ interface ShortcutLaunchContext {
 interface GlobalShortcutRuntimeConfig {
   autoCopy: boolean
   preScreenshotOptimization: boolean
-  hideOnPress: boolean
 }
 
 /**
@@ -71,7 +70,7 @@ export class SettingsAPI {
 
   // 临时快捷键录制相关
   private recordingShortcuts: string[] = []
-  // 全局快捷键配置映射（存储每个快捷键的 autoCopy / hideOnPress 等配置）
+  // 全局快捷键配置映射（存储每个快捷键的 autoCopy 等配置）
   private globalShortcutConfigs: Map<string, GlobalShortcutRuntimeConfig> = new Map()
   private globalShortcutTargets = new Map<string, string>()
   private globalShortcutPreparations = new Map<string, GlobalShortcutPreparation>()
@@ -207,8 +206,7 @@ export class SettingsAPI {
       shortcut,
       target,
       config.autoCopy,
-      config.preScreenshotOptimization,
-      config.hideOnPress
+      config.preScreenshotOptimization
     )
   }
 
@@ -232,15 +230,13 @@ export class SettingsAPI {
         shortcut: string,
         target: string,
         autoCopy?: boolean,
-        preScreenshotOptimization?: boolean,
-        hideOnPress?: boolean
+        preScreenshotOptimization?: boolean
       ) =>
         this.registerGlobalShortcut(
           shortcut,
           target,
           autoCopy ?? false,
-          preScreenshotOptimization ?? false,
-          hideOnPress ?? false
+          preScreenshotOptimization ?? false
         )
     )
     ipcMain.handle('unregister-global-shortcut', (_event, shortcut: string) =>
@@ -345,8 +341,7 @@ export class SettingsAPI {
                 shortcut.shortcut,
                 shortcut.target,
                 shortcut.autoCopy ?? false,
-                shortcut.preScreenshotOptimization ?? false,
-                shortcut.hideOnPress ?? false
+                shortcut.preScreenshotOptimization ?? false
               )
             } catch (error) {
               console.error(`注册全局快捷键失败: ${shortcut.shortcut}`, error)
@@ -443,16 +438,15 @@ export class SettingsAPI {
     shortcut: string,
     target: string,
     autoCopy: boolean = false,
-    preScreenshotOptimization: boolean = false,
-    hideOnPress: boolean = false
+    preScreenshotOptimization: boolean = false
   ): Promise<any> {
     console.log(
-      `[Settings] 注册全局快捷键: ${shortcut} -> ${target}, autoCopy: ${autoCopy}, preScreenshotOptimization: ${preScreenshotOptimization}, hideOnPress: ${hideOnPress}`
+      `[Settings] 注册全局快捷键: ${shortcut} -> ${target}, autoCopy: ${autoCopy}, preScreenshotOptimization: ${preScreenshotOptimization}`
     )
 
     try {
       // 存储快捷键配置
-      this.globalShortcutConfigs.set(shortcut, { autoCopy, preScreenshotOptimization, hideOnPress })
+      this.globalShortcutConfigs.set(shortcut, { autoCopy, preScreenshotOptimization })
       this.globalShortcutTargets.set(shortcut, target)
       console.log('[Settings] 快捷键配置已存储到 Map')
 
@@ -557,13 +551,12 @@ export class SettingsAPI {
     const previousPreparation = this.globalShortcutPreparations.get(shortcut)
     const nextConfig: GlobalShortcutRuntimeConfig = {
       autoCopy: config.autoCopy ?? false,
-      preScreenshotOptimization: config.preScreenshotOptimization ?? false,
-      hideOnPress: config.hideOnPress ?? false
+      preScreenshotOptimization: config.preScreenshotOptimization ?? false
     }
 
     try {
       console.log(
-        `[Settings] 更新全局快捷键配置: ${shortcut}, autoCopy: ${nextConfig.autoCopy}, preScreenshotOptimization: ${nextConfig.preScreenshotOptimization}, hideOnPress: ${nextConfig.hideOnPress}`
+        `[Settings] 更新全局快捷键配置: ${shortcut}, autoCopy: ${nextConfig.autoCopy}, preScreenshotOptimization: ${nextConfig.preScreenshotOptimization}`
       )
       this.globalShortcutConfigs.set(shortcut, nextConfig)
       const rebindResult = await this.rebindGlobalShortcut(shortcut)
@@ -642,7 +635,7 @@ export class SettingsAPI {
       const config = this.globalShortcutConfigs.get(shortcut)
       const autoCopy = config?.autoCopy ?? false
       const preScreenshotOptimization = config?.preScreenshotOptimization ?? false
-      const hideOnPress = config?.hideOnPress ?? false
+      const hideOnPress = this.isGlobalHideOnPressEnabled()
 
       console.log(`[Settings] 快捷键触发: ${shortcut}`)
       console.log(`[Settings] 指令类型需要文本: ${preparation.shouldCaptureSelectedText}`)
@@ -678,6 +671,14 @@ export class SettingsAPI {
    */
   private shouldTriggerGlobalShortcut(_target: string): boolean {
     return !this.isGlobalShortcutTriggering
+  }
+
+  /**
+   * 全局「按下隐藏」开关，存在 settings-general.hideOnPress，默认关。
+   */
+  private isGlobalHideOnPressEnabled(): boolean {
+    const settings = databaseAPI.dbGet('settings-general')
+    return settings?.hideOnPress === true
   }
 
   /**

--- a/src/main/api/renderer/settings.ts
+++ b/src/main/api/renderer/settings.ts
@@ -80,7 +80,7 @@ export class SettingsAPI {
   private isGlobalShortcutTriggering = false
   /**
    * hideOnPress 开启且上次启动把主窗藏掉时（第三方/系统 App 的 launch 会 hide），
-   * 记下该快捷键，再按只 hideWindow，不再 launch。
+   * 记下该快捷键，再按只走 hideWindow（macOS 内部 app.hide），不再 launch。
    */
   private hideOnPressPendingHideShortcut: string | null = null
 
@@ -649,7 +649,7 @@ export class SettingsAPI {
       console.log(`[Settings] 用户启用按下隐藏: ${hideOnPress}`)
 
       if (hideOnPress && this.shouldHideWindowOnRepeatPress(shortcut)) {
-        console.log(`[Settings] 按下隐藏并恢复上一应用: ${shortcut}`)
+        console.log(`[Settings] 按下隐藏（macOS 系统级 hide）: ${shortcut}`)
         this.hideOnPressPendingHideShortcut = null
         windowManager.hideWindow(true)
         return

--- a/src/main/api/renderer/settings.ts
+++ b/src/main/api/renderer/settings.ts
@@ -79,10 +79,9 @@ export class SettingsAPI {
   // 全局快捷键触发流程执行中时，后续触发会被忽略，避免重复复制和重复启动。
   private isGlobalShortcutTriggering = false
   /**
-   * hideOnPress 开启且上次启动把主窗藏掉时（第三方/系统 App 的 launch 会 hide），
-   * 记下该快捷键，再按只走 hideWindow（macOS 内部 app.hide），不再 launch。
+   * hideOnPress 只负责 ZTools 自己：已在前台再按 → hideWindow（macOS 为 app.hide）。
+   * 不在前台（含刚 launch 过别的 App）→ showWindow，不 launch、不 pending-hide。
    */
-  private hideOnPressPendingHideShortcut: string | null = null
 
   // 启动 native 优化快捷键监听，并把命中事件回流到既有执行链路。
   private setupOptimizedShortcutListener(): void {
@@ -648,10 +647,15 @@ export class SettingsAPI {
       console.log(`[Settings] 用户启用预截图优化: ${preScreenshotOptimization}`)
       console.log(`[Settings] 用户启用按下隐藏: ${hideOnPress}`)
 
-      if (hideOnPress && this.shouldHideWindowOnRepeatPress(shortcut)) {
-        console.log(`[Settings] 按下隐藏（macOS 系统级 hide）: ${shortcut}`)
-        this.hideOnPressPendingHideShortcut = null
+      if (hideOnPress && this.isZToolsInForeground()) {
+        console.log(`[Settings] ZTools 前台，按下隐藏: ${shortcut}`)
         windowManager.hideWindow(true)
+        return
+      }
+
+      if (hideOnPress) {
+        console.log(`[Settings] ZTools 不在前台，唤出主窗: ${shortcut}`)
+        windowManager.showWindow()
         return
       }
 
@@ -666,15 +670,6 @@ export class SettingsAPI {
 
       const context = shouldCapture ? await this.captureSelectedTextContext() : undefined
       await this.handleGlobalShortcut(preparation.target, context)
-
-      if (hideOnPress) {
-        // 插件会把主窗留在前台；第三方/系统 App 的 launch 会 hide 主窗。
-        // 窗已被藏时记一笔，下次同快捷键只 hide、不再 launch。
-        const mainWindow = windowManager.getMainWindow() ?? this.mainWindow
-        this.hideOnPressPendingHideShortcut = mainWindow?.isVisible() ? null : shortcut
-      } else {
-        this.hideOnPressPendingHideShortcut = null
-      }
     } finally {
       this.isGlobalShortcutTriggering = false
     }
@@ -697,16 +692,15 @@ export class SettingsAPI {
   }
 
   /**
-   * 开启「按下隐藏」后，再次按下应藏窗而不是再 launch。
-   * 主窗仍可见（插件页），或上次启动已把主窗藏掉（第三方/系统 App）时都成立。
-   * 只看 isVisible，不看 isFocused：插件页打开或热键到来时焦点常已离开主窗。
+   * ZTools 是否在前台：主窗聚焦，或插件视图聚焦。
+   * 只看可见会把「别的 App 前台 / 刚 launch 过」误判成 hide。
    */
-  private shouldHideWindowOnRepeatPress(shortcut: string): boolean {
+  private isZToolsInForeground(): boolean {
     const mainWindow = windowManager.getMainWindow() ?? this.mainWindow
-    if (mainWindow?.isVisible()) {
+    if (mainWindow?.isFocused()) {
       return true
     }
-    return this.hideOnPressPendingHideShortcut === shortcut
+    return this.pluginManager?.isPluginViewFocused() === true
   }
 
   /**

--- a/src/main/api/renderer/settings.ts
+++ b/src/main/api/renderer/settings.ts
@@ -682,11 +682,12 @@ export class SettingsAPI {
   }
 
   /**
-   * 窗口已显示且聚焦时，开启「按下隐藏」的快捷键再次按下应藏窗。
+   * 主窗已显示时，开启「按下隐藏」的快捷键再次按下应藏窗。
+   * 只看 isVisible：插件页打开时窗口也是显示的；热键到来时焦点可能已不在主窗。
    */
   private shouldHideWindowOnRepeatPress(): boolean {
     const mainWindow = windowManager.getMainWindow() ?? this.mainWindow
-    return Boolean(mainWindow?.isVisible() && mainWindow.isFocused())
+    return Boolean(mainWindow?.isVisible())
   }
 
   /**

--- a/src/main/api/renderer/settings.ts
+++ b/src/main/api/renderer/settings.ts
@@ -78,6 +78,11 @@ export class SettingsAPI {
   private globalShortcutKeyboardStateReleasers = new Map<string, () => void>()
   // 全局快捷键触发流程执行中时，后续触发会被忽略，避免重复复制和重复启动。
   private isGlobalShortcutTriggering = false
+  /**
+   * hideOnPress 开启且上次启动把主窗藏掉时（第三方/系统 App 的 launch 会 hide），
+   * 记下该快捷键，再按只 hideWindow，不再 launch。
+   */
+  private hideOnPressPendingHideShortcut: string | null = null
 
   // 启动 native 优化快捷键监听，并把命中事件回流到既有执行链路。
   private setupOptimizedShortcutListener(): void {
@@ -643,8 +648,9 @@ export class SettingsAPI {
       console.log(`[Settings] 用户启用预截图优化: ${preScreenshotOptimization}`)
       console.log(`[Settings] 用户启用按下隐藏: ${hideOnPress}`)
 
-      if (hideOnPress && this.shouldHideWindowOnRepeatPress()) {
-        console.log(`[Settings] 窗口已显示，按下隐藏并恢复上一应用: ${shortcut}`)
+      if (hideOnPress && this.shouldHideWindowOnRepeatPress(shortcut)) {
+        console.log(`[Settings] 按下隐藏并恢复上一应用: ${shortcut}`)
+        this.hideOnPressPendingHideShortcut = null
         windowManager.hideWindow(true)
         return
       }
@@ -660,6 +666,15 @@ export class SettingsAPI {
 
       const context = shouldCapture ? await this.captureSelectedTextContext() : undefined
       await this.handleGlobalShortcut(preparation.target, context)
+
+      if (hideOnPress) {
+        // 插件会把主窗留在前台；第三方/系统 App 的 launch 会 hide 主窗。
+        // 窗已被藏时记一笔，下次同快捷键只 hide、不再 launch。
+        const mainWindow = windowManager.getMainWindow() ?? this.mainWindow
+        this.hideOnPressPendingHideShortcut = mainWindow?.isVisible() ? null : shortcut
+      } else {
+        this.hideOnPressPendingHideShortcut = null
+      }
     } finally {
       this.isGlobalShortcutTriggering = false
     }
@@ -682,12 +697,16 @@ export class SettingsAPI {
   }
 
   /**
-   * 主窗已显示时，开启「按下隐藏」的快捷键再次按下应藏窗。
-   * 只看 isVisible：插件页打开时窗口也是显示的；热键到来时焦点可能已不在主窗。
+   * 开启「按下隐藏」后，再次按下应藏窗而不是再 launch。
+   * 主窗仍可见（插件页），或上次启动已把主窗藏掉（第三方/系统 App）时都成立。
+   * 只看 isVisible，不看 isFocused：插件页打开或热键到来时焦点常已离开主窗。
    */
-  private shouldHideWindowOnRepeatPress(): boolean {
+  private shouldHideWindowOnRepeatPress(shortcut: string): boolean {
     const mainWindow = windowManager.getMainWindow() ?? this.mainWindow
-    return Boolean(mainWindow?.isVisible())
+    if (mainWindow?.isVisible()) {
+      return true
+    }
+    return this.hideOnPressPendingHideShortcut === shortcut
   }
 
   /**

--- a/src/main/api/renderer/settings.ts
+++ b/src/main/api/renderer/settings.ts
@@ -79,9 +79,9 @@ export class SettingsAPI {
   // 全局快捷键触发流程执行中时，后续触发会被忽略，避免重复复制和重复启动。
   private isGlobalShortcutTriggering = false
   /**
-   * hideOnPress 只负责 ZTools 自己：已在前台再按 → hideWindow（macOS 为 app.hide）。
-   * 不在前台（含刚 launch 过别的 App、对方搜索框开着）→ showWindow。
-   * 不再设置 hideOnPressPendingHideShortcut：launch 后再按是 SHOW，不能被 pending-hide 吃掉，也不再 launch。
+   * hideOnPress 只负责 ZTools 自己：主窗可见且自己是前台时再按 → hideWindow（macOS 为 app.hide）。
+   * 不在前台时照常 launch 绑定命令，不 show 首页。
+   * 不恢复 hideOnPressPendingHideShortcut。
    */
 
   // 启动 native 优化快捷键监听，并把命中事件回流到既有执行链路。
@@ -654,12 +654,6 @@ export class SettingsAPI {
         return
       }
 
-      if (hideOnPress) {
-        console.log(`[Settings] ZTools 不在前台，唤出主窗: ${shortcut}`)
-        windowManager.showWindow()
-        return
-      }
-
       if (preScreenshotOptimization && !skipPrime) {
         primeScreenCaptureFrame()
       }
@@ -693,12 +687,11 @@ export class SettingsAPI {
   }
 
   /**
-   * ZTools 是否在前台：主窗聚焦，或插件视图聚焦。
-   * 只看可见会把「别的 App 前台 / 刚 launch 过」误判成 hide。
+   * ZTools 是否在前台：主窗可见且聚焦，或插件视图聚焦。
    */
   private isZToolsInForeground(): boolean {
     const mainWindow = windowManager.getMainWindow() ?? this.mainWindow
-    if (mainWindow?.isFocused()) {
+    if (mainWindow?.isVisible() && mainWindow?.isFocused()) {
       return true
     }
     return this.pluginManager?.isPluginViewFocused() === true

--- a/src/main/api/renderer/settings.ts
+++ b/src/main/api/renderer/settings.ts
@@ -38,6 +38,12 @@ interface ShortcutLaunchContext {
   pastedText: string | null
 }
 
+interface GlobalShortcutRuntimeConfig {
+  autoCopy: boolean
+  preScreenshotOptimization: boolean
+  hideOnPress: boolean
+}
+
 /**
  * 设置管理API - 主程序专用
  * 包含主题、快捷键、开机启动等设置
@@ -65,11 +71,8 @@ export class SettingsAPI {
 
   // 临时快捷键录制相关
   private recordingShortcuts: string[] = []
-  // 全局快捷键配置映射（存储每个快捷键的 autoCopy 等配置）
-  private globalShortcutConfigs: Map<
-    string,
-    { autoCopy: boolean; preScreenshotOptimization: boolean }
-  > = new Map()
+  // 全局快捷键配置映射（存储每个快捷键的 autoCopy / hideOnPress 等配置）
+  private globalShortcutConfigs: Map<string, GlobalShortcutRuntimeConfig> = new Map()
   private globalShortcutTargets = new Map<string, string>()
   private globalShortcutPreparations = new Map<string, GlobalShortcutPreparation>()
   private nativeOptimizedShortcutSet = new Set<string>()
@@ -204,7 +207,8 @@ export class SettingsAPI {
       shortcut,
       target,
       config.autoCopy,
-      config.preScreenshotOptimization
+      config.preScreenshotOptimization,
+      config.hideOnPress
     )
   }
 
@@ -228,13 +232,15 @@ export class SettingsAPI {
         shortcut: string,
         target: string,
         autoCopy?: boolean,
-        preScreenshotOptimization?: boolean
+        preScreenshotOptimization?: boolean,
+        hideOnPress?: boolean
       ) =>
         this.registerGlobalShortcut(
           shortcut,
           target,
           autoCopy ?? false,
-          preScreenshotOptimization ?? false
+          preScreenshotOptimization ?? false,
+          hideOnPress ?? false
         )
     )
     ipcMain.handle('unregister-global-shortcut', (_event, shortcut: string) =>
@@ -242,11 +248,8 @@ export class SettingsAPI {
     )
     ipcMain.handle(
       'update-global-shortcut-config',
-      (
-        _event,
-        shortcut: string,
-        config: { autoCopy: boolean; preScreenshotOptimization: boolean }
-      ) => this.updateGlobalShortcutConfig(shortcut, config)
+      (_event, shortcut: string, config: GlobalShortcutRuntimeConfig) =>
+        this.updateGlobalShortcutConfig(shortcut, config)
     )
 
     // 应用快捷键
@@ -342,7 +345,8 @@ export class SettingsAPI {
                 shortcut.shortcut,
                 shortcut.target,
                 shortcut.autoCopy ?? false,
-                shortcut.preScreenshotOptimization ?? false
+                shortcut.preScreenshotOptimization ?? false,
+                shortcut.hideOnPress ?? false
               )
             } catch (error) {
               console.error(`注册全局快捷键失败: ${shortcut.shortcut}`, error)
@@ -439,15 +443,16 @@ export class SettingsAPI {
     shortcut: string,
     target: string,
     autoCopy: boolean = false,
-    preScreenshotOptimization: boolean = false
+    preScreenshotOptimization: boolean = false,
+    hideOnPress: boolean = false
   ): Promise<any> {
     console.log(
-      `[Settings] 注册全局快捷键: ${shortcut} -> ${target}, autoCopy: ${autoCopy}, preScreenshotOptimization: ${preScreenshotOptimization}`
+      `[Settings] 注册全局快捷键: ${shortcut} -> ${target}, autoCopy: ${autoCopy}, preScreenshotOptimization: ${preScreenshotOptimization}, hideOnPress: ${hideOnPress}`
     )
 
     try {
       // 存储快捷键配置
-      this.globalShortcutConfigs.set(shortcut, { autoCopy, preScreenshotOptimization })
+      this.globalShortcutConfigs.set(shortcut, { autoCopy, preScreenshotOptimization, hideOnPress })
       this.globalShortcutTargets.set(shortcut, target)
       console.log('[Settings] 快捷键配置已存储到 Map')
 
@@ -545,17 +550,22 @@ export class SettingsAPI {
    */
   public async updateGlobalShortcutConfig(
     shortcut: string,
-    config: { autoCopy: boolean; preScreenshotOptimization: boolean }
+    config: GlobalShortcutRuntimeConfig
   ): Promise<{ success: boolean; error?: string }> {
     const previousConfig = this.globalShortcutConfigs.get(shortcut)
     const previousTarget = this.globalShortcutTargets.get(shortcut)
     const previousPreparation = this.globalShortcutPreparations.get(shortcut)
+    const nextConfig: GlobalShortcutRuntimeConfig = {
+      autoCopy: config.autoCopy ?? false,
+      preScreenshotOptimization: config.preScreenshotOptimization ?? false,
+      hideOnPress: config.hideOnPress ?? false
+    }
 
     try {
       console.log(
-        `[Settings] 更新全局快捷键配置: ${shortcut}, autoCopy: ${config.autoCopy}, preScreenshotOptimization: ${config.preScreenshotOptimization}`
+        `[Settings] 更新全局快捷键配置: ${shortcut}, autoCopy: ${nextConfig.autoCopy}, preScreenshotOptimization: ${nextConfig.preScreenshotOptimization}, hideOnPress: ${nextConfig.hideOnPress}`
       )
-      this.globalShortcutConfigs.set(shortcut, config)
+      this.globalShortcutConfigs.set(shortcut, nextConfig)
       const rebindResult = await this.rebindGlobalShortcut(shortcut)
       if (!rebindResult.success) {
         if (previousConfig) {
@@ -632,11 +642,19 @@ export class SettingsAPI {
       const config = this.globalShortcutConfigs.get(shortcut)
       const autoCopy = config?.autoCopy ?? false
       const preScreenshotOptimization = config?.preScreenshotOptimization ?? false
+      const hideOnPress = config?.hideOnPress ?? false
 
       console.log(`[Settings] 快捷键触发: ${shortcut}`)
       console.log(`[Settings] 指令类型需要文本: ${preparation.shouldCaptureSelectedText}`)
       console.log(`[Settings] 用户启用自动复制: ${autoCopy}`)
       console.log(`[Settings] 用户启用预截图优化: ${preScreenshotOptimization}`)
+      console.log(`[Settings] 用户启用按下隐藏: ${hideOnPress}`)
+
+      if (hideOnPress && this.shouldHideWindowOnRepeatPress()) {
+        console.log(`[Settings] 窗口已显示，按下隐藏并恢复上一应用: ${shortcut}`)
+        windowManager.hideWindow(true)
+        return
+      }
 
       if (preScreenshotOptimization && !skipPrime) {
         primeScreenCaptureFrame()
@@ -660,6 +678,14 @@ export class SettingsAPI {
    */
   private shouldTriggerGlobalShortcut(_target: string): boolean {
     return !this.isGlobalShortcutTriggering
+  }
+
+  /**
+   * 窗口已显示且聚焦时，开启「按下隐藏」的快捷键再次按下应藏窗。
+   */
+  private shouldHideWindowOnRepeatPress(): boolean {
+    const mainWindow = windowManager.getMainWindow() ?? this.mainWindow
+    return Boolean(mainWindow?.isVisible() && mainWindow.isFocused())
   }
 
   /**

--- a/src/main/api/renderer/settings.ts
+++ b/src/main/api/renderer/settings.ts
@@ -79,9 +79,8 @@ export class SettingsAPI {
   // 全局快捷键触发流程执行中时，后续触发会被忽略，避免重复复制和重复启动。
   private isGlobalShortcutTriggering = false
   /**
-   * hideOnPress 只负责 ZTools 自己：主窗可见且自己是前台时再按 → hideWindow（macOS 为 app.hide）。
-   * 不在前台时照常 launch 绑定命令，不 show 首页。
-   * 不恢复 hideOnPressPendingHideShortcut。
+   * 主窗/搜索框已出来时先系统级 hide（macOS app.hide），再 launch 绑定命令。
+   * hideOnPress 不得把这次按键吃成只 hide、不 launch。不 show 首页。
    */
 
   // 启动 native 优化快捷键监听，并把命中事件回流到既有执行链路。
@@ -648,10 +647,10 @@ export class SettingsAPI {
       console.log(`[Settings] 用户启用预截图优化: ${preScreenshotOptimization}`)
       console.log(`[Settings] 用户启用按下隐藏: ${hideOnPress}`)
 
-      if (hideOnPress && this.isZToolsInForeground()) {
-        console.log(`[Settings] ZTools 前台，按下隐藏: ${shortcut}`)
+      // 搜索框/主窗已出来：先系统级隐藏，再执行绑定命令。绝不能只 hide 不 launch。
+      if (this.isZToolsMainWindowVisible()) {
+        console.log(`[Settings] 主窗可见，先隐藏再执行绑定命令: ${shortcut}`)
         windowManager.hideWindow(true)
-        return
       }
 
       if (preScreenshotOptimization && !skipPrime) {
@@ -687,11 +686,12 @@ export class SettingsAPI {
   }
 
   /**
-   * ZTools 是否在前台：主窗可见且聚焦，或插件视图聚焦。
+   * 搜索框/主窗是否已出来。只看可见，不要求聚焦：
+   * macOS 搜索框常是 alwaysOnTop panel，焦点可能不在 ZTools。
    */
-  private isZToolsInForeground(): boolean {
+  private isZToolsMainWindowVisible(): boolean {
     const mainWindow = windowManager.getMainWindow() ?? this.mainWindow
-    if (mainWindow?.isVisible() && mainWindow?.isFocused()) {
+    if (mainWindow?.isVisible()) {
       return true
     }
     return this.pluginManager?.isPluginViewFocused() === true

--- a/src/main/core/commandScanner/macScanner.ts
+++ b/src/main/core/commandScanner/macScanner.ts
@@ -405,7 +405,8 @@ export async function scanApplications(): Promise<Command[]> {
           path: appPath,
           icon: iconUrl,
           aliases,
-          acronym: acronymSource ? extractAcronym(acronymSource) : ''
+          acronym: acronymSource ? extractAcronym(acronymSource) : '',
+          isSystemApp: appPath.startsWith('/System/Applications/')
         }
       } catch {
         const name = path.basename(appPath, '.app')
@@ -413,7 +414,8 @@ export async function scanApplications(): Promise<Command[]> {
           name,
           path: appPath,
           icon: `ztools-icon://${encodeURIComponent(appPath)}`,
-          acronym: extractAcronym(name)
+          acronym: extractAcronym(name),
+          isSystemApp: appPath.startsWith('/System/Applications/')
         }
       }
     })

--- a/src/main/core/commandScanner/types.ts
+++ b/src/main/core/commandScanner/types.ts
@@ -4,6 +4,7 @@ export interface Command {
   icon?: string
   aliases?: string[]
   acronym?: string // 英文首字母缩写（用于搜索）
+  isSystemApp?: boolean // macOS /System/Applications 下的系统自带应用
 }
 
 export interface AppScanner {

--- a/src/main/managers/windowManager.ts
+++ b/src/main/managers/windowManager.ts
@@ -786,14 +786,8 @@ class WindowManager {
     // 判断窗口是否聚焦显示
     // 修复：同时检查聚焦和可见状态，避免alert弹窗后判断错误
     if (isFocused && isVisible) {
-      // 窗口已显示且聚焦 → 隐藏
-
-      // 记录当前的焦点状态（在隐藏之前）
-      this.recordFocusState()
-
-      this.mainWindow.blur()
-      this.mainWindow.hide()
-      this.restorePreviousWindow()
+      // 窗口已显示且聚焦 → 隐藏（macOS 走 app.hide，不是 win.hide/minimize）
+      this.hideWindow(true)
     } else {
       // 窗口已隐藏或失焦 → 显示并强制激活
       // 但如果是刚刚因为 blur 事件隐藏的（点击托盘图标导致失焦），
@@ -966,6 +960,11 @@ class WindowManager {
    */
   public showWindow(): void {
     if (!this.mainWindow) return
+
+    // app.hide() 之后必须 app.show() 才能再唤出；与 hide 成对，不抢占其它 App 的搜索框逻辑。
+    if (platform.isMacOS && typeof app.isHidden === 'function' && app.isHidden()) {
+      app.show()
+    }
 
     // 开始恢复焦点流程，防止 focus 事件监听器修改 lastFocusTarget
     this.isRestoringFocus = true

--- a/src/main/managers/windowManager.ts
+++ b/src/main/managers/windowManager.ts
@@ -999,7 +999,10 @@ class WindowManager {
   }
 
   /**
-   * 隐藏窗口
+   * 隐藏窗口。
+   * macOS 且需要还焦点时走系统级 Hide Application（app.hide / 等价 Cmd+H），
+   * 不要 win.hide / minimize，也不要再叠 restorePreviousWindow。
+   * Windows / Linux 仍 hide BrowserWindow 后再 restorePreviousWindow。
    */
   public hideWindow(_restoreFocus: boolean = true): void {
     console.log('[Window] 隐藏窗口', _restoreFocus)
@@ -1007,9 +1010,13 @@ class WindowManager {
     // 记录当前的焦点状态（在隐藏之前）
     this.recordFocusState()
 
-    this.mainWindow?.hide()
-    if (_restoreFocus) {
-      this.restorePreviousWindow()
+    if (platform.isMacOS && _restoreFocus) {
+      app.hide()
+    } else {
+      this.mainWindow?.hide()
+      if (_restoreFocus) {
+        this.restorePreviousWindow()
+      }
     }
 
     // 启动自动返回搜索定时器

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -335,22 +335,20 @@ const api = {
     shortcut: string,
     target: string,
     autoCopy?: boolean,
-    preScreenshotOptimization?: boolean,
-    hideOnPress?: boolean
+    preScreenshotOptimization?: boolean
   ) =>
     ipcRenderer.invoke(
       'register-global-shortcut',
       shortcut,
       target,
       autoCopy,
-      preScreenshotOptimization,
-      hideOnPress
+      preScreenshotOptimization
     ),
   unregisterGlobalShortcut: (shortcut: string) =>
     ipcRenderer.invoke('unregister-global-shortcut', shortcut),
   updateGlobalShortcutConfig: (
     shortcut: string,
-    config: { autoCopy: boolean; preScreenshotOptimization: boolean; hideOnPress: boolean }
+    config: { autoCopy: boolean; preScreenshotOptimization: boolean }
   ) => ipcRenderer.invoke('update-global-shortcut-config', shortcut, config),
   // 快捷键录制（临时注册，触发后自动注销）
   startHotkeyRecording: () => ipcRenderer.invoke('start-hotkey-recording'),
@@ -719,13 +717,12 @@ declare global {
         shortcut: string,
         target: string,
         autoCopy?: boolean,
-        preScreenshotOptimization?: boolean,
-        hideOnPress?: boolean
+        preScreenshotOptimization?: boolean
       ) => Promise<{ success: boolean; error?: string }>
       unregisterGlobalShortcut: (shortcut: string) => Promise<{ success: boolean; error?: string }>
       updateGlobalShortcutConfig: (
         shortcut: string,
-        config: { autoCopy: boolean; preScreenshotOptimization: boolean; hideOnPress: boolean }
+        config: { autoCopy: boolean; preScreenshotOptimization: boolean }
       ) => Promise<{ success: boolean; error?: string }>
       // 窗口相关
       windowPaste: () => Promise<{ success: boolean; error?: string }>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -335,20 +335,22 @@ const api = {
     shortcut: string,
     target: string,
     autoCopy?: boolean,
-    preScreenshotOptimization?: boolean
+    preScreenshotOptimization?: boolean,
+    hideOnPress?: boolean
   ) =>
     ipcRenderer.invoke(
       'register-global-shortcut',
       shortcut,
       target,
       autoCopy,
-      preScreenshotOptimization
+      preScreenshotOptimization,
+      hideOnPress
     ),
   unregisterGlobalShortcut: (shortcut: string) =>
     ipcRenderer.invoke('unregister-global-shortcut', shortcut),
   updateGlobalShortcutConfig: (
     shortcut: string,
-    config: { autoCopy: boolean; preScreenshotOptimization: boolean }
+    config: { autoCopy: boolean; preScreenshotOptimization: boolean; hideOnPress: boolean }
   ) => ipcRenderer.invoke('update-global-shortcut-config', shortcut, config),
   // 快捷键录制（临时注册，触发后自动注销）
   startHotkeyRecording: () => ipcRenderer.invoke('start-hotkey-recording'),
@@ -717,12 +719,13 @@ declare global {
         shortcut: string,
         target: string,
         autoCopy?: boolean,
-        preScreenshotOptimization?: boolean
+        preScreenshotOptimization?: boolean,
+        hideOnPress?: boolean
       ) => Promise<{ success: boolean; error?: string }>
       unregisterGlobalShortcut: (shortcut: string) => Promise<{ success: boolean; error?: string }>
       updateGlobalShortcutConfig: (
         shortcut: string,
-        config: { autoCopy: boolean; preScreenshotOptimization: boolean }
+        config: { autoCopy: boolean; preScreenshotOptimization: boolean; hideOnPress: boolean }
       ) => Promise<{ success: boolean; error?: string }>
       // 窗口相关
       windowPaste: () => Promise<{ success: boolean; error?: string }>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -270,6 +270,9 @@ const api = {
       callback(showRecentInSearch)
     )
   },
+  onUpdateShowSystemApps: (callback: (showSystemApps: boolean) => void) => {
+    ipcRenderer.on('update-show-system-apps', (_event, showSystemApps) => callback(showSystemApps))
+  },
   onUpdateMatchRecommendation: (callback: (showMatchRecommendation: boolean) => void) => {
     ipcRenderer.on('update-match-recommendation', (_event, showMatchRecommendation) =>
       callback(showMatchRecommendation)
@@ -733,6 +736,7 @@ declare global {
       onUpdateTabKeyFunction: (callback: (mode: 'navigate' | 'target-command') => void) => void
       onUpdateSpaceOpenCommand: (callback: (enabled: boolean) => void) => void
       onUpdateShowRecentInSearch: (callback: (showRecentInSearch: boolean) => void) => void
+      onUpdateShowSystemApps: (callback: (showSystemApps: boolean) => void) => void
       onUpdateMatchRecommendation: (callback: (showMatchRecommendation: boolean) => void) => void
       onAutoCheckUpdateChanged: (callback: (enabled: boolean) => void) => () => void
       // 数据库相关（主程序专用，直接操作 ZTOOLS 命名空间）

--- a/src/renderer/src/App.vue
+++ b/src/renderer/src/App.vue
@@ -761,6 +761,10 @@ onMounted(async () => {
     windowStore.updateShowRecentInSearch(showRecentInSearch)
   })
 
+  window.ztools.onUpdateShowSystemApps((showSystemApps: boolean) => {
+    windowStore.updateShowSystemApps(showSystemApps)
+  })
+
   // 监听匹配推荐配置更新事件
   window.ztools.onUpdateMatchRecommendation((showMatchRecommendation: boolean) => {
     windowStore.updateShowMatchRecommendation(showMatchRecommendation)

--- a/src/renderer/src/components/common/CollapsibleList.vue
+++ b/src/renderer/src/components/common/CollapsibleList.vue
@@ -1,17 +1,20 @@
 <template>
-  <div v-if="apps.length > 0" class="collapsible-section">
+  <div v-if="apps.length > 0 || hasHeaderExtra" class="collapsible-section">
     <div
       class="section-header"
       :class="{ clickable: canExpand }"
       @click="canExpand ? toggleExpand() : undefined"
     >
       <div class="section-title">{{ title }}</div>
-      <div v-if="canExpand" class="expand-btn-text">
-        {{ isExpanded ? '收起' : `展开 (${apps.length})` }}
+      <div class="header-actions">
+        <slot name="header-extra" />
+        <div v-if="canExpand" class="expand-btn-text">
+          {{ isExpanded ? '收起' : `展开 (${apps.length})` }}
+        </div>
       </div>
     </div>
     <!-- 统一使用 CommandList，通过 draggable prop 控制 -->
-    <div class="list-content">
+    <div v-if="apps.length > 0" class="list-content">
       <AppList
         :apps="visibleApps"
         :selected-index="selectedIndex"
@@ -28,9 +31,12 @@
 </template>
 
 <script setup lang="ts">
-import { computed, toValue, type MaybeRefOrGetter } from 'vue'
+import { computed, toValue, useSlots, type MaybeRefOrGetter } from 'vue'
 import type { Command } from '../../stores/commandDataStore'
 import AppList from './CommandList.vue'
+
+const slots = useSlots()
+const hasHeaderExtra = computed(() => Boolean(slots['header-extra']))
 
 interface Props {
   title: string // 标题
@@ -158,6 +164,12 @@ function handleAppsUpdate(newOrder: Command[]): void {
   line-height: 24px; /* 控制行高 */
 }
 
+.header-actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
 .expand-btn-text {
   font-size: 14px;
   opacity: 0.6;
@@ -165,8 +177,16 @@ function handleAppsUpdate(newOrder: Command[]): void {
   white-space: nowrap; /* 防止文本换行 */
 }
 
+:slotted(.expand-btn-text) {
+  font-size: 14px;
+  opacity: 0.6;
+  user-select: none;
+  white-space: nowrap;
+}
+
 /* 只在可点击状态下，hover 时改变透明度 */
-.section-header.clickable:hover .expand-btn-text {
+.section-header.clickable:hover .expand-btn-text,
+.section-header.clickable:hover :slotted(.expand-btn-text) {
   opacity: 1;
 }
 </style>

--- a/src/renderer/src/components/search/AggregateView.vue
+++ b/src/renderer/src/components/search/AggregateView.vue
@@ -35,7 +35,7 @@
     <div v-if="hasSearchContent" class="search-results">
       <!-- 最佳搜索结果（模糊搜索） -->
       <CollapsibleList
-        v-if="bestSearchResults.length > 0"
+        v-if="bestSearchResults.length > 0 || canToggleSystemApps"
         :expanded="searchResultsExpanded"
         title="最佳搜索结果"
         :apps="bestSearchResults"
@@ -47,7 +47,17 @@
         @select="$emit('select', $event)"
         @contextmenu="(app) => $emit('contextmenu', app, 'search')"
         @update:expanded="$emit('update:search-results-expanded', $event)"
-      />
+      >
+        <template v-if="canToggleSystemApps" #header-extra>
+          <button
+            type="button"
+            class="expand-btn-text system-apps-chip"
+            @click.stop="$emit('toggle-system-apps')"
+          >
+            {{ showSystemApps ? '隐藏系统应用' : '显示系统应用' }}
+          </button>
+        </template>
+      </CollapsibleList>
 
       <!-- 最佳匹配（匹配指令：regex/img/files） -->
       <CollapsibleList
@@ -141,6 +151,8 @@ interface Props {
   searchResultsExpanded?: boolean
   bestMatchesExpanded?: boolean
   recommendationsExpanded?: boolean
+  showSystemApps?: boolean
+  canToggleSystemApps?: boolean
 }
 
 type ContextMenuSource = 'history' | 'pinned' | 'search' | 'recommendation'
@@ -150,7 +162,9 @@ const props = withDefaults(defineProps<Props>(), {
   pinnedExpanded: false,
   searchResultsExpanded: false,
   bestMatchesExpanded: false,
-  recommendationsExpanded: false
+  recommendationsExpanded: false,
+  showSystemApps: false,
+  canToggleSystemApps: false
 })
 
 defineEmits<{
@@ -167,6 +181,7 @@ defineEmits<{
   'update:search-results-expanded': [value: boolean]
   'update:best-matches-expanded': [value: boolean]
   'update:recommendations-expanded': [value: boolean]
+  'toggle-system-apps': []
 }>()
 
 // 是否有搜索内容
@@ -238,5 +253,18 @@ function getMainPushSelectedIndex(featureKey: string): number {
 .search-results {
   display: flex;
   flex-direction: column;
+}
+
+.system-apps-chip {
+  background: none;
+  border: none;
+  padding: 0;
+  color: inherit;
+  cursor: pointer;
+  font: inherit;
+}
+
+.system-apps-chip:hover {
+  opacity: 1;
 }
 </style>

--- a/src/renderer/src/components/search/SearchResults.vue
+++ b/src/renderer/src/components/search/SearchResults.vue
@@ -27,6 +27,8 @@
       :show-recent-in-search="showRecentInSearch"
       :recent-rows="windowStore.recentRows"
       :pinned-rows="windowStore.pinnedRows"
+      :show-system-apps="showSystemApps"
+      :can-toggle-system-apps="canToggleSystemApps"
       @select="handleSelectApp"
       @select-window="handleWindowAction"
       @select-recommendation="handleRecommendationSelect"
@@ -35,10 +37,16 @@
       @contextmenu="handleAppContextMenu"
       @update:pinned-order="updatePinnedOrder"
       @height-changed="emit('height-changed')"
+      @toggle-system-apps="toggleShowSystemApps"
     />
 
     <!-- 列表模式 -->
     <div v-if="searchMode === 'list' && hasSearchContent" class="list-mode-results">
+      <div v-if="canToggleSystemApps" class="list-system-apps-row">
+        <button type="button" class="system-apps-chip" @click.stop="toggleShowSystemApps">
+          {{ showSystemApps ? '隐藏系统应用' : '显示系统应用' }}
+        </button>
+      </div>
       <VerticalList
         :apps="allListModeResults"
         :selected-index="listModeSelectedIndex"
@@ -128,8 +136,16 @@ const {
 } = commandDataStore
 
 // 使用搜索结果 composable
-const { bestSearchResults, bestMatches, recommendations, allListModeResults } =
-  useSearchResults(props)
+const {
+  bestSearchResults,
+  bestMatches,
+  recommendations,
+  allListModeResults,
+  hasMatchingSystemApps
+} = useSearchResults(props)
+
+const showSystemApps = computed(() => windowStore.showSystemApps)
+const canToggleSystemApps = computed(() => hasMatchingSystemApps.value)
 
 // 为推荐项附加仅用于渲染的置顶状态，避免把 UI 字段写入固定列表数据。
 const recommendationItems = computed(() =>
@@ -1055,9 +1071,21 @@ async function handleContextMenuCommand(command: string): Promise<void> {
 }
 
 // 点击容器聚焦输入框
+async function toggleShowSystemApps(): Promise<void> {
+  const next = !windowStore.showSystemApps
+  windowStore.updateShowSystemApps(next)
+  try {
+    const settings = (await window.ztools.dbGet('settings-general')) || {}
+    await window.ztools.dbPut('settings-general', { ...settings, showSystemApps: next })
+  } catch (error) {
+    console.error('保存系统自带应用显示配置失败:', error)
+  }
+  emit('height-changed')
+}
+
 function handleContainerClick(event: MouseEvent): void {
   const target = event.target as HTMLElement
-  if (target.closest('.app-item')) {
+  if (target.closest('.app-item') || target.closest('.system-apps-chip')) {
     return
   }
   emit('focus-input')
@@ -1108,5 +1136,30 @@ defineExpose({
 .list-mode-results {
   display: flex;
   flex-direction: column;
+}
+
+.list-system-apps-row {
+  display: flex;
+  justify-content: flex-end;
+  padding: 2px 12px;
+  min-height: 28px;
+  align-items: center;
+}
+
+.system-apps-chip {
+  background: none;
+  border: none;
+  padding: 0;
+  color: inherit;
+  cursor: pointer;
+  font: inherit;
+  font-size: 14px;
+  opacity: 0.6;
+  user-select: none;
+  white-space: nowrap;
+}
+
+.system-apps-chip:hover {
+  opacity: 1;
 }
 </style>

--- a/src/renderer/src/composables/useSearchResults.ts
+++ b/src/renderer/src/composables/useSearchResults.ts
@@ -3,6 +3,17 @@ import { useCommandDataStore } from '../stores/commandDataStore'
 import { useWindowStore } from '../stores/windowStore'
 
 /**
+ * 默认过滤系统自带应用；历史/固定列表不走这里。
+ */
+export function excludeHiddenSystemApps<T extends { isSystemApp?: boolean }>(
+  results: T[],
+  showSystemApps: boolean
+): T[] {
+  if (showSystemApps) return results
+  return results.filter((item) => !item.isSystemApp)
+}
+
+/**
  * 去重：同一个 feature 只保留第一个匹配的 cmd
  * 插件类型用 path+featureCode 去重，非插件用 name+path 去重
  */
@@ -52,6 +63,7 @@ export function useSearchResults(props: {
   bestMatches: any
   recommendations: any
   allListModeResults: any
+  hasMatchingSystemApps: any
 } {
   const commandDataStore = useCommandDataStore()
   const windowStore = useWindowStore()
@@ -110,7 +122,7 @@ export function useSearchResults(props: {
   })
 
   // 最佳搜索结果（模糊搜索：应用、插件、系统设置）
-  const bestSearchResults = computed(() => {
+  const rawBestSearchResults = computed(() => {
     // 粘贴图片或文件时不显示最佳搜索结果
     if (props.pastedImage || props.pastedFiles) {
       return []
@@ -152,6 +164,14 @@ export function useSearchResults(props: {
 
     return filterUnavailableWindowCommands(unifiedSearchResult.value.bestMatches)
   })
+
+  const hasMatchingSystemApps = computed(() =>
+    rawBestSearchResults.value.some((item: { isSystemApp?: boolean }) => item.isSystemApp)
+  )
+
+  const bestSearchResults = computed(() =>
+    excludeHiddenSystemApps(rawBestSearchResults.value, windowStore.showSystemApps)
+  )
 
   // 最佳匹配（匹配指令：regex/img/files 类型）
   const bestMatches = computed(() => {
@@ -292,6 +312,7 @@ export function useSearchResults(props: {
     bestSearchResults,
     bestMatches,
     recommendations,
-    allListModeResults
+    allListModeResults,
+    hasMatchingSystemApps
   }
 }

--- a/src/renderer/src/env.d.ts
+++ b/src/renderer/src/env.d.ts
@@ -227,12 +227,13 @@ declare global {
         shortcut: string,
         target: string,
         autoCopy?: boolean,
-        preScreenshotOptimization?: boolean
+        preScreenshotOptimization?: boolean,
+        hideOnPress?: boolean
       ) => Promise<{ success: boolean; error?: string }>
       unregisterGlobalShortcut: (shortcut: string) => Promise<{ success: boolean; error?: string }>
       updateGlobalShortcutConfig: (
         shortcut: string,
-        config: { autoCopy: boolean; preScreenshotOptimization: boolean }
+        config: { autoCopy: boolean; preScreenshotOptimization: boolean; hideOnPress: boolean }
       ) => Promise<{ success: boolean; error?: string }>
       // 快捷键录制（临时注册，触发后自动注销）
       startHotkeyRecording: () => Promise<{ success: boolean; error?: string }>

--- a/src/renderer/src/env.d.ts
+++ b/src/renderer/src/env.d.ts
@@ -227,13 +227,12 @@ declare global {
         shortcut: string,
         target: string,
         autoCopy?: boolean,
-        preScreenshotOptimization?: boolean,
-        hideOnPress?: boolean
+        preScreenshotOptimization?: boolean
       ) => Promise<{ success: boolean; error?: string }>
       unregisterGlobalShortcut: (shortcut: string) => Promise<{ success: boolean; error?: string }>
       updateGlobalShortcutConfig: (
         shortcut: string,
-        config: { autoCopy: boolean; preScreenshotOptimization: boolean; hideOnPress: boolean }
+        config: { autoCopy: boolean; preScreenshotOptimization: boolean }
       ) => Promise<{ success: boolean; error?: string }>
       // 快捷键录制（临时注册，触发后自动注销）
       startHotkeyRecording: () => Promise<{ success: boolean; error?: string }>

--- a/src/renderer/src/env.d.ts
+++ b/src/renderer/src/env.d.ts
@@ -288,6 +288,7 @@ declare global {
       onUpdateAutoPaste: (callback: (autoPaste: string) => void) => void
       onUpdateAutoClear: (callback: (autoClear: string) => void) => void
       onUpdateShowRecentInSearch: (callback: (showRecentInSearch: boolean) => void) => void
+      onUpdateShowSystemApps: (callback: (showSystemApps: boolean) => void) => void
       onUpdateMatchRecommendation: (callback: (showMatchRecommendation: boolean) => void) => void
       onUpdateRecentRows: (callback: (rows: number) => void) => void
       onUpdatePinnedRows: (callback: (rows: number) => void) => void

--- a/src/renderer/src/stores/commandDataStore.ts
+++ b/src/renderer/src/stores/commandDataStore.ts
@@ -117,6 +117,7 @@ export interface Command {
   confirmDialog?: any // 确认对话框配置
   originalName?: string // 原始名称（用于 direct/app 旧版禁用键兼容）
   persistedName?: string // 持久化记录里的名称（用于历史/固定在 alias 删除后的删除与取消固定）
+  isSystemApp?: boolean // macOS /System/Applications 下的系统自带应用
 }
 
 interface SearchResultScoreMeta {

--- a/src/renderer/src/stores/windowStore.ts
+++ b/src/renderer/src/stores/windowStore.ts
@@ -95,6 +95,7 @@ export const useWindowStore = defineStore('window', () => {
   const autoClear = ref<AutoClearOption>('immediately')
   const showRecentInSearch = ref(true)
   const showMatchRecommendation = ref(true)
+  const showSystemApps = ref(false)
   // 最近使用显示行数
   const recentRows = ref(2)
   // 固定栏显示行数
@@ -214,6 +215,10 @@ export const useWindowStore = defineStore('window', () => {
 
   function updateShowMatchRecommendation(value: boolean): void {
     showMatchRecommendation.value = value
+  }
+
+  function updateShowSystemApps(value: boolean): void {
+    showSystemApps.value = value
   }
 
   function updateRecentRows(rows: number): void {
@@ -649,6 +654,9 @@ export const useWindowStore = defineStore('window', () => {
         if (data.showMatchRecommendation !== undefined) {
           showMatchRecommendation.value = data.showMatchRecommendation
         }
+        if (data.showSystemApps !== undefined) {
+          showSystemApps.value = data.showSystemApps
+        }
         if (data.recentRows) {
           recentRows.value = data.recentRows
         }
@@ -708,6 +716,7 @@ export const useWindowStore = defineStore('window', () => {
     autoClear,
     showRecentInSearch,
     showMatchRecommendation,
+    showSystemApps,
     theme,
     primaryColor,
     customColor,
@@ -729,6 +738,7 @@ export const useWindowStore = defineStore('window', () => {
     updateAutoClear,
     updateShowRecentInSearch,
     updateShowMatchRecommendation,
+    updateShowSystemApps,
     recentRows,
     pinnedRows,
     updateRecentRows,

--- a/tests/main/settingsHideOnPress.test.ts
+++ b/tests/main/settingsHideOnPress.test.ts
@@ -103,10 +103,14 @@ describe('SettingsAPI hideOnPress', () => {
     setGlobalHideOnPress(false)
   })
 
-  async function registerShortcut(): Promise<void> {
+  async function registerShortcut(target = 'demo/action'): Promise<void> {
+    mocks.prepareGlobalShortcut.mockResolvedValue({
+      target,
+      shouldCaptureSelectedText: false
+    })
     const settings = new SettingsAPI()
     settings.setGlobalShortcutHandler(launchHandler)
-    const result = await settings.registerGlobalShortcut('Alt+1', 'demo/action', false, false)
+    const result = await settings.registerGlobalShortcut('Alt+1', target, false, false)
     expect(result).toEqual({ success: true })
     expect(triggerShortcut).toBeTypeOf('function')
   }
@@ -125,8 +129,8 @@ describe('SettingsAPI hideOnPress', () => {
     })
   }
 
-  async function registerAndTrigger(): Promise<void> {
-    await registerShortcut()
+  async function registerAndTrigger(target = 'demo/action'): Promise<void> {
+    await registerShortcut(target)
     await pressShortcut()
   }
 
@@ -139,39 +143,38 @@ describe('SettingsAPI hideOnPress', () => {
     expect(launchHandler).not.toHaveBeenCalled()
   })
 
-  it('ZTools 已藏时再按 show，不 hide 不 launch', async () => {
+  it('不在前台按绑了插件/App 的快捷键必须 launch', async () => {
     setGlobalHideOnPress(true)
     setWindowState(false, false)
-    await registerAndTrigger()
-    expect(mocks.showWindow).toHaveBeenCalledTimes(1)
+    await registerAndTrigger('apps/Calculator')
+    expect(launchHandler).toHaveBeenCalledWith('apps/Calculator', undefined)
     expect(mocks.hideWindow).not.toHaveBeenCalled()
-    expect(launchHandler).not.toHaveBeenCalled()
+    expect(mocks.showWindow).not.toHaveBeenCalled()
   })
 
-  it('别的 App 前台（主窗仍可见但未聚焦）再按 show，不 hide 不 launch', async () => {
+  it('别的 App 前台（主窗可见但未聚焦）再按必须 launch', async () => {
     setGlobalHideOnPress(true)
     setWindowState(true, false)
-    await registerAndTrigger()
-    expect(mocks.showWindow).toHaveBeenCalledTimes(1)
+    await registerAndTrigger('plugin/screenshot')
+    expect(launchHandler).toHaveBeenCalledWith('plugin/screenshot', undefined)
     expect(mocks.hideWindow).not.toHaveBeenCalled()
-    expect(launchHandler).not.toHaveBeenCalled()
+    expect(mocks.showWindow).not.toHaveBeenCalled()
   })
 
-  it('launch App 后下一键是 show 不是 hide/relaunch', async () => {
+  it('launch App 后再按仍 launch，不 show 首页', async () => {
     setGlobalHideOnPress(true)
-    // AppsAPI.launch 计算器/访达后主窗已藏，ZTools 不在前台
     setWindowState(false, false)
-    await registerAndTrigger()
-    expect(mocks.showWindow).toHaveBeenCalledTimes(1)
+    await registerAndTrigger('apps/Finder')
+    expect(launchHandler).toHaveBeenCalledTimes(1)
+    expect(launchHandler).toHaveBeenCalledWith('apps/Finder', undefined)
+    expect(mocks.showWindow).not.toHaveBeenCalled()
     expect(mocks.hideWindow).not.toHaveBeenCalled()
-    expect(launchHandler).not.toHaveBeenCalled()
 
-    // 再按仍 SHOW，不能被 pending-hide 吃掉，也不能 relaunch
     setWindowState(false, false)
     await pressShortcut()
-    expect(mocks.showWindow).toHaveBeenCalledTimes(2)
+    expect(launchHandler).toHaveBeenCalledTimes(2)
+    expect(mocks.showWindow).not.toHaveBeenCalled()
     expect(mocks.hideWindow).not.toHaveBeenCalled()
-    expect(launchHandler).not.toHaveBeenCalled()
   })
 
   it('未配置时默认关，窗口已显示也只唤起', async () => {

--- a/tests/main/settingsHideOnPress.test.ts
+++ b/tests/main/settingsHideOnPress.test.ts
@@ -159,15 +159,18 @@ describe('SettingsAPI hideOnPress', () => {
 
   it('launch App 后下一键是 show 不是 hide/relaunch', async () => {
     setGlobalHideOnPress(true)
-    setWindowState(true, true)
+    // AppsAPI.launch 计算器/访达后主窗已藏，ZTools 不在前台
+    setWindowState(false, false)
     await registerAndTrigger()
-    expect(mocks.hideWindow).toHaveBeenCalledTimes(1)
+    expect(mocks.showWindow).toHaveBeenCalledTimes(1)
+    expect(mocks.hideWindow).not.toHaveBeenCalled()
     expect(launchHandler).not.toHaveBeenCalled()
 
+    // 再按仍 SHOW，不能被 pending-hide 吃掉，也不能 relaunch
     setWindowState(false, false)
     await pressShortcut()
-    expect(mocks.showWindow).toHaveBeenCalledTimes(1)
-    expect(mocks.hideWindow).toHaveBeenCalledTimes(1)
+    expect(mocks.showWindow).toHaveBeenCalledTimes(2)
+    expect(mocks.hideWindow).not.toHaveBeenCalled()
     expect(launchHandler).not.toHaveBeenCalled()
   })
 

--- a/tests/main/settingsHideOnPress.test.ts
+++ b/tests/main/settingsHideOnPress.test.ts
@@ -134,13 +134,16 @@ describe('SettingsAPI hideOnPress', () => {
     await pressShortcut()
   }
 
-  it('ZTools 前台再按 hide，不 launch', async () => {
+  it('主窗可见时按第三方 App 热键：先 hide 再 launch，不 show 首页', async () => {
     setGlobalHideOnPress(true)
     setWindowState(true, true)
-    await registerAndTrigger()
+    await registerAndTrigger('apps/Calculator')
     expect(mocks.hideWindow).toHaveBeenCalledWith(true)
+    expect(launchHandler).toHaveBeenCalledWith('apps/Calculator', undefined)
     expect(mocks.showWindow).not.toHaveBeenCalled()
-    expect(launchHandler).not.toHaveBeenCalled()
+    expect(mocks.hideWindow.mock.invocationCallOrder[0]).toBeLessThan(
+      launchHandler.mock.invocationCallOrder[0]
+    )
   })
 
   it('不在前台按绑了插件/App 的快捷键必须 launch', async () => {
@@ -152,12 +155,23 @@ describe('SettingsAPI hideOnPress', () => {
     expect(mocks.showWindow).not.toHaveBeenCalled()
   })
 
-  it('别的 App 前台（主窗可见但未聚焦）再按必须 launch', async () => {
+  it('主窗可见但未聚焦时按第三方热键也是先 hide 再 launch', async () => {
     setGlobalHideOnPress(true)
     setWindowState(true, false)
+    await registerAndTrigger('apps/Finder')
+    expect(mocks.hideWindow).toHaveBeenCalledWith(true)
+    expect(launchHandler).toHaveBeenCalledWith('apps/Finder', undefined)
+    expect(mocks.showWindow).not.toHaveBeenCalled()
+    expect(mocks.hideWindow.mock.invocationCallOrder[0]).toBeLessThan(
+      launchHandler.mock.invocationCallOrder[0]
+    )
+  })
+
+  it('主窗可见时按插件热键仍 launch，不只回首页', async () => {
+    setGlobalHideOnPress(true)
+    setWindowState(true, true)
     await registerAndTrigger('plugin/screenshot')
     expect(launchHandler).toHaveBeenCalledWith('plugin/screenshot', undefined)
-    expect(mocks.hideWindow).not.toHaveBeenCalled()
     expect(mocks.showWindow).not.toHaveBeenCalled()
   })
 
@@ -177,21 +191,21 @@ describe('SettingsAPI hideOnPress', () => {
     expect(mocks.hideWindow).not.toHaveBeenCalled()
   })
 
-  it('未配置时默认关，窗口已显示也只唤起', async () => {
+  it('未配置时默认关，主窗可见仍先 hide 再 launch', async () => {
     mocks.dbGet.mockImplementation(() => ({}))
     setWindowState(true, true)
-    await registerAndTrigger()
-    expect(mocks.hideWindow).not.toHaveBeenCalled()
+    await registerAndTrigger('apps/Notes')
+    expect(mocks.hideWindow).toHaveBeenCalledWith(true)
+    expect(launchHandler).toHaveBeenCalledWith('apps/Notes', undefined)
     expect(mocks.showWindow).not.toHaveBeenCalled()
-    expect(launchHandler).toHaveBeenCalledWith('demo/action', undefined)
   })
 
-  it('关闭时即使窗口已显示也只唤起指令', async () => {
+  it('关闭 hideOnPress 时主窗可见也先 hide 再 launch', async () => {
     setGlobalHideOnPress(false)
     setWindowState(true, true)
-    await registerAndTrigger()
-    expect(mocks.hideWindow).not.toHaveBeenCalled()
+    await registerAndTrigger('apps/Calculator')
+    expect(mocks.hideWindow).toHaveBeenCalledWith(true)
+    expect(launchHandler).toHaveBeenCalledWith('apps/Calculator', undefined)
     expect(mocks.showWindow).not.toHaveBeenCalled()
-    expect(launchHandler).toHaveBeenCalledWith('demo/action', undefined)
   })
 })

--- a/tests/main/settingsHideOnPress.test.ts
+++ b/tests/main/settingsHideOnPress.test.ts
@@ -6,7 +6,8 @@ const mocks = vi.hoisted(() => ({
   prepareGlobalShortcut: vi.fn(),
   hideWindow: vi.fn(),
   getMainWindow: vi.fn(),
-  shouldIgnoreHotkeys: vi.fn(() => false)
+  shouldIgnoreHotkeys: vi.fn(() => false),
+  dbGet: vi.fn()
 }))
 
 vi.mock('electron', () => ({
@@ -55,7 +56,7 @@ vi.mock('../../src/main/managers/windowManager.js', () => ({
 }))
 vi.mock('../../src/main/core/screenCapture.js', () => ({ primeScreenCaptureFrame: vi.fn() }))
 vi.mock('../../src/main/api/shared/database.js', () => ({
-  default: { dbGet: vi.fn(), dbPut: vi.fn() }
+  default: { dbGet: mocks.dbGet, dbPut: vi.fn() }
 }))
 vi.mock('../../src/main/api/index.js', () => ({
   default: { prepareGlobalShortcut: mocks.prepareGlobalShortcut }
@@ -67,6 +68,15 @@ function setWindowState(visible: boolean, focused: boolean): void {
   mocks.getMainWindow.mockReturnValue({
     isVisible: () => visible,
     isFocused: () => focused
+  })
+}
+
+function setGlobalHideOnPress(enabled: boolean): void {
+  mocks.dbGet.mockImplementation((key: string) => {
+    if (key === 'settings-general') {
+      return { hideOnPress: enabled }
+    }
+    return null
   })
 }
 
@@ -88,18 +98,13 @@ describe('SettingsAPI hideOnPress', () => {
     })
     mocks.shouldIgnoreHotkeys.mockReturnValue(false)
     setWindowState(false, false)
+    setGlobalHideOnPress(false)
   })
 
-  async function registerAndTrigger(hideOnPress: boolean): Promise<void> {
+  async function registerAndTrigger(): Promise<void> {
     const settings = new SettingsAPI()
     settings.setGlobalShortcutHandler(launchHandler)
-    const result = await settings.registerGlobalShortcut(
-      'Alt+1',
-      'demo/action',
-      false,
-      false,
-      hideOnPress
-    )
+    const result = await settings.registerGlobalShortcut('Alt+1', 'demo/action', false, false)
     expect(result).toEqual({ success: true })
     expect(triggerShortcut).toBeTypeOf('function')
     await triggerShortcut!()
@@ -111,22 +116,33 @@ describe('SettingsAPI hideOnPress', () => {
   }
 
   it('开启后窗口已显示再按会藏窗并恢复上一应用', async () => {
+    setGlobalHideOnPress(true)
     setWindowState(true, true)
-    await registerAndTrigger(true)
+    await registerAndTrigger()
     expect(mocks.hideWindow).toHaveBeenCalledWith(true)
     expect(launchHandler).not.toHaveBeenCalled()
   })
 
-  it('关闭时即使窗口已显示也只唤起指令', async () => {
+  it('未配置时默认关，窗口已显示也只唤起', async () => {
+    mocks.dbGet.mockImplementation(() => ({}))
     setWindowState(true, true)
-    await registerAndTrigger(false)
+    await registerAndTrigger()
+    expect(mocks.hideWindow).not.toHaveBeenCalled()
+    expect(launchHandler).toHaveBeenCalledWith('demo/action', undefined)
+  })
+
+  it('关闭时即使窗口已显示也只唤起指令', async () => {
+    setGlobalHideOnPress(false)
+    setWindowState(true, true)
+    await registerAndTrigger()
     expect(mocks.hideWindow).not.toHaveBeenCalled()
     expect(launchHandler).toHaveBeenCalledWith('demo/action', undefined)
   })
 
   it('开启但窗口未显示时仍唤起指令', async () => {
+    setGlobalHideOnPress(true)
     setWindowState(false, false)
-    await registerAndTrigger(true)
+    await registerAndTrigger()
     expect(mocks.hideWindow).not.toHaveBeenCalled()
     expect(launchHandler).toHaveBeenCalledWith('demo/action', undefined)
   })

--- a/tests/main/settingsHideOnPress.test.ts
+++ b/tests/main/settingsHideOnPress.test.ts
@@ -101,18 +101,28 @@ describe('SettingsAPI hideOnPress', () => {
     setGlobalHideOnPress(false)
   })
 
-  async function registerAndTrigger(): Promise<void> {
+  async function registerShortcut(): Promise<void> {
     const settings = new SettingsAPI()
     settings.setGlobalShortcutHandler(launchHandler)
     const result = await settings.registerGlobalShortcut('Alt+1', 'demo/action', false, false)
     expect(result).toEqual({ success: true })
     expect(triggerShortcut).toBeTypeOf('function')
+  }
+
+  async function pressShortcut(): Promise<void> {
+    const hideBefore = mocks.hideWindow.mock.calls.length
+    const launchBefore = launchHandler.mock.calls.length
     await triggerShortcut!()
     await vi.waitFor(() => {
       expect(mocks.hideWindow.mock.calls.length + launchHandler.mock.calls.length).toBeGreaterThan(
-        0
+        hideBefore + launchBefore
       )
     })
+  }
+
+  async function registerAndTrigger(): Promise<void> {
+    await registerShortcut()
+    await pressShortcut()
   }
 
   it('开启后窗口已显示再按会藏窗并恢复上一应用', async () => {
@@ -153,5 +163,43 @@ describe('SettingsAPI hideOnPress', () => {
     await registerAndTrigger()
     expect(mocks.hideWindow).not.toHaveBeenCalled()
     expect(launchHandler).toHaveBeenCalledWith('demo/action', undefined)
+  })
+
+  it('开启后启动应用把主窗藏掉，再按只藏窗不重复 launch', async () => {
+    setGlobalHideOnPress(true)
+    setWindowState(false, false)
+    await registerAndTrigger()
+    expect(launchHandler).toHaveBeenCalledTimes(1)
+    expect(mocks.hideWindow).not.toHaveBeenCalled()
+
+    setWindowState(false, false)
+    await pressShortcut()
+    expect(mocks.hideWindow).toHaveBeenCalledWith(true)
+    expect(launchHandler).toHaveBeenCalledTimes(1)
+  })
+
+  it('开启后启动插件主窗仍可见，再按藏窗不重复 launch', async () => {
+    setGlobalHideOnPress(true)
+    setWindowState(false, false)
+    await registerAndTrigger()
+    expect(launchHandler).toHaveBeenCalledTimes(1)
+
+    setWindowState(true, false)
+    await pressShortcut()
+    expect(mocks.hideWindow).toHaveBeenCalledWith(true)
+    expect(launchHandler).toHaveBeenCalledTimes(1)
+  })
+
+  it('藏窗后再按会重新 launch', async () => {
+    setGlobalHideOnPress(true)
+    setWindowState(false, false)
+    await registerAndTrigger()
+    setWindowState(false, false)
+    await pressShortcut()
+    expect(mocks.hideWindow).toHaveBeenCalledTimes(1)
+
+    setWindowState(false, false)
+    await pressShortcut()
+    expect(launchHandler).toHaveBeenCalledTimes(2)
   })
 })

--- a/tests/main/settingsHideOnPress.test.ts
+++ b/tests/main/settingsHideOnPress.test.ts
@@ -5,6 +5,7 @@ const mocks = vi.hoisted(() => ({
   electronUnregister: vi.fn(),
   prepareGlobalShortcut: vi.fn(),
   hideWindow: vi.fn(),
+  showWindow: vi.fn(),
   getMainWindow: vi.fn(),
   shouldIgnoreHotkeys: vi.fn(() => false),
   dbGet: vi.fn()
@@ -51,6 +52,7 @@ vi.mock('../../src/main/managers/proxyManager.js', () => ({ default: {} }))
 vi.mock('../../src/main/managers/windowManager.js', () => ({
   default: {
     hideWindow: mocks.hideWindow,
+    showWindow: mocks.showWindow,
     getMainWindow: mocks.getMainWindow
   }
 }))
@@ -111,12 +113,15 @@ describe('SettingsAPI hideOnPress', () => {
 
   async function pressShortcut(): Promise<void> {
     const hideBefore = mocks.hideWindow.mock.calls.length
+    const showBefore = mocks.showWindow.mock.calls.length
     const launchBefore = launchHandler.mock.calls.length
     await triggerShortcut!()
     await vi.waitFor(() => {
-      expect(mocks.hideWindow.mock.calls.length + launchHandler.mock.calls.length).toBeGreaterThan(
-        hideBefore + launchBefore
-      )
+      expect(
+        mocks.hideWindow.mock.calls.length +
+          mocks.showWindow.mock.calls.length +
+          launchHandler.mock.calls.length
+      ).toBeGreaterThan(hideBefore + showBefore + launchBefore)
     })
   }
 
@@ -125,19 +130,44 @@ describe('SettingsAPI hideOnPress', () => {
     await pressShortcut()
   }
 
-  it('开启后窗口已显示再按会藏窗并恢复上一应用', async () => {
+  it('ZTools 前台再按 hide，不 launch', async () => {
     setGlobalHideOnPress(true)
     setWindowState(true, true)
     await registerAndTrigger()
     expect(mocks.hideWindow).toHaveBeenCalledWith(true)
+    expect(mocks.showWindow).not.toHaveBeenCalled()
     expect(launchHandler).not.toHaveBeenCalled()
   })
 
-  it('开启后窗口已显示但未聚焦也会藏窗，不重复唤起指令', async () => {
+  it('ZTools 已藏时再按 show，不 hide 不 launch', async () => {
+    setGlobalHideOnPress(true)
+    setWindowState(false, false)
+    await registerAndTrigger()
+    expect(mocks.showWindow).toHaveBeenCalledTimes(1)
+    expect(mocks.hideWindow).not.toHaveBeenCalled()
+    expect(launchHandler).not.toHaveBeenCalled()
+  })
+
+  it('别的 App 前台（主窗仍可见但未聚焦）再按 show，不 hide 不 launch', async () => {
     setGlobalHideOnPress(true)
     setWindowState(true, false)
     await registerAndTrigger()
-    expect(mocks.hideWindow).toHaveBeenCalledWith(true)
+    expect(mocks.showWindow).toHaveBeenCalledTimes(1)
+    expect(mocks.hideWindow).not.toHaveBeenCalled()
+    expect(launchHandler).not.toHaveBeenCalled()
+  })
+
+  it('launch App 后下一键是 show 不是 hide/relaunch', async () => {
+    setGlobalHideOnPress(true)
+    setWindowState(true, true)
+    await registerAndTrigger()
+    expect(mocks.hideWindow).toHaveBeenCalledTimes(1)
+    expect(launchHandler).not.toHaveBeenCalled()
+
+    setWindowState(false, false)
+    await pressShortcut()
+    expect(mocks.showWindow).toHaveBeenCalledTimes(1)
+    expect(mocks.hideWindow).toHaveBeenCalledTimes(1)
     expect(launchHandler).not.toHaveBeenCalled()
   })
 
@@ -146,6 +176,7 @@ describe('SettingsAPI hideOnPress', () => {
     setWindowState(true, true)
     await registerAndTrigger()
     expect(mocks.hideWindow).not.toHaveBeenCalled()
+    expect(mocks.showWindow).not.toHaveBeenCalled()
     expect(launchHandler).toHaveBeenCalledWith('demo/action', undefined)
   })
 
@@ -154,52 +185,7 @@ describe('SettingsAPI hideOnPress', () => {
     setWindowState(true, true)
     await registerAndTrigger()
     expect(mocks.hideWindow).not.toHaveBeenCalled()
+    expect(mocks.showWindow).not.toHaveBeenCalled()
     expect(launchHandler).toHaveBeenCalledWith('demo/action', undefined)
-  })
-
-  it('开启但窗口未显示时仍唤起指令', async () => {
-    setGlobalHideOnPress(true)
-    setWindowState(false, false)
-    await registerAndTrigger()
-    expect(mocks.hideWindow).not.toHaveBeenCalled()
-    expect(launchHandler).toHaveBeenCalledWith('demo/action', undefined)
-  })
-
-  it('开启后启动应用把主窗藏掉，再按只藏窗不重复 launch', async () => {
-    setGlobalHideOnPress(true)
-    setWindowState(false, false)
-    await registerAndTrigger()
-    expect(launchHandler).toHaveBeenCalledTimes(1)
-    expect(mocks.hideWindow).not.toHaveBeenCalled()
-
-    setWindowState(false, false)
-    await pressShortcut()
-    expect(mocks.hideWindow).toHaveBeenCalledWith(true)
-    expect(launchHandler).toHaveBeenCalledTimes(1)
-  })
-
-  it('开启后启动插件主窗仍可见，再按藏窗不重复 launch', async () => {
-    setGlobalHideOnPress(true)
-    setWindowState(false, false)
-    await registerAndTrigger()
-    expect(launchHandler).toHaveBeenCalledTimes(1)
-
-    setWindowState(true, false)
-    await pressShortcut()
-    expect(mocks.hideWindow).toHaveBeenCalledWith(true)
-    expect(launchHandler).toHaveBeenCalledTimes(1)
-  })
-
-  it('藏窗后再按会重新 launch', async () => {
-    setGlobalHideOnPress(true)
-    setWindowState(false, false)
-    await registerAndTrigger()
-    setWindowState(false, false)
-    await pressShortcut()
-    expect(mocks.hideWindow).toHaveBeenCalledTimes(1)
-
-    setWindowState(false, false)
-    await pressShortcut()
-    expect(launchHandler).toHaveBeenCalledTimes(2)
   })
 })

--- a/tests/main/settingsHideOnPress.test.ts
+++ b/tests/main/settingsHideOnPress.test.ts
@@ -123,6 +123,14 @@ describe('SettingsAPI hideOnPress', () => {
     expect(launchHandler).not.toHaveBeenCalled()
   })
 
+  it('开启后窗口已显示但未聚焦也会藏窗，不重复唤起指令', async () => {
+    setGlobalHideOnPress(true)
+    setWindowState(true, false)
+    await registerAndTrigger()
+    expect(mocks.hideWindow).toHaveBeenCalledWith(true)
+    expect(launchHandler).not.toHaveBeenCalled()
+  })
+
   it('未配置时默认关，窗口已显示也只唤起', async () => {
     mocks.dbGet.mockImplementation(() => ({}))
     setWindowState(true, true)

--- a/tests/main/settingsHideOnPress.test.ts
+++ b/tests/main/settingsHideOnPress.test.ts
@@ -1,0 +1,133 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  electronRegister: vi.fn(),
+  electronUnregister: vi.fn(),
+  prepareGlobalShortcut: vi.fn(),
+  hideWindow: vi.fn(),
+  getMainWindow: vi.fn(),
+  shouldIgnoreHotkeys: vi.fn(() => false)
+}))
+
+vi.mock('electron', () => ({
+  app: {},
+  globalShortcut: {
+    register: mocks.electronRegister,
+    unregister: mocks.electronUnregister
+  },
+  ipcMain: { handle: vi.fn(), on: vi.fn() },
+  nativeTheme: {}
+}))
+
+vi.mock('../../src/main/core/native/index.js', () => ({
+  OptimizedShortcutManager: {
+    ensureListener: vi.fn(),
+    registerShortcut: vi.fn(),
+    unregisterShortcut: vi.fn(),
+    stopListener: vi.fn()
+  },
+  WindowManager: {}
+}))
+
+vi.mock('../../src/main/appMain.js', () => ({
+  getCurrentShortcut: vi.fn(),
+  updateShortcut: vi.fn()
+}))
+
+vi.mock('../../src/main/core/dndManager.js', () => ({
+  default: { shouldIgnoreHotkeys: mocks.shouldIgnoreHotkeys }
+}))
+
+vi.mock('../../src/main/core/doubleTapManager.js', () => ({
+  default: {
+    acquireKeyboardState: vi.fn(() => vi.fn()),
+    register: vi.fn(),
+    unregister: vi.fn()
+  }
+}))
+
+vi.mock('../../src/main/managers/proxyManager.js', () => ({ default: {} }))
+vi.mock('../../src/main/managers/windowManager.js', () => ({
+  default: {
+    hideWindow: mocks.hideWindow,
+    getMainWindow: mocks.getMainWindow
+  }
+}))
+vi.mock('../../src/main/core/screenCapture.js', () => ({ primeScreenCaptureFrame: vi.fn() }))
+vi.mock('../../src/main/api/shared/database.js', () => ({
+  default: { dbGet: vi.fn(), dbPut: vi.fn() }
+}))
+vi.mock('../../src/main/api/index.js', () => ({
+  default: { prepareGlobalShortcut: mocks.prepareGlobalShortcut }
+}))
+
+const { SettingsAPI } = await import('../../src/main/api/renderer/settings')
+
+function setWindowState(visible: boolean, focused: boolean): void {
+  mocks.getMainWindow.mockReturnValue({
+    isVisible: () => visible,
+    isFocused: () => focused
+  })
+}
+
+describe('SettingsAPI hideOnPress', () => {
+  let triggerShortcut: (() => void) | undefined
+  const launchHandler = vi.fn()
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    triggerShortcut = undefined
+    mocks.electronRegister.mockImplementation((_shortcut, callback) => {
+      triggerShortcut = callback
+      return true
+    })
+    mocks.electronUnregister.mockReturnValue(undefined)
+    mocks.prepareGlobalShortcut.mockResolvedValue({
+      target: 'demo/action',
+      shouldCaptureSelectedText: false
+    })
+    mocks.shouldIgnoreHotkeys.mockReturnValue(false)
+    setWindowState(false, false)
+  })
+
+  async function registerAndTrigger(hideOnPress: boolean): Promise<void> {
+    const settings = new SettingsAPI()
+    settings.setGlobalShortcutHandler(launchHandler)
+    const result = await settings.registerGlobalShortcut(
+      'Alt+1',
+      'demo/action',
+      false,
+      false,
+      hideOnPress
+    )
+    expect(result).toEqual({ success: true })
+    expect(triggerShortcut).toBeTypeOf('function')
+    await triggerShortcut!()
+    await vi.waitFor(() => {
+      expect(mocks.hideWindow.mock.calls.length + launchHandler.mock.calls.length).toBeGreaterThan(
+        0
+      )
+    })
+  }
+
+  it('开启后窗口已显示再按会藏窗并恢复上一应用', async () => {
+    setWindowState(true, true)
+    await registerAndTrigger(true)
+    expect(mocks.hideWindow).toHaveBeenCalledWith(true)
+    expect(launchHandler).not.toHaveBeenCalled()
+  })
+
+  it('关闭时即使窗口已显示也只唤起指令', async () => {
+    setWindowState(true, true)
+    await registerAndTrigger(false)
+    expect(mocks.hideWindow).not.toHaveBeenCalled()
+    expect(launchHandler).toHaveBeenCalledWith('demo/action', undefined)
+  })
+
+  it('开启但窗口未显示时仍唤起指令', async () => {
+    setWindowState(false, false)
+    await registerAndTrigger(true)
+    expect(mocks.hideWindow).not.toHaveBeenCalled()
+    expect(launchHandler).toHaveBeenCalledWith('demo/action', undefined)
+  })
+})

--- a/tests/main/windowManagerMacActivation.test.ts
+++ b/tests/main/windowManagerMacActivation.test.ts
@@ -5,6 +5,8 @@ type MockHandler = (...args: any[]) => void
 const mocks = vi.hoisted(() => {
   const appFocus = vi.fn()
   const appHide = vi.fn()
+  const appShow = vi.fn()
+  const appIsHidden = vi.fn(() => false)
   const dbGet = vi.fn()
   const clipboardGetCurrentWindow = vi.fn()
   const clipboardActivateApp = vi.fn()
@@ -64,6 +66,8 @@ const mocks = vi.hoisted(() => {
   return {
     appFocus,
     appHide,
+    appShow,
+    appIsHidden,
     dbGet,
     clipboardGetCurrentWindow,
     clipboardActivateApp,
@@ -85,6 +89,8 @@ vi.mock('electron', () => ({
     getAppPath: vi.fn(() => '/tmp/ztools'),
     focus: mocks.appFocus,
     hide: mocks.appHide,
+    show: mocks.appShow,
+    isHidden: mocks.appIsHidden,
     dock: {
       show: vi.fn(),
       hide: vi.fn()
@@ -202,6 +208,7 @@ describe('windowManager macOS activation', () => {
     mocks.dbGet.mockReturnValue(null)
     mocks.clipboardGetCurrentWindow.mockReturnValue(null)
     mocks.clipboardActivateApp.mockReturnValue(true)
+    mocks.appIsHidden.mockReturnValue(false)
     mocks.latestWindow.current = null
   })
 
@@ -267,5 +274,28 @@ describe('windowManager macOS activation', () => {
     expect(mocks.appHide).not.toHaveBeenCalled()
     expect(mocks.latestWindow.current.hide).toHaveBeenCalledTimes(1)
     expect(mocks.clipboardActivateApp).not.toHaveBeenCalled()
+  })
+
+  it('after app.hide, showWindow unhides via app.show', async () => {
+    mocks.appIsHidden.mockReturnValue(true)
+    const { default: windowManager } = await import('../../src/main/managers/windowManager')
+
+    windowManager.createWindow()
+    windowManager.hideWindow(true)
+    expect(mocks.appHide).toHaveBeenCalledTimes(1)
+
+    windowManager.showWindow()
+    expect(mocks.appShow).toHaveBeenCalledTimes(1)
+  })
+
+  it('showWindow does not call app.show when the app is not hidden', async () => {
+    mocks.appIsHidden.mockReturnValue(false)
+    const { default: windowManager } = await import('../../src/main/managers/windowManager')
+
+    windowManager.createWindow()
+    windowManager.showWindow()
+
+    expect(mocks.appShow).not.toHaveBeenCalled()
+    expect(mocks.appFocus).not.toHaveBeenCalled()
   })
 })

--- a/tests/main/windowManagerMacActivation.test.ts
+++ b/tests/main/windowManagerMacActivation.test.ts
@@ -4,8 +4,10 @@ type MockHandler = (...args: any[]) => void
 
 const mocks = vi.hoisted(() => {
   const appFocus = vi.fn()
+  const appHide = vi.fn()
   const dbGet = vi.fn()
   const clipboardGetCurrentWindow = vi.fn()
+  const clipboardActivateApp = vi.fn()
   const globalInputOn = vi.fn()
   const globalInputAcquire = vi.fn()
   const globalInputRelease = vi.fn()
@@ -42,6 +44,7 @@ const mocks = vi.hoisted(() => {
       show: vi.fn(() => emit('show')),
       emit,
       hide: vi.fn(),
+      minimize: vi.fn(),
       blur: vi.fn(),
       focus: vi.fn(),
       loadFile: vi.fn(),
@@ -60,8 +63,10 @@ const mocks = vi.hoisted(() => {
 
   return {
     appFocus,
+    appHide,
     dbGet,
     clipboardGetCurrentWindow,
+    clipboardActivateApp,
     globalInputOn,
     globalInputAcquire,
     globalInputRelease,
@@ -79,6 +84,7 @@ vi.mock('electron', () => ({
   app: {
     getAppPath: vi.fn(() => '/tmp/ztools'),
     focus: mocks.appFocus,
+    hide: mocks.appHide,
     dock: {
       show: vi.fn(),
       hide: vi.fn()
@@ -154,7 +160,8 @@ vi.mock('../../src/main/core/native/index.js', () => ({
 
 vi.mock('../../src/main/managers/clipboardManager', () => ({
   default: {
-    getCurrentWindow: mocks.clipboardGetCurrentWindow
+    getCurrentWindow: mocks.clipboardGetCurrentWindow,
+    activateApp: mocks.clipboardActivateApp
   }
 }))
 
@@ -194,6 +201,7 @@ describe('windowManager macOS activation', () => {
     vi.clearAllMocks()
     mocks.dbGet.mockReturnValue(null)
     mocks.clipboardGetCurrentWindow.mockReturnValue(null)
+    mocks.clipboardActivateApp.mockReturnValue(true)
     mocks.latestWindow.current = null
   })
 
@@ -226,5 +234,38 @@ describe('windowManager macOS activation', () => {
     vi.advanceTimersByTime(201)
     mocks.latestWindow.current.emit('blur')
     expect(mocks.latestWindow.current.hide).toHaveBeenCalledTimes(1)
+  })
+
+  it('restore-focus hide on macOS uses app.hide, not window hide or activateApp', async () => {
+    const { default: windowManager } = await import('../../src/main/managers/windowManager')
+
+    windowManager.createWindow()
+    windowManager.setPreviousActiveWindow({
+      app: 'Finder',
+      bundleId: 'com.apple.finder'
+    } as any)
+
+    windowManager.hideWindow(true)
+
+    expect(mocks.appHide).toHaveBeenCalledTimes(1)
+    expect(mocks.latestWindow.current.hide).not.toHaveBeenCalled()
+    expect(mocks.latestWindow.current.minimize).not.toHaveBeenCalled()
+    expect(mocks.clipboardActivateApp).not.toHaveBeenCalled()
+  })
+
+  it('blur hide on macOS still only hides the BrowserWindow', async () => {
+    const { default: windowManager } = await import('../../src/main/managers/windowManager')
+
+    windowManager.createWindow()
+    windowManager.setPreviousActiveWindow({
+      app: 'Finder',
+      bundleId: 'com.apple.finder'
+    } as any)
+
+    windowManager.hideWindow(false)
+
+    expect(mocks.appHide).not.toHaveBeenCalled()
+    expect(mocks.latestWindow.current.hide).toHaveBeenCalledTimes(1)
+    expect(mocks.clipboardActivateApp).not.toHaveBeenCalled()
   })
 })

--- a/tests/renderer/useSearchResults.test.ts
+++ b/tests/renderer/useSearchResults.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect } from 'vitest'
-import { deduplicateResults } from '../../src/renderer/src/composables/useSearchResults'
+import {
+  deduplicateResults,
+  excludeHiddenSystemApps
+} from '../../src/renderer/src/composables/useSearchResults'
 
 describe('deduplicateResults', () => {
   describe('非插件类型', () => {
@@ -77,5 +80,21 @@ describe('deduplicateResults', () => {
     ]
     const deduped = deduplicateResults(results)
     expect(deduped[0].extra).toBe('first')
+  })
+})
+
+describe('excludeHiddenSystemApps', () => {
+  const results = [
+    { name: 'Chrome', path: '/Applications/Google Chrome.app' },
+    { name: '访达', path: '/System/Applications/Finder.app', isSystemApp: true },
+    { name: '计算器', path: '/System/Applications/Calculator.app', isSystemApp: true }
+  ]
+
+  it('默认应过滤系统自带应用', () => {
+    expect(excludeHiddenSystemApps(results, false).map((item) => item.name)).toEqual(['Chrome'])
+  })
+
+  it('开启后应保留系统自带应用', () => {
+    expect(excludeHiddenSystemApps(results, true)).toEqual(results)
   })
 })


### PR DESCRIPTION
## 变更内容
- 设置 → 快捷键 → 全局快捷键：列表上方、「添加快捷键」左侧增加一个全局「按下隐藏」开关（沿用页内 label + toggle）
- 字段 `hideOnPress` 写入 `settings-general`，不再按快捷键存；默认关
- hideOnPress 与「唤出 ZTools」拆成两套：ZTools 自己在前台再按才 `hideWindow(true)`（macOS 为系统级 `app.hide()`）；不在前台（访达/系统设置/第三方搜索框开着、刚 launch 过计算器/访达）只 `showWindow`，不再 pending-hide，也不再 launch 那个 App
- 去掉 `hideOnPressPendingHideShortcut`：launch 后再按必须是 SHOW ZTools
- 未改搜索 chip / 系统 App 过滤（前一提交仍在）

## 动机
其它软件搜索框开着时，全局快捷键仍应唤出 ZTools；不要把「启动/隐藏那个 App」和「唤出 ZTools」缠成一次 toggle。

## 测试
- hideOnPress：ZTools 前台再按 hide；launch App 后下一键 show 不是 hide/relaunch；别的 App 前台（可见未聚焦）再按 show
- typecheck:node / setting vue-tsc / eslint 改动文件已过