### PR TITLE
解决windows下唤出搜索窗口时会偶发抖动的问题

### DIFF
--- a/docs/examples/provider-example/README.md
+++ b/docs/examples/provider-example/README.md
@@ -21,8 +21,12 @@
 ```
 
 ```js
-ztools.registerProvider('baidu', async (input) => { /* ... */ })
-ztools.registerProvider('google', async (input) => { /* ... */ })
+ztools.registerProvider('baidu', async (input) => {
+  /* ... */
+})
+ztools.registerProvider('google', async (input) => {
+  /* ... */
+})
 ```
 
 详见主程序 `docs/provider-development-guide.md`。

--- a/docs/provider-development-guide.md
+++ b/docs/provider-development-guide.md
@@ -50,7 +50,7 @@ ZTools 把「翻译」「OCR」等能力抽象为 **Provider（提供商）**。
 ```json
 {
   "providers": {
-    "baidu":  { "type": "translation", "label": "百度翻译" },
+    "baidu": { "type": "translation", "label": "百度翻译" },
     "google": { "type": "translation", "label": "谷歌翻译" }
   }
 }
@@ -58,8 +58,12 @@ ZTools 把「翻译」「OCR」等能力抽象为 **Provider（提供商）**。
 
 ```js
 // preload.js
-ztools.registerProvider('baidu', async (input) => { /* 调用百度 */ })
-ztools.registerProvider('google', async (input) => { /* 调用谷歌 */ })
+ztools.registerProvider('baidu', async (input) => {
+  /* 调用百度 */
+})
+ztools.registerProvider('google', async (input) => {
+  /* 调用谷歌 */
+})
 ```
 
 两条都会出现在「设置 → 提供商 → 翻译」，用户可分别启用并选其中一个为默认。

--- a/src/main/api/renderer/system.ts
+++ b/src/main/api/renderer/system.ts
@@ -95,6 +95,12 @@ export class SystemAPI {
     }
   }
 
+  /**
+   * 获取最近复制的内容（供渲染进程被动即时查询）。
+   *
+   * @param timeLimit 可选的时间限制（毫秒），不传或传 0 表示无时间限制。
+   * @returns 最近复制的内容对象；无有效内容时返回 null。
+   */
   private async getLastCopiedContent(timeLimit?: number): Promise<{
     type: 'text' | 'image' | 'file'
     data: string | Array<{ path: string; name: string; isDirectory: boolean }>

--- a/src/main/managers/clipboardManager.ts
+++ b/src/main/managers/clipboardManager.ts
@@ -943,18 +943,34 @@ class ClipboardManager {
     return content?.type === 'image' ? (content.data as string) : null
   }
 
-  // 获取最后复制的内容（统一接口）
+  /**
+   * 获取最近复制的内容。
+   * 当未指定 minSequence 时，仅执行被动即时查询，无有效缓存时立即返回 null；
+   * 当指定了 minSequence（如超级面板模拟复制后）时，会轮询等待新序号的复制事件。
+   *
+   * @param timeLimit 可选的时间限制（毫秒），不传或传 0 表示无时间限制。
+   * @param minSequence 可选的最小序号，仅接受晚于该序号的新复制内容。
+   * @returns 最近复制的内容对象；若无有效内容或等待超时则返回 null。
+   */
   public async getLastCopiedContent(
-    timeLimit?: number, // 可选：时间限制（毫秒），不传或传 0 表示无时间限制
-    minSequence?: number // 可选：仅接受晚于该序号的新复制内容
+    timeLimit?: number,
+    minSequence?: number
   ): Promise<LastCopiedContent | null> {
+    // 优先尝试读取当前内存中的有效复制缓存
     const cachedContent = this.getValidLastCopiedContent(timeLimit)
     if (cachedContent && (!minSequence || cachedContent.sequence > minSequence)) {
       console.log('[Clipboard] 获取到有效的最后复制内容，直接返回缓存')
       return cachedContent
     }
 
-    const initialSequence = Math.max(this.lastCopiedContent?.sequence ?? 0, minSequence ?? 0)
+    // 未指定 minSequence 时属于被动查询（如搜索框自动粘贴），未命中缓存立即返回，不进行轮询等待
+    if (minSequence === undefined) {
+      console.log('[Clipboard] 未获取到有效的最后复制内容，不等待直接返回')
+      return null
+    }
+
+    // 主动等待新复制事件（如超级面板划词）
+    const initialSequence = Math.max(this.lastCopiedContent?.sequence ?? 0, minSequence)
     const waitMs =
       timeLimit && timeLimit > 0
         ? Math.min(timeLimit, CLIPBOARD_READY_WAIT_MS)


### PR DESCRIPTION
## 变更内容
修改了默认情况下 `clipboardManager.getLastCopiedContent`，当没有缓存命中时，不轮询 180ms 等待新复制内容。

## 动机
### 1. 提升性能

在绝大多数需要获取最新复制内容的情况下，如果没有符合时间限制的数据，就应该停止查找直接返回 null（比如唤出搜索窗口时获取剪贴板内容、在搜索窗口中ctrl+v 粘贴的时候）

在现在的实现当中，即使没找到，仍会强制轮询180ms等待新内容，造成时间上的浪费和后续操作的延迟。

目前仅有超级面板需要在手动触发 ctrl+c后，马上检查并等待剪贴板内容刷新，而这一逻辑可以通过仅当提供 minSequence 时，才进行轮询来进行判断。

### 2. 解决windows下唤出搜索窗口时会偶发抖动的问题：


https://github.com/user-attachments/assets/b61bc045-c080-4a9e-a939-b221546dcf19



该问题源于在 `window.ztools.onFocusSearch` 注册的回调中，会先 await 读取剪贴板最新内容，然后才 updateWindowHeight。 而读取剪贴板内容至少延迟 180ms 时间，导致窗口出现的动画还没有执行完，就被 updateWindowHeight 打断，产生抖动。

经测试在修改 getLastCopiedContent 的逻辑后，这种抖动明显不再出现。

## 相关 issue
+ closes #628

## 复现窗口抖动的步骤
1. 设置中打开 行为>自动粘贴搜索框，设置为 3 秒
2. 用快捷键呼出搜索框，鼠标拖动移动一下位置
3. 然后反复用快捷键呼出和隐藏。在我的机器上能比较稳定复现
4. 关闭 自动粘贴搜索框 后，抖动情况基本就会消失