### PR TITLE
feat: 将搜索框中的 tab 按键事件传递给插件

### DIFF
--- a/src/renderer/src/App.vue
+++ b/src/renderer/src/App.vue
@@ -54,7 +54,11 @@ import SearchBox from './components/search/SearchBox.vue'
 import SearchResults from './components/search/SearchResults.vue'
 import { useCommandDataStore } from './stores/commandDataStore'
 import { useWindowStore } from './stores/windowStore'
-import { CommonKeyboardModifier, readModifiers } from '@renderer/utils/convertKeyboardEvent'
+import {
+  NavDirectionKey,
+  convertToElectronKeyboardEvent,
+  readModifiers
+} from '@renderer/utils/convertKeyboardEvent'
 
 // FileItem 接口（从剪贴板管理器返回的格式）
 interface FileItem {
@@ -254,62 +258,38 @@ function handlePluginStepExit(): void {
   exitPluginToSearch()
 }
 
-// 将浏览器 KeyboardEvent 转换为 Electron KeyboardInputEvent 格式
-function convertToElectronKeyboardEvent(
-  direction: 'left' | 'right' | 'up' | 'down' | 'enter',
-  type: 'keyDown' | 'keyUp' = 'keyDown',
-  modifiers: CommonKeyboardModifier[] = []
-): {
-  type: 'keyDown' | 'keyUp'
-  keyCode: string
-  modifiers: CommonKeyboardModifier[]
-} {
-  // 映射方向键和回车键的 keyCode
-  const keyCodeMap: Record<string, string> = {
-    left: 'Left',
-    right: 'Right',
-    up: 'Up',
-    down: 'Down',
-    enter: 'Return'
-  }
-
-  return {
-    type,
-    keyCode: keyCodeMap[direction],
-    modifiers
-  }
-}
-
-// 处理方向键事件
-async function handleArrowKeydown(
-  event: KeyboardEvent,
-  direction: 'left' | 'right' | 'up' | 'down' | 'enter'
-): Promise<void> {
-  // 只在插件模式下转发方向键事件
+/**
+ * 处理搜索框转发的导航按键事件（方向键、回车键、Tab 键）。
+ * @param event 原生键盘事件。
+ * @param direction 按键动作名称。
+ * @returns 操作完成后的 Promise。
+ */
+async function handleArrowKeydown(event: KeyboardEvent, direction: NavDirectionKey): Promise<void> {
+  // 仅在插件模式且存在活动插件时转发按键事件
   if (currentView.value !== ViewMode.Plugin || !windowStore.currentPlugin) {
     return
   }
 
-  // 只有上下方向键阻止默认行为，左右方向键允许在搜索框中移动光标
-  if (direction === 'up' || direction === 'down') {
+  // 阻止上下方向键与 Tab 键的默认行为（避免光标跳动或触发表头 DOM 焦点切换），左右方向键放行以允许移动光标
+  if (direction === 'up' || direction === 'down' || direction === 'tab') {
     event.preventDefault()
     event.stopPropagation()
   }
 
+  // 读取当前按下的修饰键状态（Shift/Ctrl/Alt/Meta）
   const modifiers = readModifiers(event)
 
-  // 转换为 Electron 格式
+  // 转换为 Electron 输入事件数据
   const keyDownEvent = convertToElectronKeyboardEvent(direction, 'keyDown', modifiers)
   const keyUpEvent = convertToElectronKeyboardEvent(direction, 'keyUp', modifiers)
 
-  // 发送给主进程：先发送 keyDown，再发送 keyUp
+  // 依次向主进程发送 keyDown 与延迟的 keyUp 事件，模拟真实的按键时序
   try {
     await window.ztools.sendInputEvent(keyDownEvent)
-    // 短暂延迟后发送 keyUp，模拟真实的按键行为
     await new Promise((resolve) => setTimeout(resolve, 10))
     await window.ztools.sendInputEvent(keyUpEvent)
   } catch (error) {
-    console.error('发送方向键事件失败:', error)
+    console.error('发送按键事件失败:', error)
   }
 }
 
@@ -419,7 +399,11 @@ watch(currentView, (newView) => {
   updateWindowHeight()
 })
 
-//键盘操作
+/**
+ * 全局键盘事件监听处理函数，分发快捷键、Tab导航、分步退出及搜索结果导航。
+ * @param event 键盘事件对象。
+ * @returns 操作完成后的 Promise。
+ */
 async function handleKeydown(event: KeyboardEvent): Promise<void> {
   // 如果正在输入法组合中,忽略所有键盘事件
   if (isComposing.value) {
@@ -463,7 +447,7 @@ async function handleKeydown(event: KeyboardEvent): Promise<void> {
     return
   }
 
-  // Tab 键：根据设置执行目标指令或切换选中项
+  // Tab 键：搜索模式下执行目标指令或切换选中项，插件模式下拦截默认行为并转发给插件
   if (event.key === 'Tab') {
     if (currentView.value === ViewMode.Search) {
       if (windowStore.tabKeyFunction === 'target-command') {
@@ -477,6 +461,22 @@ async function handleKeydown(event: KeyboardEvent): Promise<void> {
         searchResultsRef.value?.handleKeydown(event)
         return
       }
+    } else if (currentView.value === ViewMode.Plugin && windowStore.currentPlugin) {
+      // 插件模式下若未被输入框拦截（如焦点位于窗口其他区域），同样拦截并转发 Tab，避免在宿主 DOM 间跳转
+      if (!event.defaultPrevented) {
+        event.preventDefault()
+        const modifiers = readModifiers(event)
+        const keyDownEvent = convertToElectronKeyboardEvent('tab', 'keyDown', modifiers)
+        const keyUpEvent = convertToElectronKeyboardEvent('tab', 'keyUp', modifiers)
+        try {
+          await window.ztools.sendInputEvent(keyDownEvent)
+          await new Promise((resolve) => setTimeout(resolve, 10))
+          await window.ztools.sendInputEvent(keyUpEvent)
+        } catch (error) {
+          console.error('发送 Tab 键事件失败:', error)
+        }
+      }
+      return
     }
   }
 

--- a/src/renderer/src/components/detached/DetachedTitlebar.vue
+++ b/src/renderer/src/components/detached/DetachedTitlebar.vue
@@ -739,7 +739,11 @@ function handleDblClick(): void {
   }
 }
 
-// 键盘事件处理
+/**
+ * 键盘事件处理，拦截并转发回车、Tab 及方向键至插件。
+ * @param event 键盘事件对象。
+ * @returns 无返回值。
+ */
 function handleKeydown(event: KeyboardEvent): void {
   // ESC 键清空输入
   if (event.key === 'Escape') {
@@ -752,11 +756,20 @@ function handleKeydown(event: KeyboardEvent): void {
     return
   }
 
-  // 回车键传递给插件
+  // 提取当前生效的修饰键
   const modifiers = readModifiers(event)
+
+  // 回车键传递给插件
   if (event.key === 'Enter') {
     event.preventDefault()
     sendKeyToPlugin('Enter', modifiers)
+    return
+  }
+
+  // Tab 键传递给插件（同时阻止宿主标题栏 DOM 焦点跳转）
+  if (event.key === 'Tab') {
+    event.preventDefault()
+    sendKeyToPlugin('Tab', modifiers)
     return
   }
 
@@ -772,7 +785,12 @@ function handleKeydown(event: KeyboardEvent): void {
   }
 }
 
-// 发送方向键到插件
+/**
+ * 发送方向键按键事件至插件。
+ * @param key 方向键键名（ArrowLeft/ArrowRight/ArrowUp/ArrowDown）。
+ * @param modifiers 修饰键列表。
+ * @returns 无返回值。
+ */
 function sendArrowKeyToPlugin(key: string, modifiers: CommonKeyboardModifier[] = []): void {
   const keyCodeMap: Record<string, string> = {
     ArrowLeft: 'Left',
@@ -800,7 +818,12 @@ function sendArrowKeyToPlugin(key: string, modifiers: CommonKeyboardModifier[] =
   }
 }
 
-// 发送按键到插件（用于回车键等）
+/**
+ * 发送通用功能键按键事件至插件（用于回车键、Tab 键等）。
+ * @param key 目标键名字符串（例如 'Enter'、'Tab'）。
+ * @param modifiers 修饰键列表。
+ * @returns 无返回值。
+ */
 function sendKeyToPlugin(key: string, modifiers: CommonKeyboardModifier[] = []): void {
   // 发送 keyDown 事件
   window.electron.ipcRenderer.send('send-arrow-key', {

--- a/src/renderer/src/components/search/SearchBox.vue
+++ b/src/renderer/src/components/search/SearchBox.vue
@@ -137,6 +137,7 @@
           @keydown.down="(e) => keydownEvent(e, 'down')"
           @keydown.up="(e) => keydownEvent(e, 'up')"
           @keydown.enter="(e) => keydownEvent(e, 'enter')"
+          @keydown.tab="(e) => keydownEvent(e, 'tab')"
           @paste="handlePaste"
         />
       </div>
@@ -273,6 +274,7 @@ import {
   toggleMainPushSetting
 } from '../../composables/useMainPushSetting'
 import { DEFAULT_AVATAR, useWindowStore } from '../../stores/windowStore'
+import type { NavDirectionKey } from '@renderer/utils/convertKeyboardEvent'
 import AdaptiveIcon from '../common/AdaptiveIcon.vue'
 import UpdateIcon from './UpdateIcon.vue'
 
@@ -309,11 +311,7 @@ const emit = defineEmits<{
   (e: 'update:pastedFiles', value: FileItem[] | null): void
   (e: 'update:pastedText', value: string | null): void
   (e: 'keydown', event: KeyboardEvent): void
-  (
-    e: 'arrow-keydown',
-    event: KeyboardEvent,
-    direction: 'left' | 'right' | 'up' | 'down' | 'enter'
-  ): void
+  (e: 'arrow-keydown', event: KeyboardEvent, direction: NavDirectionKey): void
   (e: 'composing', isComposing: boolean): void
   (e: 'settings-click'): void
   (e: 'close-plugin'): void
@@ -691,16 +689,19 @@ async function onKeydown(event: KeyboardEvent): Promise<void> {
   emit('keydown', event)
 }
 
-function keydownEvent(
-  event: KeyboardEvent,
-  direction: 'left' | 'right' | 'up' | 'down' | 'enter'
-): void {
-  // 如果正在输入法组合中,不触发键盘事件
+/**
+ * 处理搜索输入框的导航按键事件（方向键、回车键、Tab键），向上层派发转发或导航请求。
+ * @param event 键盘事件对象。
+ * @param direction 按键动作类型（'left' | 'right' | 'up' | 'down' | 'enter' | 'tab'）。
+ * @returns 无返回值。
+ */
+function keydownEvent(event: KeyboardEvent, direction: NavDirectionKey): void {
+  // 处于输入法组合态时，忽略导航与按键转发，避免打断拼音选词
   if (isComposing.value) {
     return
   }
 
-  // 如果输入框有选中的文字,不触发列表导航（仅搜索模式下生效，插件模式下需要转发给插件）
+  // 搜索模式下若存在文本选中态，阻止列表导航以优先保障输入框文本编辑行为
   if (
     props.currentView !== 'plugin' &&
     inputRef.value &&
@@ -710,6 +711,7 @@ function keydownEvent(
     return
   }
 
+  // 向父组件派发按键动作，供上层决定列表导航或转发给插件
   emit('arrow-keydown', event, direction)
 }
 

--- a/src/renderer/src/utils/convertKeyboardEvent.ts
+++ b/src/renderer/src/utils/convertKeyboardEvent.ts
@@ -1,7 +1,18 @@
-// 当前按下的修饰键
+/**
+ * 当前按下的修饰键类型。
+ */
 export type CommonKeyboardModifier = 'shift' | 'ctrl' | 'alt' | 'meta'
 
-// 将 KeyboardEvent 中的修饰键转换成 Electron.KeyboardEvent 键盘事件中的修饰键
+/**
+ * 支持转发给插件的导航按键动作类型。
+ */
+export type NavDirectionKey = 'left' | 'right' | 'up' | 'down' | 'enter' | 'tab'
+
+/**
+ * 将原生 KeyboardEvent 中的修饰键提取为 Electron 所需的修饰键数组。
+ * @param event 键盘事件对象。
+ * @returns 修饰键名称数组（'shift' | 'ctrl' | 'alt' | 'meta'）。
+ */
 export function readModifiers(event: KeyboardEvent): CommonKeyboardModifier[] {
   const modifiers: CommonKeyboardModifier[] = []
 
@@ -22,4 +33,37 @@ export function readModifiers(event: KeyboardEvent): CommonKeyboardModifier[] {
   }
 
   return modifiers
+}
+
+/**
+ * 将按键动作转换为 Electron KeyboardInputEvent 格式。
+ * @param direction 按键动作名称（方向键、回车键或 Tab 键）。
+ * @param type 按键事件类型（keyDown 或 keyUp）。
+ * @param modifiers 修饰键列表。
+ * @returns 构造的 Electron KeyboardInputEvent 数据。
+ */
+export function convertToElectronKeyboardEvent(
+  direction: NavDirectionKey,
+  type: 'keyDown' | 'keyUp' = 'keyDown',
+  modifiers: CommonKeyboardModifier[] = []
+): {
+  type: 'keyDown' | 'keyUp'
+  keyCode: string
+  modifiers: CommonKeyboardModifier[]
+} {
+  // 映射方向键、回车键和 Tab 键的 keyCode
+  const keyCodeMap: Record<NavDirectionKey, string> = {
+    left: 'Left',
+    right: 'Right',
+    up: 'Up',
+    down: 'Down',
+    enter: 'Return',
+    tab: 'Tab'
+  }
+
+  return {
+    type,
+    keyCode: keyCodeMap[direction],
+    modifiers
+  }
 }


### PR DESCRIPTION
## 变更内容
类似方向键和回车键，将搜索栏中的tab按键事件转发给插件
完善了一些注释

## 动机
还原 utools 行为，一些插件依赖 tab 作为切换内部标签页的快捷键，比如【本地搜索】
tab键对于搜索栏没有实际用途，发给插件可以作为切换内部标签页的实用快捷键，同时保持搜索栏的focus

## 相关 issue
+ https://github.com/guopenghui/local-search-neo/issues/2
