### PR TITLE
AN-61: improve palette search states and accessibility

### DIFF
--- a/src/renderer/src/components/common/CommandList.vue
+++ b/src/renderer/src/components/common/CommandList.vue
@@ -16,6 +16,8 @@
           :ref="(el) => setItemRef(el, index)"
           class="app-item"
           :class="{ selected: index === selectedIndex }"
+          role="option"
+          :aria-selected="index === selectedIndex"
           :title="getTitleText(app)"
           @click="$emit('select', app)"
           @contextmenu.prevent="$emit('contextmenu', app)"
@@ -52,13 +54,15 @@
       </template>
     </Draggable>
     <!-- 普通列表 -->
-    <div v-if="!props.draggable" class="app-grid">
+    <div v-if="!props.draggable" class="app-grid" role="listbox" aria-label="搜索结果列表">
       <div
         v-for="(app, index) in apps"
         :key="`${app.path}-${app.featureCode || ''}-${app.name}`"
         :ref="(el) => setItemRef(el, index)"
         class="app-item"
         :class="{ selected: index === selectedIndex }"
+        role="option"
+        :aria-selected="index === selectedIndex"
         draggable="false"
         :title="getTitleText(app)"
         @click="$emit('select', app)"

--- a/src/renderer/src/components/common/MainPushList.vue
+++ b/src/renderer/src/components/common/MainPushList.vue
@@ -12,12 +12,14 @@
       </div>
       <div class="section-action">进入应用 ›</div>
     </div>
-    <div class="push-list">
+    <div class="push-list" role="listbox" :aria-label="title">
       <div
         v-for="(item, index) in items"
         :key="index"
         class="push-item list-item"
         :class="{ selected: index === selectedIndex }"
+        role="option"
+        :aria-selected="index === selectedIndex"
         @click="$emit('select', item, index)"
       >
         <div class="item-icon">

--- a/src/renderer/src/components/common/VerticalList.vue
+++ b/src/renderer/src/components/common/VerticalList.vue
@@ -1,10 +1,12 @@
 <template>
-  <div v-if="apps.length > 0" class="vertical-list">
+  <div v-if="apps.length > 0" class="vertical-list" role="listbox" aria-label="搜索结果列表">
     <div
       v-for="(app, index) in apps"
       :key="app.name + '|' + app.path + (app.featureCode || '')"
       class="list-item"
       :class="{ selected: index === selectedIndex }"
+      role="option"
+      :aria-selected="index === selectedIndex"
       @click="$emit('select', app)"
       @contextmenu.prevent="$emit('contextmenu', app)"
     >

--- a/src/renderer/src/components/search/SearchResults.vue
+++ b/src/renderer/src/components/search/SearchResults.vue
@@ -1,8 +1,28 @@
 <template>
-  <div ref="scrollContainerRef" class="scrollable-content" @click="handleContainerClick">
+  <div
+    ref="scrollContainerRef"
+    class="scrollable-content"
+    role="region"
+    aria-label="搜索结果"
+    aria-live="polite"
+    :aria-busy="isLoading"
+    @click="handleContainerClick"
+  >
+    <div v-if="isLoading" class="palette-state" role="status">
+      <span class="state-spinner" aria-hidden="true"></span>
+      <span>正在加载搜索结果</span>
+    </div>
+    <div v-else-if="loadError" class="palette-state palette-state-error" role="alert">
+      <p>{{ loadError }}</p>
+      <button type="button" class="state-action" @click="retryLoading">重试</button>
+    </div>
+    <div v-else-if="showEmptyState" class="palette-state" role="status">
+      <strong>{{ emptyStateTitle }}</strong>
+      <span>{{ emptyStateDescription }}</span>
+    </div>
     <!-- 聚合模式 -->
     <AggregateView
-      v-if="searchMode === 'aggregate'"
+      v-if="!isLoading && !loadError && !showEmptyState && searchMode === 'aggregate'"
       v-model:recent-expanded="isRecentExpanded"
       v-model:pinned-expanded="isPinnedExpanded"
       v-model:search-results-expanded="isSearchResultsExpanded"
@@ -38,7 +58,12 @@
     />
 
     <!-- 列表模式 -->
-    <div v-if="searchMode === 'list' && hasSearchContent" class="list-mode-results">
+    <div
+      v-if="
+        !isLoading && !loadError && !showEmptyState && searchMode === 'list' && hasSearchContent
+      "
+      class="list-mode-results"
+    >
       <VerticalList
         :apps="allListModeResults"
         :selected-index="listModeSelectedIndex"
