### PR TITLE
fix: windows 上一些系统 exe 无法打开

### DIFF
--- a/src/main/core/commandLauncher/windowsLauncher.ts
+++ b/src/main/core/commandLauncher/windowsLauncher.ts
@@ -271,18 +271,6 @@ export async function launchApp(
     }
   }
 
-  // 系统可执行文件（不包含路径分隔符，说明在 PATH 中）
-  if (ext === 'exe' && !appPath.includes('\\') && !appPath.includes('/')) {
-    // 对于 PATH 中的可执行文件，使用 shell.openPath（Electron 会自动在 PATH 中查找）
-    // 这是最可靠的方式，避免路径解析问题
-    const error = await shell.openPath(appPath)
-    if (error) {
-      throw new Error(`启动系统命令失败: ${error}`)
-    }
-    console.log(`[Launcher] 成功启动系统命令: ${appPath}`)
-    return
-  }
-
   if (appPath.toLowerCase().endsWith('.exe') || appPath.toLowerCase().endsWith('.lnk')) {
     await openApplicationViaExplorer(appPath, 'openPath', resolveLaunchWorkingDirectory(appPath))
     return


### PR DESCRIPTION
## 变更内容
去除了裸 `文件名.exe` 用 electron shell.openPath 的启动路径

## 动机
`shell.openPath(path)` 仅支持绝对路径，在打开类似 `wt.exe` 这样的路径时会报错。
删除这个分支后，仅靠下面的分支，可以处理类似 `wt.exe` 这样的路径

类似这样的内置命令：
<img width="135" height="146" alt="image" src="https://github.com/user-attachments/assets/a879b0b0-8729-4c17-9a64-0dde48130853" />


## 相关issue
+ closes #639