### PR TITLE
feat: 插件支持专属数据文件目录

### DIFF
--- a/src/main/api/index.ts
+++ b/src/main/api/index.ts
@@ -138,7 +138,7 @@ class APIManager {
     })
     pluginClipboardAPI.init()
     pluginDeviceAPI.init()
-    pluginDialogAPI.init(mainWindow)
+    pluginDialogAPI.init(mainWindow, pluginManager)
     pluginWindowAPI.init(mainWindow, pluginManager)
     pluginScreenAPI.init(mainWindow)
     // 初始化插件输入 API（需要 windowManager 和 clipboardManager 支持 paste/type 功能）

--- a/src/main/api/plugin/dialog.ts
+++ b/src/main/api/plugin/dialog.ts
@@ -1,5 +1,9 @@
 import { ipcMain, dialog, app } from 'electron'
+import fs from 'fs'
+import type { PluginManager } from '../../managers/pluginManager'
 import detachedWindowManager from '../../core/detachedWindowManager'
+import pluginWindowManager from '../../core/pluginWindowManager'
+import { getPluginDataPath } from '../../core/appData/appDataPaths'
 import windowManager from '../../managers/windowManager'
 
 /**
@@ -7,10 +11,44 @@ import windowManager from '../../managers/windowManager'
  */
 export class PluginDialogAPI {
   private mainWindow: Electron.BrowserWindow | null = null
+  private pluginManager: PluginManager | null = null
 
-  public init(mainWindow: Electron.BrowserWindow): void {
+  /**
+   * 初始化对话框 API 并注册 IPC 处理器。
+   * @param mainWindow 主窗口
+   * @param pluginManager 插件运行管理器（用于解析发起调用的插件名）
+   * @returns 无返回值
+   */
+  public init(mainWindow: Electron.BrowserWindow, pluginManager: PluginManager): void {
     this.mainWindow = mainWindow
+    this.pluginManager = pluginManager
     this.setupIPC()
+  }
+
+  /**
+   * 解析发起该 IPC 调用的插件名。
+   * 依次匹配主窗口内的插件视图、插件独立子窗口、插件会话隔离分区。
+   * @param event 插件侧发起的 IPC 事件
+   * @returns 插件名；无法定位到插件时返回 null
+   */
+  private resolvePluginName(event: Electron.IpcMainEvent): string | null {
+    const pluginInfo = this.pluginManager?.getPluginInfoByWebContents(event.sender)
+    if (pluginInfo) {
+      return pluginInfo.name
+    }
+
+    const pluginName = pluginWindowManager.getPluginNameByWebContentsId(event.sender.id)
+    if (pluginName) {
+      return pluginName
+    }
+
+    const partition = (event.sender.session as any)?.partition
+    if (typeof partition === 'string' && partition.startsWith('persist:')) {
+      const partitionPluginName = partition.slice('persist:'.length)
+      return partitionPluginName || null
+    }
+
+    return null
   }
 
   private setupIPC(): void {
@@ -55,6 +93,23 @@ export class PluginDialogAPI {
           case 'logs':
             result = app.getPath('logs')
             break
+          case 'pluginData': {
+            // 返回当前插件的专属数据目录，缺失时自动创建，插件拿到即可写入。
+            const pluginName = this.resolvePluginName(event)
+            if (!pluginName) {
+              result = ''
+              break
+            }
+            const pluginDataPath = getPluginDataPath(pluginName)
+            try {
+              fs.mkdirSync(pluginDataPath, { recursive: true })
+              result = pluginDataPath
+            } catch (mkdirError) {
+              console.error('[PluginDialog] 创建插件数据目录失败:', pluginName, mkdirError)
+              result = ''
+            }
+            break
+          }
           default:
             result = ''
         }

--- a/src/main/api/renderer/plugins.ts
+++ b/src/main/api/renderer/plugins.ts
@@ -800,7 +800,8 @@ export class PluginsAPI {
   /**
    * 删除插件
    * @param pluginPath 插件路径
-   * @param options 删除选项 当 options.deleteData 显式设置为 false 时，保留插件数据
+   * @param options 删除选项 当 options.deleteData 显式设置为 false 时，保留 LMDB 数据、插件专属数据目录
+   * 与各插件名配置；默认或为 true 时一并清除。
    * @returns 删除结果
    */
   public async deletePlugin(pluginPath: string, options: DeletePluginOptions = {}): Promise<any> {

--- a/src/main/api/shared/database.ts
+++ b/src/main/api/shared/database.ts
@@ -2,6 +2,8 @@ import { ipcMain, IpcMainEvent, IpcMainInvokeEvent } from 'electron'
 import type { PluginManager } from '../../managers/pluginManager'
 import lmdbInstance from '../../core/lmdb/lmdbInstance'
 import pluginWindowManager from '../../core/pluginWindowManager'
+import { getPluginDataPath } from '../../core/appData/appDataPaths'
+import { physicalFs } from '../../utils/physicalFs'
 import {
   getPluginDataPrefix,
   isDevelopmentPluginName,
@@ -740,6 +742,17 @@ export class DatabaseAPI {
         deletedCount++
       }
 
+      // 3. 清理插件专属文件系统数据目录（ztools.getPath('pluginData')），与「清除数据」语义保持一致。
+      // 失败不阻断清空，避免残留目录导致本次操作整体失败。
+      try {
+        await physicalFs.promises.rm(getPluginDataPath(pluginName), {
+          recursive: true,
+          force: true
+        })
+      } catch (error) {
+        console.error('[Database] 删除插件数据目录失败:', error)
+      }
+
       return { success: true, deletedCount }
     } catch (error: unknown) {
       console.error('[Database] 清空插件数据失败:', error)
@@ -790,7 +803,7 @@ export class DatabaseAPI {
   }
 
   /**
-   * 公共方法：清空指定插件的所有数据
+   * 公共方法：清空指定插件的所有数据（LMDB 文档、附件与 ztools.getPath('pluginData') 数据目录）。
    */
   public async clearPluginData(
     pluginName: string

--- a/src/main/core/appData/appDataPaths.ts
+++ b/src/main/core/appData/appDataPaths.ts
@@ -2,6 +2,7 @@ import fs from 'fs'
 import os from 'os'
 import path from 'path'
 import { app } from 'electron'
+import { assertSafePluginArtifactPart } from '../../utils/pluginStorage.js'
 
 export interface AppDataPathOptions {
   dataRoot?: string
@@ -57,6 +58,30 @@ export function getDefaultAccountLmdbPath(options: AppDataPathOptions = {}): str
 
 export function getPluginsPath(options: AppDataPathOptions = {}): string {
   return path.join(getZToolsRoot(options), 'plugins')
+}
+
+/**
+ * 获取插件数据目录的根容器（存放所有插件的专属数据目录）。
+ *
+ * @param options 数据目录解析选项
+ * @returns 插件数据根目录绝对路径
+ */
+export function getPluginDataRoot(options: AppDataPathOptions = {}): string {
+  return path.join(getZToolsRoot(options), 'plugins-data')
+}
+
+/**
+ * 获取指定插件的专属数据目录（`ztools.getPath('pluginData')` 指向的目录）。
+ * 该目录随插件卸载且勾选「同时删除插件数据」时一并删除，禁止存放插件实体。
+ *
+ * @param pluginName 插件名，用作数据根下的子目录名
+ * @param options 数据目录解析选项
+ * @returns 插件数据目录绝对路径
+ * @throws 插件名不合法（空、`.`、`..`、含分隔符或绝对路径）时抛出异常，避免目录穿越
+ */
+export function getPluginDataPath(pluginName: string, options: AppDataPathOptions = {}): string {
+  assertSafePluginArtifactPart(pluginName, '插件名称')
+  return path.join(getPluginDataRoot(options), pluginName)
 }
 
 export function getAvatarPath(options: AppDataPathOptions = {}): string {

--- a/tests/main/databasePluginIsolation.test.ts
+++ b/tests/main/databasePluginIsolation.test.ts
@@ -42,6 +42,8 @@ vi.mock('../../src/main/core/pluginWindowManager', () => ({
 }))
 
 import { DatabaseAPI } from '../../src/main/api/shared/database'
+import { getPluginDataPath } from '../../src/main/core/appData/appDataPaths'
+import { physicalFs } from '../../src/main/utils/physicalFs'
 
 describe('database plugin isolation', () => {
   beforeEach(() => {
@@ -195,6 +197,33 @@ describe('database plugin isolation', () => {
       success: true,
       deletedCount: 2
     })
+  })
+
+  it('clears the plugin filesystem data directory alongside the database namespace', async () => {
+    const fsRm = vi.spyOn(physicalFs.promises, 'rm').mockResolvedValue(undefined as any)
+    mockLmdb.allDocs.mockReturnValue([])
+
+    const database = new DatabaseAPI()
+    const result = await database.clearPluginData('demo')
+
+    expect(result).toEqual({ success: true, deletedCount: 0 })
+    // 「清除数据」同时删除 ztools.getPath('pluginData') 指向的目录，与卸载清理语义一致
+    expect(fsRm).toHaveBeenCalledWith(getPluginDataPath('demo'), {
+      recursive: true,
+      force: true
+    })
+    fsRm.mockRestore()
+  })
+
+  it('does not delete the filesystem data directory when clearing host data', async () => {
+    const fsRm = vi.spyOn(physicalFs.promises, 'rm').mockResolvedValue(undefined as any)
+
+    const database = new DatabaseAPI()
+    const result = await database.clearPluginData('ZTOOLS')
+
+    expect(result).toEqual({ success: false, error: '主程序数据不支持通过该接口清空' })
+    expect(fsRm).not.toHaveBeenCalled()
+    fsRm.mockRestore()
   })
 
   it('derives plugin prefix from child window session partition when webContents is not a main view', () => {

--- a/tests/main/pluginDataPath.test.ts
+++ b/tests/main/pluginDataPath.test.ts
@@ -1,0 +1,43 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import os from 'os'
+import path from 'path'
+import { getPluginDataPath, getPluginDataRoot } from '../../src/main/core/appData/appDataPaths'
+
+vi.mock('electron', () => ({
+  app: { getPath: vi.fn() }
+}))
+
+describe('getPluginDataPath', () => {
+  const existingDataRoot = process.env.ZTOOLS_DATA_ROOT
+
+  afterEach(() => {
+    if (existingDataRoot === undefined) {
+      delete process.env.ZTOOLS_DATA_ROOT
+    } else {
+      process.env.ZTOOLS_DATA_ROOT = existingDataRoot
+    }
+  })
+
+  it('返回数据根目录下的插件数据根容器', () => {
+    expect(getPluginDataRoot()).toBe(path.join(os.homedir(), '.ztools', 'plugins-data'))
+  })
+
+  it('返回插件名对应的专属数据目录', () => {
+    expect(getPluginDataPath('demo')).toBe(
+      path.join(os.homedir(), '.ztools', 'plugins-data', 'demo')
+    )
+  })
+
+  it('支持通过 ZTOOLS_DATA_ROOT 隔离数据根目录', () => {
+    process.env.ZTOOLS_DATA_ROOT = path.join(os.tmpdir(), 'ztools-data-root')
+    expect(getPluginDataPath('demo')).toBe(
+      path.join(process.env.ZTOOLS_DATA_ROOT, 'plugins-data', 'demo')
+    )
+  })
+
+  it('拒绝会导致目录穿越的插件名', () => {
+    for (const name of ['', '.', '..', 'a/b', 'a\\b', 'C:\\evil', '/abs']) {
+      expect(() => getPluginDataPath(name)).toThrow()
+    }
+  })
+})

--- a/tests/main/pluginDialogGetPath.test.ts
+++ b/tests/main/pluginDialogGetPath.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import os from 'os'
+import path from 'path'
+
+const mockGetPath = vi.hoisted(() => vi.fn())
+const mockMkdirSync = vi.hoisted(() => vi.fn())
+const ipcHandlers = new Map<string, (...args: any[]) => void>()
+
+vi.mock('electron', () => ({
+  dialog: { showOpenDialog: vi.fn(), showSaveDialog: vi.fn() },
+  app: { getPath: mockGetPath },
+  ipcMain: {
+    on: (channel: string, handler: (...args: any[]) => void) => {
+      ipcHandlers.set(channel, handler)
+    }
+  }
+}))
+
+vi.mock('fs', async () => {
+  const actual = await vi.importActual<typeof import('fs')>('fs')
+  const mockedFs = { ...actual, mkdirSync: mockMkdirSync }
+  return { ...mockedFs, default: mockedFs }
+})
+
+vi.mock('../../src/main/core/detachedWindowManager', () => ({
+  default: { getWindowByPluginWebContents: vi.fn() }
+}))
+vi.mock('../../src/main/managers/windowManager', () => ({
+  default: { withBlurHideSuppressed: vi.fn() }
+}))
+vi.mock('../../src/main/core/pluginWindowManager', () => ({
+  default: { getPluginNameByWebContentsId: vi.fn(() => undefined) }
+}))
+
+import { PluginDialogAPI } from '../../src/main/api/plugin/dialog'
+import { getPluginDataPath } from '../../src/main/core/appData/appDataPaths'
+
+describe('plugin dialog get-path', () => {
+  const existingDataRoot = process.env.ZTOOLS_DATA_ROOT
+  const testRoot = path.join(os.tmpdir(), 'ztools-dialog-test')
+  let handler: ((event: any, name: string) => void) | undefined
+
+  beforeEach(() => {
+    process.env.ZTOOLS_DATA_ROOT = testRoot
+    ipcHandlers.clear()
+    mockMkdirSync.mockReset()
+    mockGetPath.mockReset().mockImplementation((name: string) => `/mock/${name}`)
+  })
+
+  afterEach(() => {
+    if (existingDataRoot === undefined) {
+      delete process.env.ZTOOLS_DATA_ROOT
+    } else {
+      process.env.ZTOOLS_DATA_ROOT = existingDataRoot
+    }
+  })
+
+  function makeApi(pluginManager: { getPluginInfoByWebContents: (...args: any[]) => any }): void {
+    const api = new PluginDialogAPI()
+    api.init({} as any, pluginManager as any)
+    handler = ipcHandlers.get('get-path')
+  }
+
+  it('返回发起调用的插件专属数据目录并自动创建', () => {
+    makeApi({
+      getPluginInfoByWebContents: vi.fn(() => ({ name: 'demo', path: '/plugins/demo' }))
+    })
+    const event = { sender: { id: 1, session: {} } as any, returnValue: '' } as any
+    handler?.(event, 'pluginData')
+    expect(event.returnValue).toBe(getPluginDataPath('demo'))
+    expect(mockMkdirSync).toHaveBeenCalledWith(getPluginDataPath('demo'), { recursive: true })
+  })
+
+  it('无法定位插件时返回空字符串且不创建目录', () => {
+    makeApi({ getPluginInfoByWebContents: vi.fn(() => null) })
+    const event = { sender: { id: 42, session: {} } as any, returnValue: '' } as any
+    handler?.(event, 'pluginData')
+    expect(event.returnValue).toBe('')
+    expect(mockMkdirSync).not.toHaveBeenCalled()
+  })
+
+  it('保留原有系统路径透传', () => {
+    makeApi({ getPluginInfoByWebContents: vi.fn(() => null) })
+    const event = { sender: {} as any, returnValue: '' } as any
+    handler?.(event, 'home')
+    expect(event.returnValue).toBe('/mock/home')
+  })
+})


### PR DESCRIPTION
新增插件数据目录（~/.ztools/plugins-data/<插件名>），插件可通过 ztools.getPath('pluginData') 获取并自动创建；清空插件数据与卸载删除时一并清理该目录，目录名校验防止路径穿越。