@@ -108,7 +133,8 @@ const emit = defineEmits<{
 
 // 使用 store
 const commandDataStore = useCommandDataStore()
-const { loading } = storeToRefs(commandDataStore)
+const { loading, loadError } = storeToRefs(commandDataStore)
+const isLoading = computed(() => loading.value || !commandDataStore.isInitialized)
 const {
   getRecentCommands,
   removeFromHistory,
@@ -178,6 +204,23 @@ function parsePluginPayload(raw: string): PluginPayload | null {
 const hasSearchContent = computed(() => {
   return !!(props.searchQuery.trim() || props.pastedImage || props.pastedText || props.pastedFiles)
 })
+
+const hasResults = computed(
+  () => navigationGrid.value.length > 0 || allListModeResults.value.length > 0
+)
+const showEmptyState = computed(() => commandDataStore.isInitialized && !hasResults.value)
+const emptyStateTitle = computed(() => (hasSearchContent.value ? '没有匹配结果' : '开始输入'))
+const emptyStateDescription = computed(() =>
+  hasSearchContent.value ? '尝试更短的关键词，或检查输入内容。' : '搜索应用、设置或插件功能。'
+)
+
+/**
+ * 重新加载搜索索引并恢复可用的结果视图。
+ * @returns 加载完成后结束的 Promise
+ */
+async function retryLoading(): Promise<void> {
+  await commandDataStore.loadCommands()
+}
 
 // 窗口匹配的操作列表（基于 feature 动态匹配）
 const windowMatchedActions = computed(() => {
@@ -1103,6 +1146,62 @@ defineExpose({
   user-select: none;
   padding: 0 0 2px 0;
   border-radius: 0;
+}
+
+.palette-state {
+  min-height: 96px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 24px 16px;
+  color: var(--text-secondary);
+  text-align: center;
+  font-size: 13px;
+}
+
+.palette-state strong {
+  color: var(--text-color);
+  font-size: 14px;
+}
+
+.palette-state-error p {
+  margin: 0;
+  color: var(--highlight-color);
+}
+
+.state-action {
+  min-height: 30px;
+  padding: 0 14px;
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  background: var(--control-bg);
+  color: var(--text-color);
+  cursor: pointer;
+  font: inherit;
+}
+
+.state-action:hover,
+.state-action:focus-visible {
+  border-color: var(--primary-color);
+  outline: 2px solid color-mix(in srgb, var(--primary-color), transparent 70%);
+  outline-offset: 1px;
+}
+
+.state-spinner {
+  width: 18px;
+  height: 18px;
+  border: 2px solid var(--border-color);
+  border-top-color: var(--primary-color);
+  border-radius: 50%;
+  animation: palette-spin 0.8s linear infinite;
+}
+
+@keyframes palette-spin {
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 .list-mode-results {

--- a/src/renderer/src/composables/useMainPushResults.ts
+++ b/src/renderer/src/composables/useMainPushResults.ts
@@ -49,6 +49,26 @@ export interface UseMainPushResultsProps {
   pastedText?: string | null
 }
 
+const MAIN_PUSH_QUERY_TIMEOUT_MS = 2500
+
+/**
+ * 为插件查询增加有限等待时间，避免失去响应的插件阻塞整个结果区域。
+ * @param promise 插件查询 Promise
+ * @param timeoutMs 最大等待时长
+ * @returns 原查询结果或超时拒绝的 Promise
+ * @throws 查询失败或超时时抛出错误
+ */
+function withQueryTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(new Error('plugin query timed out')), timeoutMs)
+  })
+
+  return Promise.race([promise, timeout]).finally(() => {
+    if (timer) clearTimeout(timer)
+  })
+}
+
 /**
  * mainPush 查询 composable
  * 监听搜索输入，自动查询匹配的 mainPush 插件获取动态结果
@@ -104,10 +124,9 @@ export function useMainPushResults(props: UseMainPushResultsProps): {
             type: feature.matchedCmdType,
             payload: searchText
           }
-          const items = await window.ztools.queryMainPush(
-            feature.pluginPath,
-            feature.featureCode,
-            queryData
+          const items = await withQueryTimeout(
+            window.ztools.queryMainPush(feature.pluginPath, feature.featureCode, queryData),
+            MAIN_PUSH_QUERY_TIMEOUT_MS
           )
           return { feature, items: Array.isArray(items) ? items : [] }
         } catch (error) {
@@ -147,6 +166,8 @@ export function useMainPushResults(props: UseMainPushResultsProps): {
       () => props.pastedFiles
     ],
     () => {
+      // 立即失效正在返回的查询，后续结果只能由最新输入提交。
+      queryVersion++
       if (queryTimer) {
         clearTimeout(queryTimer)
       }

--- a/src/renderer/src/stores/commandDataStore.ts
+++ b/src/renderer/src/stores/commandDataStore.ts
@@ -276,6 +276,7 @@ export const useCommandDataStore = defineStore('commandData', () => {
   // 存原始本地启动项数据（保留 name/alias），由 buildLocalShortcutCommandItems 映射为搜索指令
   const localShortcutCommandsCache = ref<any[]>([])
   const loading = ref(false)
+  const loadError = ref<string | null>(null)
   const fuse = ref<Fuse<Command> | null>(null)
   let loadCommandsRequestId = 0
   // 是否已初始化
@@ -1258,6 +1259,7 @@ export const useCommandDataStore = defineStore('commandData', () => {
   async function loadCommands(): Promise<void> {
     const requestId = ++loadCommandsRequestId
     loading.value = true
+    loadError.value = null
     try {
       const [rawApps, plugins, disabledPlugins, enabledMainPushPlugins, commandAliases] =
         await Promise.all([
@@ -1318,6 +1320,7 @@ export const useCommandDataStore = defineStore('commandData', () => {
       rebuildCommandCollections(commandAliases)
     } catch (error) {
       console.error('加载指令失败:', error)
+      loadError.value = '搜索数据加载失败，请重试。'
     } finally {
       if (requestId === loadCommandsRequestId) {
         loading.value = false
@@ -1846,6 +1849,7 @@ export const useCommandDataStore = defineStore('commandData', () => {
     regexCommands,
     mainPushFeatures,
     loading,
+    loadError,
     isInitialized,
 
     // 初始化


### PR DESCRIPTION
Closes AN-61

## Summary
- add observable loading and recoverable error states with retry
- add empty-state guidance and accessible listbox/option semantics
- bound mainPush queries and invalidate stale responses

## Verification
- `pnpm typecheck:web`
- focused renderer Vitest: 12 passed
- scoped ESLint and Prettier checks
- full Vitest has 13 pre-existing Windows scanner failures in 5 files