### PR TITLE
chore: 开启主进程调试端口

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "typecheck:web": "vue-tsc --noEmit -p tsconfig.web.json --composite false",
     "typecheck": "pnpm typecheck:node && pnpm typecheck:web",
     "start": "node -e \"if (process.platform === 'win32') require('child_process').execSync('chcp 65001 >nul 2>&1', {stdio: 'ignore'})\" && electron-vite preview",
-    "dev:main": "node -e \"if (process.platform === 'win32') require('child_process').execSync('chcp 65001 >nul 2>&1', {stdio: 'ignore'})\" && electron-vite dev",
+    "dev:main": "node -e \"if (process.platform === 'win32') require('child_process').execSync('chcp 65001 >nul 2>&1', {stdio: 'ignore'})\" && electron-vite dev --inspect --sourcemap",
     "dev:setting": "cd internal-plugins/setting && pnpm dev",
     "dev": "concurrently -n \"main,setting\" -c \"blue,green\" \"pnpm dev:main\" \"pnpm dev:setting\"",
     "kill": "pkill -9 Electron",


### PR DESCRIPTION
## 变更内容
增加参数，开启主进程调试端口，可以从 `chrome://inspect/#devices` 中打开调试器

## 动机
方便开发过程中主进程的调试

## 截图
<img width="1457" height="957" alt="image" src="https://github.com/user-attachments/assets/59623275-0039-4778-ac15-eeccf9b67d4b" />
