### PR TITLE
Feature/ctrl + D分离窗口显示窗口控件 + 解决linux环境下无法最大化的问题

### DIFF
--- a/src/main/core/detachedWindowManager.ts
+++ b/src/main/core/detachedWindowManager.ts
@@ -347,6 +347,9 @@ class DetachedWindowManager {
 
           // 升级期间的 0 高度是临时状态，不得覆盖用户保存的窗口尺寸。
           if (!this.suppressedSizePersistenceWindows.has(windowId)) {
+            // 最大化/全屏状态触发的 resize 不算用户偏好尺寸，
+            // 否则会把屏幕工作区尺寸误存为下次 Ctrl+D 的“默认尺寸”。
+            if (win.isMaximized() || win.isFullScreen()) return
             this.schedulePersistWindowSize(
               windowId,
               pluginName,
@@ -356,6 +359,33 @@ class DetachedWindowManager {
           }
         }
       })
+
+      // 仅同步 pluginView 位置，不写数据库。
+      // 用于 maximize/unmaximize 兜底：Linux 上 WM 走 _NET_WM_STATE_MAXIMIZED_*
+      // 时常不触发 ConfigureNotify，resize 事件可能不发生，导致 pluginView
+      // 保持旧 bounds、看起来“窗口最大化但内容没放大”。
+      const syncPluginViewBoundsOnly = (): void => {
+        if (win.isDestroyed() || pluginView.webContents.isDestroyed()) return
+        const bounds = win.getContentBounds()
+        pluginView.setBounds({
+          x: 0,
+          y: DETACHED_TITLEBAR_HEIGHT,
+          width: bounds.width,
+          height: Math.max(0, bounds.height - DETACHED_TITLEBAR_HEIGHT)
+        })
+      }
+
+      // maximize/unmaximize 兜底：WM 异步处理状态切换时，多次同步 pluginView，
+      // 确保 WM 完成几何变更后视图尺寸一定跟上。
+      // 注意：这里**绝不**调用 schedulePersistWindowSize，也不修改 BrowserWindow
+      // 几何；持久化和窗口几何全部由 resize 事件处理，避免引入新的副作用。
+      const syncAfterStateChange = (): void => {
+        syncPluginViewBoundsOnly()
+        setImmediate(syncPluginViewBoundsOnly)
+        setTimeout(syncPluginViewBoundsOnly, 100)
+      }
+      win.on('maximize', syncAfterStateChange)
+      win.on('unmaximize', syncAfterStateChange)
 
       // 保存窗口信息
       const windowInfo: DetachedWindowInfo = {

--- a/src/renderer/src/components/detached/DetachedTitlebar.vue
+++ b/src/renderer/src/components/detached/DetachedTitlebar.vue
@@ -137,8 +137,8 @@
       </button>
     </div>
 
-    <!-- Windows 窗口控制按钮 -->
-    <div v-if="platform === 'win32'" class="window-controls">
+    <!-- Windows / Linux 窗口控制按钮：frameless 窗口依赖 HTML 自绘控件 -->
+    <div v-if="platform === 'win32' || platform === 'linux'" class="window-controls">
       <button class="window-btn minimize-btn" @click="minimize">
         <svg width="10" height="10" viewBox="0 0 10 10">
           <path d="M 0 5 L 10 5" stroke="currentColor" stroke-width="1" />
@@ -178,7 +178,7 @@ import AdaptiveIcon from '../common/AdaptiveIcon.vue'
 import { CommonKeyboardModifier, readModifiers } from '@renderer/utils/convertKeyboardEvent'
 import type { AiRequestStatus, AiRequestStatusChange } from '@shared/aiRequestStatus'
 
-const platform = ref<'darwin' | 'win32'>('darwin')
+const platform = ref<'darwin' | 'win32' | 'linux'>('darwin')
 const pluginName = ref('Plugin')
 const pluginId = ref('') // 插件的实际 name（用于数据库操作，与未分离状态保持一致）
 const pluginPath = ref('')


### PR DESCRIPTION
### 变更内容

本 PR 修复 ZTools 分离窗口在 **Linux 平台** 的两个问题，涉及 2 个 commit：

1. **`e79a3e4`** Linux 分离窗口显示最小化/最大化/关闭按钮
   - `DetachedTitlebar.vue`：`platform` 类型扩展为 `'darwin' | 'win32' | 'linux'`
   - 窗口控制按钮的 `v-if` 条件同步匹配 `linux`，让 Linux 用户也能在独立窗口右上角看到最小化、最大化、关闭按钮
   - 背景：分离窗口以 `frame: false` 创建，Linux WM 不会自动绘制窗口控件，必须由 HTML 自绘

2. **`25d43cc`** Linux 分离窗口 maximize 时同步 WebContentsView bounds（保守修复）
   - `detachedWindowManager.ts` 新增 `maximize` / `unmaximize` 监听器，触发 `syncPluginViewBoundsOnly`
   - `syncAfterStateChange` 在三个时间点同步：立即、`setImmediate`、100ms，覆盖 WM 异步处理状态切换的不同延迟
   - resize 监听器增加 `win.isMaximized() / win.isFullScreen()` 守卫：最大化/全屏触发的 resize 不写数据库，避免把屏幕工作区尺寸误存为下次 Ctrl+D 的"默认尺寸"
   - 背景：Linux WM 走 `_NET_WM_STATE_MAXIMIZED_*` 时常不发 `ConfigureNotify`，resize 事件可能不触发，导致 `pluginView` 保持旧 bounds、看起来"窗口最大化但内容没放大"

### 文件改动

| 文件 | 变更 |
|---|---|
| `src/main/core/detachedWindowManager.ts` | +30 / -0 |
| `src/renderer/src/components/detached/DetachedTitlebar.vue` | +3 / -3 |

### 动机

Linux 平台上分离窗口体验存在两个缺陷：

| 场景 | 修复前 | 修复后 |
|---|---|---|
| 用户在 Linux 上分离插件窗口 | 标题栏没有最小化/最大化/关闭按钮，只能从 Dock/任务栏操作 | 右上角显示完整控件，符合 Linux 用户预期 |
| 用户在 Linux 上最大化分离窗口 | 窗口框架最大化，但 pluginView 保持原大小，内容没跟上 | pluginView 与窗口同步最大化 |

### 截图
改动前linux的无窗口控件
<img width="1384" height="889" alt="img" src="https://github.com/user-attachments/assets/29cd686c-7624-47b7-8e86-8c81a85b1aad" />

改动前linux调出窗口控件后点击最大化按钮
<img width="2553" height="1414" alt="img_1" src="https://github.com/user-attachments/assets/9d69dd1e-5c78-4204-b5b0-b2522a1471e3" />


改动后linux的窗口控件可见
<img width="1027" height="773" alt="img_2" src="https://github.com/user-attachments/assets/f24bd23b-195f-4f26-b352-1d0f8bf715eb" />

改动后linux窗口最大化时内容等比例放大
<img width="2544" height="1403" alt="img_3" src="https://github.com/user-attachments/assets/5fff4ebe-f767-4e8f-afc7-6756e7d03226" />

### 手动验证（Linux GNOME Wayland / KDE X11）

1. **窗口控件可见性**
   - 打开任意插件 → 按 `Ctrl+D` 分离窗口
   - 预期：右上角出现最小化 / 最大化 / 关闭按钮，与 Windows 客户端一致

2. **最大化同步**
   - 分离窗口 → 点击最大化按钮（或双击标题栏）
   - 预期：pluginView 内容随窗口一起放大，无"窗口大、内容小"的撕裂感
   - 取消最大化：预期：pluginView 缩回原尺寸

3. **持久化不被污染**
   - 分离窗口 → 调整到一个非最大化的尺寸（记住这个尺寸）→ 关闭窗口
   - 再次分离同一插件 → 恢复成上次的非最大化尺寸（不是屏幕工作区尺寸）

4. **不影响其他平台**
   - macOS：分离窗口已有原生交通灯按钮，本变更不影响
   - Windows：分离窗口已有 HTML 自绘按钮，本变更不影响（仅扩展 `v-if` 条件）

### 相关 Issue

无

### 影响范围

- **Linux**：完整支持（控件可见 + 最大化同步）
- **macOS / Windows**：不受影响（`v-if` 仅扩展，`maximize` 监听器为 no-op，因为 Windows 上 `maximize` 事件正常触发 resize）
- **其他平台**：不受影响

### 检查清单

- [x] `pnpm typecheck:node` 通过
- [x] `pnpm typecheck:web` 通过
- [x] `pnpm lint`（改动文件）通过 — `detachedWindowManager.ts` / `DetachedTitlebar.vue` 均为 0 错误
- [x] 提交信息符合 conventional commits 格式（`fix:` + 详细 body）
- [x] 无 `any` 使用
- [x] 命名规范符合（camelCase）
- [x] Linux 上手动验证通过